### PR TITLE
don't remove prj meta when freezing

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -198,7 +198,8 @@ def do_staging(self, subcmd, opts, *args):
         self._staging_submit_devel(project, opts)
     elif cmd in ['freeze']:
         import osclib.freeze_command
-        osclib.freeze_command.FreezeCommand(opts.apiurl).perform(api.prj_from_letter(args[1]))
+        for prj in args[1:]:
+            osclib.freeze_command.FreezeCommand(api).perform(api.prj_from_letter(prj))
     elif cmd in ['accept']:
         import osclib.accept_command
         osclib.accept_command.AcceptCommand(api).perform(api.prj_from_letter(args[1]))


### PR DESCRIPTION
- Preserve title and description of the frozen prj (issue 1585)
- add a small stagingapi wrapper for makeurl, makes the code easier to read
  - url = makeurl(self.apiurl, ...
  - url = self.makeurl(...
- don't freeze AGGR (issue 1611)
