### PR TITLE
check_source: SLE: allow in-air-rename and place maintainer review check behind ignore_devel.

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -39,6 +39,7 @@ class CheckSource(ReviewBot.ReviewBot):
         config = self.staging_config[project]
 
         self.ignore_devel = not str2bool(config.get('devel-project-enforce', 'False'))
+        self.in_air_rename_allow = str2bool(config.get('check-source-in-air-rename-allow', 'False'))
         self.add_review_team = str2bool(config.get('check-source-add-review-team', 'True'))
         self.review_team = config.get('review-team')
         self.repo_checker = config.get('repo-checker')
@@ -101,7 +102,7 @@ class CheckSource(ReviewBot.ReviewBot):
             return False
 
         # We want to see the same package name in the devel project as in the distro; anything else calls for confusion
-        if source_package != target_package:
+        if not self.in_air_rename_allow and source_package != target_package:
             self.review_messages['declined'] = "No in-air renames: The package must be called the same in the devel project as in the target project"
             return False
 

--- a/check_source.py
+++ b/check_source.py
@@ -262,8 +262,9 @@ class CheckSource(ReviewBot.ReviewBot):
         # Decline the delete request against linked package.
         links = root.findall('sourceinfo/linked')
         if links is None or len(links) == 0:
-            # Utilize maintbot to add devel project review if necessary.
-            self.maintbot.check_one_request(request)
+            if not self.ignore_devel:
+                # Utilize maintbot to add devel project review if necessary.
+                self.maintbot.check_one_request(request)
 
             if not self.skip_add_reviews and self.repo_checker is not None:
                 self.add_review(self.request, by_user=self.repo_checker, msg='Is this delete request safe?')

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -111,6 +111,7 @@ DEFAULT = {
         'delreq-review': None,
         'main-repo': 'standard',
         # check_source.py
+        'check-source-in-air-rename-allow': 'True',
         'repo-checker': 'repo-checker',
         'repo_checker-package-comment-devel': '',
         'pkglistgen-archs': 'x86_64',


### PR DESCRIPTION
- 42139de4d68490f8128cfae6451a21d8e9f2db5d:
    check_source: delete: place maintainer review check behind ignore_devel.
    
    SLE does not utilize devel projects and so adding such reviewer does not
    make sense. Additionally, for Leap the right review will depend on origin
    which leaper handles.

- e964cb58a4c551085eee5663d2741c8ce0301955:                                                                                                
    osclib/conf: SLE-15: set check-source-in-air-rename-allow to True.                                                                     
                                                                                                                                           
- a7e36b03f7afc3112ff57dbd35f50a4240f1d40a:                                                                                                
    check_source: provide in-air-rename-allow config setting.

Fixes #1464.