### PR TITLE
repo-checker: check delete requests for runtime deps

### DIFF
--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -2,6 +2,7 @@ from xml.etree import cElementTree as ET
 
 from osc.core import makeurl
 from osc.core import http_GET
+from osclib.core import fileinfo_ext_all
 
 import urllib2
 
@@ -150,7 +151,7 @@ class CleanupRings(object):
     def check_requiredby(self, project, package):
         # Prioritize x86_64 bit.
         for arch in reversed(self.api.ring_archs(project)):
-            for fileinfo in self.api.fileinfo_ext_all(project, 'standard', arch, package):
+            for fileinfo in fileinfo_ext_all(self.api.apiurl, project, 'standard', arch, package):
                 for requiredby in fileinfo.findall('provides_ext/requiredby[@name]'):
                     b = self.bin2src[requiredby.get('name')]
                     if b == package:

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -188,3 +188,22 @@ def project_list_prefix(apiurl, prefix):
     url = makeurl(apiurl, ['search', 'project', 'id'], query)
     root = ETL.parse(http_GET(url)).getroot()
     return root.xpath('project/@name')
+
+#
+# Depdendency helpers
+#
+def fileinfo_ext_all(apiurl, project, repo, arch, package):
+    url = makeurl(apiurl, ['build', project, repo, arch, package])
+    binaries = ET.parse(http_GET(url)).getroot()
+    for binary in binaries.findall('binary'):
+        filename = binary.get('filename')
+        if not filename.endswith('.rpm'):
+            continue
+
+        yield fileinfo_ext(apiurl, project, repo, arch, package, filename)
+
+def fileinfo_ext(apiurl, project, repo, arch, package, filename):
+    url = makeurl(apiurl,
+                  ['build', project, repo, arch, package, filename],
+                  {'view': 'fileinfo_ext'})
+    return ET.parse(http_GET(url)).getroot()

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1808,22 +1808,6 @@ class StagingAPI(object):
             return self.cstaging_dvd_archs
         return self.cstaging_archs
 
-    def fileinfo_ext_all(self, project, repo, arch, package):
-        url = makeurl(self.apiurl, ['build', project, repo, arch, package])
-        binaries = ET.parse(http_GET(url)).getroot()
-        for binary in binaries.findall('binary'):
-            filename = binary.get('filename')
-            if not filename.endswith('.rpm'):
-                continue
-
-            yield self.fileinfo_ext(project, repo, arch, package, filename)
-
-    def fileinfo_ext(self, project, repo, arch, package, filename):
-        url = makeurl(self.apiurl,
-                      ['build', project, repo, arch, package, filename],
-                      {'view': 'fileinfo_ext'})
-        return ET.parse(http_GET(url)).getroot()
-
     def ignore_format(self, request_id):
         requests_ignored = self.get_ignored_requests()
         if request_id in requests_ignored:


### PR DESCRIPTION
I took a stab at this old P1 issue

Tested with the current gegl-unstable delete request:

```
$ ./repo_checker.py --dry  --skip-cycle --debug --force id 590049
[D] 590049: openSUSE:Factory:Staging:G ready
[D] requests: 0 skipped, 1 queued
[I] checking 590049
[W] gegl-unstable is still a build requirement of:

- bundle-lang-gnome
- gimp
- gnome-photos
- openttd-opengfx
[W] gegl-unstable provides runtime dependencies to:

- gimp
- gnome-photos
[D] removing previous comment on 590049
[D] adding comment to 590049: <!-- RepoChecker state=seen result=failed -->

gegl-unstable is still a build requirement of:

- bundle-lang-gnome
- gimp
- gnome-photos
- openttd-opengfx

gegl-unstable provides runtime dependencies to:

- gimp
- gnome-photos
[I] 590049 ignored
```

In many cases, build deps and runtime deps will have some overlap, but as can already be seen: not all build deps result in runtime deps - and we know from the past that not all runtime deps stem from build deps.