### PR TITLE
totest_manager: Also release openSUSE:Leap:15.0:Images/opensuse-leap-image

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -756,6 +756,7 @@ class ToTest150Images(ToTestBaseNew):
         'livecd-leap-gnome',
         'livecd-leap-kde',
         'livecd-leap-x11',
+        'opensuse-leap-image',
     ]
 
     ftp_products = []


### PR DESCRIPTION
Tested with `--dry --verbose release openSUSE:Leap:15.0:Images`:

```
2018-03-26 11:10:11,528 - totest-manager:451 INFO Updating snapshot None
2018-03-26 11:10:11,528 - totest-manager:434 INFO release openSUSE:Leap:15.0:Images/livecd-leap-gnome (None)
2018-03-26 11:10:11,529 - totest-manager:434 INFO release openSUSE:Leap:15.0:Images/livecd-leap-kde (None)
2018-03-26 11:10:11,529 - totest-manager:434 INFO release openSUSE:Leap:15.0:Images/livecd-leap-x11 (None)
2018-03-26 11:10:11,529 - totest-manager:434 INFO release openSUSE:Leap:15.0:Images/opensuse-leap-image (None)
```