### PR TITLE
conf: make sure variable is not None before do lower()

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -172,7 +172,7 @@ DEFAULT = {
 
 
 def str2bool(v):
-    return v.lower() in ("yes", "true", "t", "1")
+    return (v is not None and v.lower() in ("yes", "true", "t", "1"))
 
 
 class Config(object):


### PR DESCRIPTION
Fix AttributeError: 'NoneType' object has no attribute 'lower' error