### PR TITLE
Change remaining usage of _product to 000product

### DIFF
--- a/ToolBase.py
+++ b/ToolBase.py
@@ -106,7 +106,7 @@ class ToolBase(object):
 
     def meta_get_packagelist(self, prj, deleted=None, expand=False):
         root = ET.fromstring(self._meta_get_packagelist(prj, deleted, expand))
-        return [ node.get('name') for node in root.findall('entry') if not node.get('name') == '_product' and not node.get('name').startswith('_product:') and not node.get('name').startswith('patchinfo.') ]
+        return [ node.get('name') for node in root.findall('entry') if not node.get('name') == '000product' and not node.get('name').startswith('patchinfo.') ]
 
     # FIXME: duplicated from manager_42
     def latest_packages(self, project):

--- a/biarchtool.py
+++ b/biarchtool.py
@@ -169,11 +169,11 @@ class BiArchTool(ToolBase.ToolBase):
         else:
             self.packages = packages
 
-    # check when _product was last changed, eg by packagelist
+    # check when 000product was last changed, eg by packagelist
     # generator. Yield only packges that got checked in after that
     # point in time.
     def _filter_packages_by_time(self, packages):
-        x = ET.fromstring(self.cached_GET(self.makeurl(['source', self.project, '_product', '_history'], {'limit': '1'})))
+        x = ET.fromstring(self.cached_GET(self.makeurl(['source', self.project, '000product', '_history'], {'limit': '1'})))
         producttime = int(x.find('./revision/time').text)
         for pkg in packages:
             try:

--- a/update_crawler.py
+++ b/update_crawler.py
@@ -128,7 +128,7 @@ class UpdateCrawler(object):
 
     def meta_get_packagelist(self, prj, deleted=None, expand=False):
         root = ET.fromstring(self._meta_get_packagelist(prj, deleted, expand))
-        return [ node.get('name') for node in root.findall('entry') if not node.get('name') == '_product' and not node.get('name').startswith('_product:') and not node.get('name').startswith('patchinfo.') ]
+        return [ node.get('name') for node in root.findall('entry') if not node.get('name') == '000product' and not node.get('name').startswith('patchinfo.') ]
 
     def _get_source_infos(self, project, packages):
         query = [ 'view=info' ]


### PR DESCRIPTION
All openSUSE distros in developments switched to the new product builder, meaning
they no longer use _product as the package container, but operate on the standardized
name 000product.

Addresses https://progress.opensuse.org/issues/20890