### PR TITLE
devel-project: provide notify sub-command.

### DIFF
--- a/issue-diff.py
+++ b/issue-diff.py
@@ -21,6 +21,7 @@ import osc.conf
 import osc.core
 
 from osclib.cache import Cache
+from osclib.core import entity_email
 from osclib.core import package_list
 from osclib.git import CACHE_DIR
 from osclib.git import sync
@@ -54,12 +55,6 @@ def bug_create(bugzilla_api, meta, assigned_to, cc, summary, description):
 
     return newbug.id
 
-def entity_email(apiurl, entity, key):
-    url = osc.core.makeurl(apiurl, (entity, key))
-    root = ET.parse(osc.core.http_GET(url)).getroot()
-    email = root.find('email')
-    return email.text if email is not None else None
-
 def bug_owner(apiurl, package, entity='person'):
     query = {
         'binary': package,
@@ -69,10 +64,10 @@ def bug_owner(apiurl, package, entity='person'):
 
     bugowner = root.find('.//{}[@role="bugowner"]'.format(entity))
     if bugowner is not None:
-        return entity_email(apiurl, entity, bugowner.get('name'))
+        return entity_email(apiurl, bugowner.get('name'), entity)
     maintainer = root.find('.//{}[@role="maintainer"]'.format(entity))
     if maintainer is not None:
-        return entity_email(apiurl, entity, maintainer.get('name'))
+        return entity_email(apiurl, maintainer.get('name'), entity)
     if entity == 'person':
         return bug_owner(apiurl, package, 'group')
 

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -54,6 +54,10 @@ DEFAULT = {
         'legal-review-group': 'legal-auto',
         'repo-checker': 'repo-checker',
         'pkglistgen-product-family-include': 'openSUSE:Leap:N',
+        'mail-list': 'opensuse-factory@opensuse.org',
+        'mail-maintainer': 'Dominique Leuenberger <dimstar@suse.de>',
+        'mail-noreply': 'noreply@opensuse.org',
+        'mail-release-list': 'opensuse-releaseteam@opensuse.org',
     },
     r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+))': {
         'staging': 'openSUSE:%(project)s:Staging',
@@ -94,6 +98,10 @@ DEFAULT = {
         'pkglistgen-include-suggested': '1',
         'pkglistgen-delete-kiwis-rings': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
         'pkglistgen-delete-kiwis-staging': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
+        'mail-list': 'opensuse-factory@opensuse.org',
+        'mail-maintainer': 'Ludwig Nussel <ludwig.nussel@suse.de>',
+        'mail-noreply': 'noreply@opensuse.org',
+        'mail-release-list': 'opensuse-releaseteam@opensuse.org',
     },
     r'SUSE:(?P<project>SLE-15.*$)': {
         'staging': 'SUSE:%(project)s:Staging',

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -207,3 +207,18 @@ def fileinfo_ext(apiurl, project, repo, arch, package, filename):
                   ['build', project, repo, arch, package, filename],
                   {'view': 'fileinfo_ext'})
     return ET.parse(http_GET(url)).getroot()
+
+def entity_email(apiurl, key, entity_type='person', include_name=False):
+    url = makeurl(apiurl, [entity_type, key])
+    root = ET.parse(http_GET(url)).getroot()
+
+    email = root.find('email')
+    if email is None:
+        return None
+    email = email.text
+
+    realname = root.find('realname')
+    if include_name and realname is not None:
+        email = '{} <{}>'.format(realname.text, email)
+
+    return email


### PR DESCRIPTION
- 961d3456dee4d1ad00749bd0ea6e98ff49239d71:
    issue-diff: utilize entity_mail() as adapted into osclib.core.

- 156e81156577256a41f1e2157bef98688929c1b2:
    devel-project: provide notify sub-command.

- db3fdf6d22b2237663bec0ff883bc391c5f15942:
    osclib/util: provide mail_send(), modified from announcer.py.
    
    Depend on config for relay, from, and followup-to.

- b472a899292a83d975f3db795c6e69529aab5116:
    osclib/core: provide entity_email(), modified from issue-diff.py.

Fixes [poo#29277](https://progress.opensuse.org/issues/29277).