### PR TITLE
ReviewBot: disable comment handler for default action handler.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -343,6 +343,10 @@ class ReviewBot(object):
         return self.check_source_submission(a.src_project, a.src_package, a.src_rev, a.tgt_project, a.tgt_package)
 
     def check_action__default(self, req, a):
+        # Disable any comment handler to avoid making a comment even if
+        # comment_write() is called by another bot wrapping __default().
+        self.comment_handler_remove()
+
         message = 'unhandled request type {}'.format(a.type)
         self.logger.error(message)
         self.review_messages['accepted'] += ': ' + message


### PR DESCRIPTION
- f196526e733ee81c49692805e19a884029ebfad3:
    ReviewBot: disable comment handler for default action handler.
    
    Otherwise, if a bot overrides __default() and still calls super method and
    then comment_write(), as leaper does, a comment will still be generated. If
    a bot wants a comment even when "unhandled" it is likely deviating
    enough that it should not call the super method.

With change:
```
$ ./leaper.py --debug --dry id 597102
[I] checking 597102
[E] unhandled request type set_bugowner
[E] unhandled request type set_bugowner
[D] has_correct_maintainer: None
[D] review result: True
[D] skipping empty comment for 597102
[I] 597102 needs review by [leap-reviewers](/group/show/leap-reviewers)
[D] skipped adding duplicate review for leap-reviewers
[I] 597102 accepted: ok: unhandled request type set_bugowner
[D] 597102 review not changed
```

Without change:
```
$ ./leaper.py --debug --dry id 597102
[I] checking 597102
[E] unhandled request type set_bugowner
[E] unhandled request type set_bugowner
[D] has_correct_maintainer: None
[D] review result: True
[D] previous comment too similar on 597102
[I] 597102 needs review by [leap-reviewers](/group/show/leap-reviewers)
[D] skipped adding duplicate review for leap-reviewers
[I] 597102 accepted: ok: unhandled request type set_bugowner
[D] 597102 review not changed
```

