### PR TITLE
ReviewBot: replace default handler for legal-auto and check_tags_in_requests

### DIFF
--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -67,6 +67,7 @@ See also https://en.opensuse.org/openSUSE:Packaging_Patches_guidelines#Current_s
 Note that not all of the tags listed there are necessarily supported
 by OBS on which this bot relies.
 """
+        self.request_default_return = True
 
     def isNewPackage(self, tgt_project, tgt_package):
         try:
@@ -142,13 +143,6 @@ by OBS on which this bot relies.
 
     def check_action_maintenance_release(self, req, a):
         return self.checkTagInRequest(req, a)
-
-    def check_action__default(self, req, a):
-        # accept all other requests
-        self.logger.debug("auto accept request type %s"%a.type)
-        return True
-
-
 
 
 class CommandLineInterface(ReviewBot.CommandLineInterface):

--- a/legal-auto.py
+++ b/legal-auto.py
@@ -60,6 +60,7 @@ class LegalAuto(ReviewBot.ReviewBot):
         else:
             self.apinick = 'obs#'
         self.override_allow = False # Handled via external tool.
+        self.request_default_return = True
 
     def request_priority(self):
         prio = self.request.priority or 'moderate'
@@ -133,10 +134,6 @@ class LegalAuto(ReviewBot.ReviewBot):
                 return False
             # print url, json.dumps(report)
         self.message = 'ok'
-        return True
-
-    def check_action__default(self, req, a):
-        self.logger.error("unhandled request type %s" % a.type)
         return True
 
     def prepare_review(self):


### PR DESCRIPTION
- f751f4768a84509f5c4b3efc3342ffd7564660f1:
    check_tags_in_requests: replace check_action__default() with built-in.

- 202d1397437a9a0ba9f7df79d7ffbdb1ac21575b:
    legal-auto: replace check_action__default() with built-in.

Noticed while working on #1490.