### PR TITLE
Handle Leap:15.0:Ports images_arm repository

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -756,6 +756,8 @@ class ToTest150Ports(ToTestBaseNew):
 
     livecd_products = []
 
+    product_repo = 'images_arm'
+
     def openqa_group(self):
         return 'openSUSE Leap 15.0 Ports'
 


### PR DESCRIPTION
For Leap 15.0 Ports we need to be able to support two image
repos, one for arm and one for ppc because they get published
to two different locations. for now as we have only images_arm
add support for that while ppc is still making its way through
an initial build.