### PR TITLE
devel-project: notify: utilize osclib.core.package_list_without_links().

### DIFF
--- a/devel-project.py
+++ b/devel-project.py
@@ -10,13 +10,13 @@ import osc.conf
 from osc.core import HTTPError
 from osc.core import get_request_list
 from osc.core import get_review_list
-from osc.core import meta_get_packagelist
 from osc.core import show_package_meta
 from osc.core import show_project_meta
 from osclib.comments import CommentAPI
 from osclib.conf import Config
 from osclib.core import devel_project_fallback
 from osclib.core import entity_email
+from osclib.core import package_list_without_links
 from osclib.core import request_age
 from osclib.stagingapi import StagingAPI
 from osclib.util import mail_send
@@ -103,7 +103,7 @@ def notify(args):
 
     # devel_projects_get() only works for Factory as such
     # devel_project_fallback() must be used on a per package basis.
-    packages = meta_get_packagelist(apiurl, args.project)
+    packages = package_list_without_links(apiurl, args.project)
     maintainer_map = {}
     for package in packages:
         devel_project, devel_package = devel_project_fallback(apiurl, args.project, package)

--- a/devel-project.py
+++ b/devel-project.py
@@ -10,8 +10,6 @@ import osc.conf
 from osc.core import HTTPError
 from osc.core import get_request_list
 from osc.core import get_review_list
-from osc.core import http_GET
-from osc.core import makeurl
 from osc.core import meta_get_packagelist
 from osc.core import show_package_meta
 from osc.core import show_project_meta

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -232,3 +232,15 @@ def source_file_load(apiurl, project, package, filename, revision=None):
         return http_GET(url).read()
     except HTTPError:
         return None
+
+# Should be an API call that says give me "real" packages that does not include
+# multibuild entries nor linked packages.
+def package_list_without_links(apiurl, project):
+    query = {
+        'view': 'info',
+        'nofilename': '1',
+    }
+    url = makeurl(apiurl, ['source', project], query)
+    root = ETL.parse(http_GET(url)).getroot()
+    return root.xpath(
+        '//sourceinfo[not(./linked[@project="{}"]) and not(contains(@package, ":"))]/@package'.format(project))


### PR DESCRIPTION
- 9c214723c18108d3ec7b99fd14bb00a739c2e059:
    **devel-project: notify: utilize osclib.core.package_list_without_links().**
    
    Otherwise, all packages are returned which include psuedo-packages like
    kernel-default which is really a multi-build of kernel-source. When
    invoking devel_project_fallback() the return ends up being
    openSUSE:Factory/kernel-source which is less than desireable.

- c6289c8516f52e7add838ae0f922199100d233ed:
    osclib/core: provide package_list_without_links().

- 1dc269feaf8ffd5730f15ae45c89202dc939bf4c:
    devel-project: remove unused imports.

There should really be a distinction/API param for this on OBS side. Dropped package count from ~500 which should remove `kernel-default` from being considered a package apart from `kernel-source`. The special devel project for Leap is still respected.