### PR TITLE
metrics/annotation: add openSUSE:Leap:15.0 schedule.

### DIFF
--- a/metrics/annotation/openSUSE:Leap:15.0.yaml
+++ b/metrics/annotation/openSUSE:Leap:15.0.yaml
@@ -1,0 +1,4 @@
+2018-02-01: "Beta phase"
+2018-04-24: "RC phase (package freeze)"
+2018-05-14: "Final submission deadline"
+2018-05-23: "Final release"


### PR DESCRIPTION
To be confirmed by @lnussel, but we can always change as this is only used for annotating graphs.