### PR TITLE
metrics: walk dashboard revisions and extract metrics from relevant files

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -365,7 +365,8 @@ def main(args):
     Cache.CACHE_DIR = Cache.CACHE_DIR + '-metrics'
     if args.wipe_cache:
         Cache.delete_all()
-    Cache.PATTERNS['/search/request'] = sys.maxint
+    if args.heavy_cache:
+        Cache.PATTERNS['/search/request'] = sys.maxint
     Cache.init()
 
     Config(args.project)
@@ -395,6 +396,8 @@ if __name__ == '__main__':
     parser.add_argument('--user', default='root', help='InfluxDB user')
     parser.add_argument('--password', default='root', help='InfluxDB password')
     parser.add_argument('--wipe-cache', action='store_true', help='wipe GET request cache before executing')
+    parser.add_argument('--heavy-cache', action='store_true',
+                        help='cache ephemeral queries indefinitely (useful for development)')
     parser.add_argument('--release-only', action='store_true', help='ingest release metrics only')
     args = parser.parse_args()
 

--- a/metrics.py
+++ b/metrics.py
@@ -393,6 +393,125 @@ def dashboard_at(api, filename, datetime=None, revision=None):
 
     return content
 
+def dashboard_at_changed(api, filename, revision=None):
+    if not hasattr(dashboard_at_changed, 'previous'):
+        dashboard_at_changed.previous = {}
+
+    content = dashboard_at(api, filename, revision=revision)
+
+    if content is None and filename == 'repo_checker' and api.project == 'openSUSE:Factory':
+        # Special case to fallback to installcheck pre repo_checker file.
+        return dashboard_at_changed(api, 'installcheck', revision)
+
+    if content and content != dashboard_at_changed.previous.get(filename):
+        dashboard_at_changed.previous[filename] = content
+        return content
+
+    return None
+
+def ingest_dashboard_config(content):
+    if not hasattr(ingest_dashboard_config, 'seen'):
+        ingest_dashboard_config.seen = set()
+
+    fields = {}
+    for key, value in content.items():
+        if key.startswith('repo_checker-binary-whitelist'):
+            ingest_dashboard_config.seen.add(key)
+
+            fields[key] = len(value.split())
+
+    # Ensure any previously seen key are filled with zeros if no longer present
+    # to allow graphs to fill with previous.
+    missing = ingest_dashboard_config.seen - set(fields.keys())
+    for key in missing:
+        fields[key] = 0
+
+    return fields
+
+def ingest_dashboard_devel_projects(content):
+    return {
+        'count': len(content.strip().split()),
+    }
+
+def ingest_dashboard_repo_checker(content):
+    return {
+        'install_count': content.count("can't install "),
+        'conflict_count': content.count('found conflict of '),
+        'line_count': content.count('\n'),
+    }
+
+def ingest_dashboard_version_snapshot(content):
+    return {
+        'version': content.strip(),
+    }
+
+def ingest_dashboard_revision_get():
+    result = client.query('SELECT revision FROM dashboard ORDER BY time DESC LIMIT 1')
+    if result:
+        return next(result.get_points())['revision']
+
+    return None
+
+def ingest_dashboard_revision_put(revision):
+    client.drop_measurement('dashboard')
+    client.write_points([{
+        'measurement': 'dashboard',
+        'fields': {
+            'revision': revision,
+        },
+        'time': timestamp(datetime.now()),
+    }], 's')
+
+def ingest_dashboard(api):
+    index = revision_index(api)
+
+    revision_last = ingest_dashboard_revision_get()
+    past = True if revision_last is None else False
+    print('dashboard ingest: processing {:,} revisions starting after {}'.format(
+        len(index), 'the beginning' if past else revision_last))
+
+    filenames = ['config', 'repo_checker', 'version_snapshot']
+    if api.project == 'openSUSE:Factory':
+        filenames.append('devel_projects')
+
+    count = 0
+    points = []
+    for made, revision in sorted(index.items()):
+        if not past:
+            if revision == revision_last:
+                past = True
+            continue
+
+        time = timestamp(made)
+        for filename in filenames:
+            content = dashboard_at_changed(api, filename, revision)
+            if content:
+                map_func = globals()['ingest_dashboard_{}'.format(filename)]
+                fields = map_func(content)
+                if not len(fields):
+                    continue
+
+                points.append({
+                    'measurement': 'dashboard_{}'.format(filename),
+                    'fields': fields,
+                    'time': time,
+                })
+
+        if len(points) >= 1000:
+            client.write_points(points, 's')
+            count += len(points)
+            points = []
+
+    if len(points):
+        client.write_points(points, 's')
+        count += len(points)
+
+    # Keep track of last revision process to start after that next time.
+    print('storing last revision processed: {}'.format(revision))
+    ingest_dashboard_revision_put(revision)
+
+    return count
+
 def main(args):
     global client
     client = InfluxDBClient(args.host, args.port, args.user, args.password, args.project)
@@ -419,6 +538,8 @@ def main(args):
 
     Config(args.project)
     api = StagingAPI(osc.conf.config['apiurl'], args.project)
+
+    print('dashboard: wrote {:,} points'.format(ingest_dashboard(api)))
 
     global who_workaround_swap, who_workaround_miss
     who_workaround_swap = who_workaround_miss = 0

--- a/metrics/grafana/dashboard.json
+++ b/metrics/grafana/dashboard.json
@@ -1,0 +1,632 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1524204893070,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$project",
+      "description": "The number of devel projects utilized.",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "interval": "1d",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$col",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "previous"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "dashboard_devel_projects",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              },
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Devel Projects",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$project",
+      "description": "The number of issues detect in main project by repo-checker by type plus line count.",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "interval": "1d",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$col",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "previous"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "dashboard_repo_checker",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "conflict_count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  "conflict"
+                ],
+                "type": "alias"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "install_count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  "install"
+                ],
+                "type": "alias"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "line_count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  "line"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Repo Checker Issues",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$project",
+      "description": "The number of binaries whitelisted from repo-checker during staging process.",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 2,
+      "interval": "1d",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$col",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "previous"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "dashboard_config",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "repo_checker-binary-whitelist"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              },
+              {
+                "params": [
+                  "all"
+                ],
+                "type": "alias"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "repo_checker-binary-whitelist-i586"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              },
+              {
+                "params": [
+                  "i586"
+                ],
+                "type": "alias"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "repo_checker-binary-whitelist-x86_64"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              },
+              {
+                "params": [
+                  "x86_64"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Repo Checker Whitelist",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$project",
+      "description": "The number of releases made during a week.",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$col",
+          "groupBy": [
+            {
+              "params": [
+                "1w"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "dashboard_version_snapshot",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "version"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "count"
+              },
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Weekly Releases",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": "7",
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "tags": [],
+          "text": "openSUSE:Factory",
+          "value": "openSUSE:Factory"
+        },
+        "hide": 0,
+        "label": null,
+        "name": "project",
+        "options": [],
+        "query": "influxdb",
+        "refresh": 1,
+        "regex": "/openSUSE:.*/",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1y",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "OSRT: Dashboard",
+  "uid": "osrt_dashboard",
+  "version": 1
+}

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1520,8 +1520,8 @@ class StagingAPI(object):
         url = self.makeurl(['source', project, package, filename], {'comment': comment})
         http_PUT(url, data=content)
 
-    def dashboard_content_load(self, filename):
-        return self.load_file_content(self.cstaging, 'dashboard', filename)
+    def dashboard_content_load(self, filename, revision=None):
+        return self.load_file_content(self.cstaging, 'dashboard', filename, revision)
 
     def dashboard_content_save(self, filename, content, comment='script updated'):
         return self.save_file_content(self.cstaging, 'dashboard', filename, content, comment)

--- a/systemd/osrt-metrics@.service
+++ b/systemd/osrt-metrics@.service
@@ -4,9 +4,7 @@ Description=openSUSE Release Tools: metrics for %i
 [Service]
 User=osrt-metrics
 SyslogIdentifier=osrt-metrics
-# TODO #1244: improve incremental data ingest
-# ExecStart=/usr/bin/osrt-metrics --debug -p "%i"
-ExecStart=/usr/bin/osrt-metrics --debug -p "%i" --wipe-cache
+ExecStart=/usr/bin/osrt-metrics --debug -p "%i"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- 0ec3569d7068bae5dff9417183499ce10c228768:
    metrics/grafana: add dashboard.json.

- a45c3358df2e0b0e46c63677a394b5cdd69b35aa:
    metrics: ingest relevant dashboard files and extract metrics.

- 4ee96ae3d20b5174d33c96e97ecaced65ff19ebf:
    metrics: provide dashboard revision walking function and cache patterns.

- 079eda3ba69b883262635be945bf44bf0641a4dd:
    metrics: instead of wiping cache place ephemeral patterns behind flag.
    
    This allows for non-ephemeral queries to be cached indeinitely in the
    future (like source queries that include the revision). For development
    one may use --heavy-cache to be able to quickly iterate.

- 48913abc47e88f0d8416f7f5d1f6bd4665a2c241:
    osclib/stagingapi: dashboard_content_load(): expose revision parameter.

This is also step one towards #1168 which is useful to cleanup incorrect spikes in graphs. Had much of this code sitting around for several months so cleaned it up and added a grafana dashboard.