### PR TITLE
unmaintained: utilize package_binary_list(exclude_src_debug).

### DIFF
--- a/unmaintained.py
+++ b/unmaintained.py
@@ -29,9 +29,9 @@ def unmaintained(apiurl, project_target):
     lookup = {k: v for k, v in lookup.iteritems() if v.startswith('SUSE:SLE')}
 
     package_binaries, _ = package_binary_list(
-        apiurl, project_target, 'standard', 'x86_64')
+        apiurl, project_target, 'standard', 'x86_64', exclude_src_debug=True)
     package_binaries_total = len(package_binaries)
-    package_binaries = [pb for pb in package_binaries if pb.arch != 'src' and pb.package in lookup]
+    package_binaries = [pb for pb in package_binaries if pb.package in lookup]
 
     # Determine max length possible for each column.
     maxes = [


### PR DESCRIPTION
- d65e037d18380b520cd97de18b43378e93fafca9:
    unmaintained: utilize package_binary_list(exclude_src_debug).

- 3c560d0c68ff1f2cffbb2abd53fab52dc09e415c:
    osclib/core: package_binary_list(): provide exclude_src_debug option.

Per feedback in [poo#28815](https://progress.opensuse.org/issues/28815).