### PR TITLE
repo_checker: provide whitelist_clean subcommand.

### DIFF
--- a/osclib/core.py
+++ b/osclib/core.py
@@ -16,7 +16,7 @@ from osc.core import show_package_meta
 from osc.core import show_project_meta
 from osclib.memoize import memoize
 
-BINARY_REGEX = r'(?:.*::)?(?P<filename>(?P<name>.*?)-(?P<version>[^-]+)-(?P<release>[^-]+)\.(?P<arch>[^-\.]+))'
+BINARY_REGEX = r'(?:.*::)?(?P<filename>(?P<name>.*)-(?P<version>[^-]+)-(?P<release>[^-]+)\.(?P<arch>[^-\.]+))'
 RPM_REGEX = BINARY_REGEX + '\.rpm'
 BinaryParsed = namedtuple('BinaryParsed', ('package', 'filename', 'name', 'arch'))
 

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 import cmdln
 from collections import namedtuple
 import hashlib
@@ -518,6 +520,77 @@ class RepoChecker(ReviewBot.ReviewBot):
         self.review_messages['accepted'] = 'delete request is safe'
         return True
 
+    def whitelist_clean(self, project):
+        from copy import copy
+        from difflib import unified_diff
+        from osclib.core import BINARY_REGEX
+
+        api = self.staging_api(project)
+
+        # Determine which binaries are mentioned in repo_checker output.
+        content = api.dashboard_content_load('repo_checker')
+        sections = self.install_check_parse(content)
+        binaries = set()
+        for section in sections:
+            for binary in section.binaries:
+                match = re.match(BINARY_REGEX, binary)
+                if match:
+                    binaries.add(match.group('name'))
+
+        # Find whitelist config entries and filter list to only those mentioned.
+        prefix = 'repo_checker-binary-whitelist'
+        binaries_common = None
+        whitelists = {}
+        whitelists_remaining = {}
+        for key, value in self.staging_config[project].items():
+            if not key.startswith(prefix):
+                continue
+
+            whitelists[key] = set(value.split())
+            whitelists_remaining[key] = whitelists[key].intersection(binaries)
+
+            if key != prefix:
+                if binaries_common is None:
+                    binaries_common = whitelists_remaining[key]
+                else:
+                    binaries_common = binaries_common.intersection(whitelists_remaining[key])
+
+        if len(binaries_common):
+            # Remove entries common to all archs and place in common whitelist.
+            whitelists_remaining[prefix].update(binaries_common)
+
+            for key, value in whitelists_remaining.items():
+                if key == prefix:
+                    continue
+
+                whitelists_remaining[key] = whitelists_remaining[key] - binaries_common
+
+        # Update whitelist entries with new values.
+        config = api.dashboard_content_load('config').splitlines(True)
+        config_new = copy(config)
+        for key, value in whitelists_remaining.items():
+            if value != whitelists[key]:
+                self.whitelist_clean_set(config_new, key, ' '.join(value))
+
+        if config == config_new:
+            print('No changes')
+            return
+
+        # Present diff and prompt to apply.
+        print(''.join(unified_diff(config, config_new, fromfile='config.orig', tofile='config.new')))
+        print('Apply config changes? [y/n] (y): ',  end='')
+        response = raw_input().lower()
+        if response == '' or response == 'y':
+            api.dashboard_content_save('config', ''.join(config_new), 'repo_checker whitelist clean')
+
+    def whitelist_clean_set(self, config, key, value):
+        # Unfortunately even OscConfigParser does not preserve empty lines.
+        for i, line in enumerate(config):
+            if line.startswith(key + ' ='):
+                config[i] = '{} = {}\n'.format(key, value) if value else '{} =\n'.format(key)
+
+        return config
+
 
 class CommandLineInterface(ReviewBot.CommandLineInterface):
 
@@ -549,6 +622,10 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
     def do_project_only(self, subcmd, opts, project):
         self.checker.check_requests() # Needed to properly init ReviewBot.
         self.checker.project_only(project, opts.post_comments)
+
+    def do_whitelist_clean(self, subcmd, opts, project):
+        self.checker.check_requests() # Needed to properly init ReviewBot.
+        self.checker.whitelist_clean(project)
 
 if __name__ == "__main__":
     app = CommandLineInterface()


### PR DESCRIPTION
- 35989be1da0688d7be3a28aea6f415908029ace9:
    **repo_checker: provide whitelist_clean subcommand.**
    
    Removes whitelist entries that are no longer mentioned in repo_checker
    output and condenses entries common to all.

- c4f799d7ddcd04d23d47d1856440cec512ac8668:
    osclib/core: correct BINARY_REGEX by making it greedy.
    
    Should not effect RPM_REGEX usage since it appends suffix.

Automates the last portion of [poo#35425](https://progress.opensuse.org/issues/35425).

I ran locally for _Leap 15.0_:

```
$ ./repo_checker.py whitelist_clean openSUSE:Leap:15.0
```

```diff
--- config.orig
+++ config.new
@@ -15,9 +15,9 @@
 repo_checker-arch-whitelist = x86_64
 
 # these issues should be resolved, see dashboard/repo_checker for details
-repo_checker-binary-whitelist = atkmm1_6-doc autoyast2 build-mkbaselibs build-mkbaselibs-sle devscripts duplicity dvd+rw-tools gedit-plugin-zeitgeist git-cvs gnome-boxes gnome-boxes-lang gnome-builder-plugin-ctags gnome-builder-plugin-gnome-code-assistance gnome-builder-plugin-jedi gnome-shell-search-provider-boxes graphviz graphviz-smyrna gtkmm3-doc inkscape-extensions-skencil java-1_7_0-openjdk-accessibility java-1_8_0-openjdk-accessibility k3b k3b-devel k3b-lang kdebase4-workspace kiwi-instsource-plugins-openSUSE-13-2 ldirectord libreoffice-l10n-fi libvirt-daemon-vbox monitoring-plugins-metadata ocaml-brlapi patterns-media-rest_cd_core patterns-media-rest_cd_gnome patterns-media-rest_cd_kde patterns-media-rest_cd_x11 pcp-import-iostat2pcp pcp-import-sar2pcp pcp-pmda-ds389 pcp-pmda-ds389log pcp-pmda-snmp perl-CPAN-Meta plasma-nm5-openvpn plasma-nm5-strongswan python-katedj python-kdebase4 python2-Beaker python2-kiwi python3-Beaker samba-pidl sk1 skelcd-control-openSUSE speech-dispatcher-configure unbound-munin xorg-x11-Xvnc-novnc  firewall-applet kernel-default-livepatch NetworkManager-vpnc NetworkManager-vpnc-gnome NetworkManager-vpnc-lang plasma-nm5-vpnc patterns-media-rest_dvd
+repo_checker-binary-whitelist = patterns-media-rest_dvd kiwi-instsource-plugins-openSUSE-13-2
 
-repo_checker-binary-whitelist-x86_64 = ceph ceph-mgr enchant-voikko-32bit idnkit-devel-32bit libfabric-devel-32bit libvoikko1-32bit patterns-devel-base-devel_web patterns-media-rest_dvd perl-CPAN-Meta python-katedj python3-Beaker samba-pidl skelcd-control-openSUSE zeitgeist
+repo_checker-binary-whitelist-x86_64 =
 
 nocleanup-packages = bootstrap-copy 000product 000release-packages
 

Apply config changes? [y/n] (y):
```

Created [revision 879](https://build.opensuse.org/package/rdiff/openSUSE:Leap:15.0:Staging/dashboard?linkrev=base&rev=879).