### PR TITLE
metrics: ingest_dashboard_config: initialize seen with last record keys.

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -411,7 +411,14 @@ def dashboard_at_changed(api, filename, revision=None):
 
 def ingest_dashboard_config(content):
     if not hasattr(ingest_dashboard_config, 'seen'):
-        ingest_dashboard_config.seen = set()
+        result = client.query('SELECT * FROM dashboard_config ORDER BY time DESC LIMIT 1')
+        if result:
+            # Extract last point and remove zero values since no need to fill.
+            point = next(result.get_points())
+            point = {k: v for (k, v) in point.iteritems() if k != 'time' and v != 0}
+            ingest_dashboard_config.seen = set(point.keys())
+        else:
+            ingest_dashboard_config.seen = set()
 
     fields = {}
     for key, value in content.items():

--- a/metrics.py
+++ b/metrics.py
@@ -422,9 +422,13 @@ def ingest_dashboard_config(content):
 
     # Ensure any previously seen key are filled with zeros if no longer present
     # to allow graphs to fill with previous.
-    missing = ingest_dashboard_config.seen - set(fields.keys())
-    for key in missing:
-        fields[key] = 0
+    fields_keys = set(fields.keys())
+    missing = ingest_dashboard_config.seen - fields_keys
+    if len(missing):
+        ingest_dashboard_config.seen = fields_keys
+
+        for key in missing:
+            fields[key] = 0
 
     return fields
 

--- a/metrics.py
+++ b/metrics.py
@@ -410,29 +410,29 @@ def dashboard_at_changed(api, filename, revision=None):
     return None
 
 def ingest_dashboard_config(content):
-    if not hasattr(ingest_dashboard_config, 'seen'):
+    if not hasattr(ingest_dashboard_config, 'previous'):
         result = client.query('SELECT * FROM dashboard_config ORDER BY time DESC LIMIT 1')
         if result:
             # Extract last point and remove zero values since no need to fill.
             point = next(result.get_points())
             point = {k: v for (k, v) in point.iteritems() if k != 'time' and v != 0}
-            ingest_dashboard_config.seen = set(point.keys())
+            ingest_dashboard_config.previous = set(point.keys())
         else:
-            ingest_dashboard_config.seen = set()
+            ingest_dashboard_config.previous = set()
 
     fields = {}
     for key, value in content.items():
         if key.startswith('repo_checker-binary-whitelist'):
-            ingest_dashboard_config.seen.add(key)
+            ingest_dashboard_config.previous.add(key)
 
             fields[key] = len(value.split())
 
     # Ensure any previously seen key are filled with zeros if no longer present
     # to allow graphs to fill with previous.
     fields_keys = set(fields.keys())
-    missing = ingest_dashboard_config.seen - fields_keys
+    missing = ingest_dashboard_config.previous - fields_keys
     if len(missing):
-        ingest_dashboard_config.seen = fields_keys
+        ingest_dashboard_config.previous = fields_keys
 
         for key in missing:
             fields[key] = 0


### PR DESCRIPTION
- 40dd33f3e053c56688197155c56f473b85f6006d:
    metrics: ingest_dashboard_config: rename seen to previous.
    
    More accurately describes the new purpose.

- da3400b62ede6ecb674d65b461601d618c376a83:
    **metrics: ingest_dashboard_config: initialize seen with last record keys.**

- 060ac43784df403ab0b81db5aee0cd0d132460b1:
    metrics: ingest_dashboard_config: only fill missing values once.

Properly fills removed key with 0 if removed in between runs.