### PR TITLE
metrics: dashboard: include revisions graph.

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -446,21 +446,11 @@ def ingest_dashboard_version_snapshot(content):
     }
 
 def ingest_dashboard_revision_get():
-    result = client.query('SELECT revision FROM dashboard ORDER BY time DESC LIMIT 1')
+    result = client.query('SELECT revision FROM dashboard_revision ORDER BY time DESC LIMIT 1')
     if result:
         return next(result.get_points())['revision']
 
     return None
-
-def ingest_dashboard_revision_put(revision):
-    client.drop_measurement('dashboard')
-    client.write_points([{
-        'measurement': 'dashboard',
-        'fields': {
-            'revision': revision,
-        },
-        'time': timestamp(datetime.now()),
-    }], 's')
 
 def ingest_dashboard(api):
     index = revision_index(api)
@@ -514,9 +504,7 @@ def ingest_dashboard(api):
         client.write_points(points, 's')
         count += len(points)
 
-    # Keep track of last revision process to start after that next time.
-    print('storing last revision processed: {}'.format(revision))
-    ingest_dashboard_revision_put(revision)
+    print('last revision processed: {}'.format(revision))
 
     return count
 

--- a/metrics.py
+++ b/metrics.py
@@ -497,6 +497,14 @@ def ingest_dashboard(api):
                     'time': time,
                 })
 
+        points.append({
+            'measurement': 'dashboard_revision',
+            'fields': {
+                'revision': revision,
+            },
+            'time': time,
+        })
+
         if len(points) >= 1000:
             client.write_points(points, 's')
             count += len(points)

--- a/metrics/grafana/dashboard.json
+++ b/metrics/grafana/dashboard.json
@@ -571,6 +571,118 @@
           "show": true
         }
       ]
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$project",
+      "description": "The number of revisions to dashboard container made during a week.",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$col",
+          "groupBy": [
+            {
+              "params": [
+                "1w"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "dashboard_revision",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "revision"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "count"
+              },
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Weekly Revisions",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": "7",
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
     }
   ],
   "refresh": false,


### PR DESCRIPTION
- 1268165f53cb1f492ab1edd509e63ac7338dee71:
    metrics: dashboard: drop dashboard measurement in favor of dashboard_revision.

- 6e74ae62fd92201d317389386f710a5074f25490:
    metrics: dashboard: include revisions graph.