### PR TITLE
freeze_command: rebase staging project do not erase users data

### DIFF
--- a/osclib/freeze_command.py
+++ b/osclib/freeze_command.py
@@ -43,6 +43,9 @@ class FreezeCommand(object):
         meta = ET.fromstring(self.prj_meta_for_bootstrap_copy(self.prj))
         meta.find('title').text = oldmeta.find('title').text
         meta.find('description').text = oldmeta.find('description').text
+        for person in oldmeta.findall('person'):
+            # the xml has a fixed structure
+            meta.insert(2, ET.Element('person', role=person.get('role'), userid=person.get('userid')))
 
         self.api.retried_PUT(url, ET.tostring(meta))
 


### PR DESCRIPTION
Sometimes we has distributed a staging project for specific reason and given people the maintainership, after froze staging project the users data will be erased, freeze command should copy the users data therefore we do not need to add people back again. Staging Master have to remember reset users data when the goal of staging project has achieved.