### PR TITLE
osclib/check_duplicate_binaries: ignore s/glibc.i686/glibc:i686/.

### DIFF
--- a/osclib/check_duplicate_binaries_command.py
+++ b/osclib/check_duplicate_binaries_command.py
@@ -16,7 +16,7 @@ class CheckDuplicateBinariesCommand(object):
         # different architecture than built for.
         self.ignore_extra_archs = {
             'i586': {
-                'glibc.i686': ('i686',)
+                'glibc:i686': ('i686',)
             },
             'x86_64': {
                 'syslinux': ('s390x', 'ppc64le',)


### PR DESCRIPTION
Presumably an oversight when lnussel added.

@lnussel: Would it make more sense to just ignore all cases where `parch != arch`?

This changes drop the following from output:

```
  glibc:
  - glibc
  - glibc:i686
  glibc-debuginfo:
  - glibc
  - glibc:i686
  glibc-debugsource:
  - glibc
  - glibc:i686
  glibc-devel:
  - glibc
  - glibc:i686
  glibc-devel-debuginfo:
  - glibc
  - glibc:i686
  glibc-devel-static:
  - glibc
  - glibc:i686
  glibc-locale:
  - glibc
  - glibc:i686
  glibc-locale-debuginfo:
  - glibc
  - glibc:i686
  glibc-profile:
  - glibc
  - glibc:i686
```