### PR TITLE
repo_checker: project_only: store build hash and skip when unchanged and increase timer frequency to hourly

### DIFF
--- a/repo_checker.py
+++ b/repo_checker.py
@@ -59,7 +59,16 @@ class RepoChecker(ReviewBot.ReviewBot):
             self.logger.info('{}/standard not published'.format(project))
             return
 
-        comment = []
+        build = ET.fromstringlist(show_results_meta(
+            self.apiurl, project, multibuild=True, repository=['standard'])).get('state')
+        dashboard_content = api.dashboard_content_load('repo_checker')
+        if not self.force and dashboard_content:
+            build_previous = dashboard_content.splitlines()[0]
+            if build == build_previous:
+                self.logger.info('{} build unchanged'.format(project))
+                return
+
+        comment = [build]
         for arch in self.target_archs(project):
             directory_project = self.mirror(project, arch)
 

--- a/systemd/osrt-repo-checker-project_only@.timer
+++ b/systemd/osrt-repo-checker-project_only@.timer
@@ -2,7 +2,7 @@
 Description=openSUSE Release Tools: repo-checker project_only for %i
 
 [Timer]
-OnCalendar=daily
+OnCalendar=hourly
 Unit=osrt-repo-checker-project_only@%i.service
 
 [Install]


### PR DESCRIPTION
- b5320317d7e0c2a5dfba0e5e87707dc807c08391:
    systemd/osrt-repo-checker-project_only@.timer: increase frequency to hourly.
    
    Now that repo_checker will skip identical builds this will increase the
    chances that repo_checker project_only hits the project when it is not
    building and will decrease the wait time for updates.

- 4f26b0881af2991b93662a1c29406e731d79fe2a:
    repo_checker: project_only: store build hash and skip when unchanged.

_Leap 15.0_ is running hourly on tortuga and SLE-15 was the same before it was migrated. The main reason for the daily run was prior to the published check to avoid changing all the time during builds, but with the check that is not longer an issue. To avoid lots of extra process and API calls when using `--post-comments` the same build hash style check is added.

@coolo Since we talked about `project_only` comments and such can you verify the new setup is using the updated timer and original flags?