### PR TITLE
ReviewBot: runner: reload checker and reset memoize session caches.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -30,6 +30,7 @@ from osclib.comments import CommentAPI
 from osclib.conf import Config
 from osclib.core import group_members
 from osclib.memoize import memoize
+from osclib.memoize import memoize_session_reset
 from osclib.stagingapi import StagingAPI
 import signal
 import datetime
@@ -719,7 +720,17 @@ class CommandLineInterface(cmdln.Cmdln):
                 else:
                     self.logger.info("sleeping %d minutes." % interval)
                     time.sleep(interval * 60)
+
+                # Reset all memoize session caches which are designed for single
+                # tool run and not extended usage.
+                memoize_session_reset()
+
+                # Reload checker to flush instance variables and thus any config
+                # or caches they may contain.
+                self.postoptparse()
+
                 continue
+
             break
 
 if __name__ == "__main__":

--- a/osclib/memoize.py
+++ b/osclib/memoize.py
@@ -100,6 +100,7 @@ def memoize(ttl=None, session=False, add_invalidate=False):
     SLOTS = 4096            # Number of slots in the cache file
     NCLEAN = 1024           # Number of slots to remove when limit reached
     TIMEOUT = 60*60*2       # Time to live for every cache slot (seconds)
+    memoize.session_functions = []
 
     def _memoize(fn):
         # Implement a POSIX lock / unlock extension for shelves. Inspired
@@ -123,6 +124,7 @@ def memoize(ttl=None, session=False, add_invalidate=False):
             else:
                 if not hasattr(fn, '_memoize_session_cache'):
                     fn._memoize_session_cache = {}
+                    memoize.session_functions.append(fn)
                 cache = fn._memoize_session_cache
             return cache
 
@@ -197,3 +199,8 @@ def memoize(ttl=None, session=False, add_invalidate=False):
 
     ttl = ttl if ttl else TIMEOUT
     return _memoize
+
+def memoize_session_reset():
+    """Reset all session caches."""
+    for i, _ in enumerate(memoize.session_functions):
+        memoize.session_functions[i]._memoize_session_cache = {}


### PR DESCRIPTION
- 7b2f07c5f5e713f632cfa7296479cbb98facbfa7:
    ReviewBot: runner: reload checker and reset memoize session caches.
    
    Otherwise, memoize(session=True) caches are kept until the process is
    stopped which is obviously not how they were intended to be used. This
    can cause incorrect behavior and continued memory growth.

- 2a43297880d99d0fc1310c50d0469a4362da18c8:
    osclib/memoize: provide memoize_session_reset().
    
    Allows all session caches to be reset.

Fixes #1511. At least the glaring problems like never reloading build status until the process runs out of memory and crashes. I'd need to do more extensive testing to verify memory no longer climbs. I am doing some test runs locally, but may not be thorough enough.