### PR TITLE
Handle armv6/armv7 with totest manager as well

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -320,9 +320,6 @@ class ToTestBase(object):
             # meant to use the totest manager.
             if repo.get('repository') in ('ports', 'factory', 'images_staging'):
                 continue
-            # ignore 32bit for now. We're only interesed in aarch64 here
-            if repo.get('arch') in ('armv6l', 'armv7l'):
-                continue
             if repo.get('dirty', '') == 'true':
                 logger.info('%s %s %s -> %s' % (repo.get('project'),
                                                 repo.get('repository'), repo.get('arch'), 'dirty'))


### PR DESCRIPTION
Recently we decided to incorporate armv6 and armv7 publishing into
ToTest as well.