### PR TITLE
osclib/comments: command_find: use MULTILINE mode.

### DIFF
--- a/osclib/comments.py
+++ b/osclib/comments.py
@@ -126,7 +126,8 @@ class CommentAPI(object):
             if who_allowed and comment['who'] not in who_allowed:
                 continue
 
-            match = command_re.search(comment['comment'])
+            # Handle stupid line endings returned in comments.
+            match = command_re.search(comment['comment'].replace('\r', ''))
             if not match:
                 continue
 

--- a/osclib/comments.py
+++ b/osclib/comments.py
@@ -119,7 +119,7 @@ class CommentAPI(object):
         Usage (in comment):
             @<user> <command> [args...]
         """
-        command_re = re.compile(r'^@(?P<user>[^ ]+) (?P<args>.*)$')
+        command_re = re.compile(r'^@(?P<user>[^ ]+) (?P<args>.*)$', re.MULTILINE)
 
         # Search for commands in the order the comment was created.
         for comment in sorted(comments.values(), key=lambda c: c['when']):


### PR DESCRIPTION
- d583ced482332ab218e4198376c21c5fd34eec84:
    osclib/comments: command_find: use MULTILINE mode.

- 5cc8920689189701f870c359618955e7b55eea42:
    osclib/comments: command_find: stupid \r line endings.

As observed in [request#605258](https://build.opensuse.org/request/show/605258).