### PR TITLE
osclib/conf: update remaining non-merged Leap:15.0 settings.

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -95,7 +95,7 @@ DEFAULT = {
         'pkglistgen-archs': 'x86_64',
         'pkglistgen-archs-ports': 'aarch64',
         'pkglistgen-locales-from': 'openSUSE.product',
-        'pkglistgen-include-suggested': '1',
+        'pkglistgen-include-suggested': 'False',
         'pkglistgen-delete-kiwis-rings': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
         'pkglistgen-delete-kiwis-staging': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
         'mail-list': 'opensuse-factory@opensuse.org',

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -64,7 +64,7 @@ DEFAULT = {
         'staging-group': 'factory-staging',
         'staging-archs': 'i586 x86_64',
         'staging-dvd-archs': 'x86_64',
-        'nocleanup-packages': 'Test-DVD-x86_64 bootstrap-copy',
+        'nocleanup-packages': 'bootstrap-copy 000product 000release-packages',
         'rings': 'openSUSE:%(project)s:Rings',
         'nonfree': 'openSUSE:%(project)s:NonFree',
         'rebuild': 'openSUSE:%(project)s:Rebuild',


### PR DESCRIPTION
- 628519d370fe597ded44d6b9958f8f9eb636e04f:
    osclib/conf: update nocleanup-packages post migration to new pkglistgen.

- e7c611e9edba8e01c1ea2f14f073d119af3f20c9:
    osclib/conf: change pkglistgen-include-suggested to False.

To be read for _Leap:15.1_.