### PR TITLE
openqa-comments: drop openSUSE: prefix to allow for generic usage and shebang.

### DIFF
--- a/openqa-comments.py
+++ b/openqa-comments.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 # Copyright (C) 2014 SUSE Linux Products GmbH
 #
 # This program is free software; you can redistribute it and/or modify

--- a/openqa-comments.py
+++ b/openqa-comments.py
@@ -225,8 +225,8 @@ if __name__ == '__main__':
     if args.force:
         MARGIN_HOURS = 0
 
-    Config('openSUSE:%s' % args.project)
-    api = StagingAPI(osc.conf.config['apiurl'], 'openSUSE:%s' % args.project)
+    Config(args.project)
+    api = StagingAPI(osc.conf.config['apiurl'], args.project)
     openQA = OpenQAReport(api)
 
     if args.staging:


### PR DESCRIPTION
- eca6670be1ce4aa262beb3de2e051cca233f1a63:
    openqa-comments: drop openSUSE: prefix to allow for generic usage.

- 284584cc81530df7c59981ac42980a79e0932704:
    openqa-comments: meant to be executable thus should include a shebang.