### PR TITLE
config/manager_42/leap:15.0: increase priority of SLE-workarounds.

### DIFF
--- a/config/manager_42/openSUSE:Leap:15.0.yml
+++ b/config/manager_42/openSUSE:Leap:15.0.yml
@@ -2,9 +2,9 @@
 from_prj: openSUSE:Leap:15.0
 project_preference_order:
 - SUSE:SLE-15:GA
+- openSUSE:Leap:15.0:SLE-workarounds
 - openSUSE:Factory
 - openSUSE:Factory:NonFree
-- openSUSE:Leap:15.0:SLE-workarounds
 drop_if_vanished_from:
 - SUSE:SLE-15:GA
 - openSUSE:Factory


### PR DESCRIPTION
In order to allow for SLE packages to be taken from Factory while waiting on acceptance to SLE, but still mark as from SLE and avoid delete request to SLE-workarounds.

The output when simulated to not be in SLE-15, but marked previous as from there while being in Factory is:

```
2018-05-11 15:53:54,274 - manager_42:361 - INFO - netcdf is from openSUSE:Leap:15.0:SLE-workarounds but should come from SUSE:SLE-15:GA
```

whereas before it would have switched the origin to Factory and the filed a delete request against SLE-workarounds since not utilized.

I believe this make sense rather than a code change since it really is a priority over Factory.