### PR TITLE
Add ppc64le to pkglist gen for Leap 15.0 Ports

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -93,7 +93,7 @@ DEFAULT = {
         # - F-C-C submitter requests (maxlin_factory)
         'unselect-cleanup-whitelist': 'leaper maxlin_factory',
         'pkglistgen-archs': 'x86_64',
-        'pkglistgen-archs-ports': 'aarch64',
+        'pkglistgen-archs-ports': 'aarch64 ppc64le',
         'pkglistgen-locales-from': 'openSUSE.product',
         'pkglistgen-include-suggested': 'False',
         'pkglistgen-delete-kiwis-rings': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1257,7 +1257,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
         self.do_update('update', opts)
 
         nonfree = target_config.get('nonfree')
-        if nonfree and drop_list:
+        if opts.scope != 'ports' and nonfree and drop_list:
             print('-> do_update nonfree')
 
             # Switch to nonfree repo (ugly, but that's how the code was setup).


### PR DESCRIPTION
this architecture is also part of port, not only aarch64, and
we need architecture specific expansions, so extend default list
of architectures accordingly.