### PR TITLE
Freeze adi: do not check the first package in frozenlinks but metadata

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -392,9 +392,9 @@ class StagingAPI(object):
         except urllib2.HTTPError as e:
             if e.code == 404:
                 return None
-        packages = root.findall('./frozenlink/package')
+        meta = self.get_prj_pseudometa(prj)
         # the first package's devel project is good enough
-        return devel_project_get(self.apiurl, self.project, packages[0].get('name'))[0]
+        return devel_project_get(self.apiurl, self.project, meta['requests'][0].get('package'))[0]
 
     def do_change_review_state(self, request_id, newstate, message=None,
                                by_group=None, by_user=None, by_project=None):


### PR DESCRIPTION
Check the devel project from the first package in frozenlinks won't work if the package has been deleted, check the first package in metadata instead.

Tested it on Factory adi:27