### PR TITLE
metrics/annotation/leap:15.0: update final release date.

### DIFF
--- a/metrics/annotation/openSUSE:Leap:15.0.yaml
+++ b/metrics/annotation/openSUSE:Leap:15.0.yaml
@@ -1,4 +1,4 @@
 2018-02-01: "Beta phase"
 2018-04-24: "RC phase (package freeze)"
 2018-05-14: "Final submission deadline"
-2018-05-23: "Final release"
+2018-05-25: "Final release"


### PR DESCRIPTION
Per https://lists.opensuse.org/opensuse-factory/2018-05/msg00223.html.