### PR TITLE
metrics: drop release schedule before writing.

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -345,6 +345,7 @@ def ingest_release_schedule(project):
             'time': timestamp(date),
         })
 
+    client.drop_measurement('release_schedule')
     client.write_points(points, 's')
     return len(points)
 


### PR DESCRIPTION
After change from dropping entire database to individual measurements this was overlooked and instead new points are simply written each time which results in duplicates.