### PR TITLE
Also release 000product:openSUSE-ftp-ftp-armv7hl for Leap 15.0 ports

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -823,6 +823,7 @@ class ToTest150Ports(ToTestBaseNew):
     ]
 
     ftp_products = ['000product:openSUSE-ftp-ftp-aarch64',
+                    '000product:openSUSE-ftp-ftp-armv7hl',
                     ]
 
     livecd_products = []


### PR DESCRIPTION
http://download.opensuse.org/ports/armv7hl/distribution/leap/15.0/repo/oss/ is currently empty, this should fix it.

Untested.