### PR TITLE
Update announcer.py to ask people to report bugs

### DIFF
--- a/factory-package-news/announcer.py
+++ b/factory-package-news/announcer.py
@@ -55,7 +55,7 @@ Please check the known defects of this snapshot before upgrading:
 https://openqa.opensuse.org/tests/overview?distri=opensuse&groupid=1&version=Tumbleweed&build={version}
 
 Please do not reply to this email to report issues, rather file a bug
-on bugzilla.opensuse.org for more information on filing bugs please
+on bugzilla.opensuse.org. For more information on filing bugs please
 see https://en.opensuse.org/openSUSE:Submitting_bug_reports
 
 {text}

--- a/factory-package-news/announcer.py
+++ b/factory-package-news/announcer.py
@@ -54,9 +54,9 @@ The full online repo contains too many changes to be listed here.
 Please check the known defects of this snapshot before upgrading:
 https://openqa.opensuse.org/tests/overview?distri=opensuse&groupid=1&version=Tumbleweed&build={version}
 
-When you reply to report some issues, make sure to change the subject.
-It is not helpful to keep the release announcement subject in a thread
-while discussing a specific problem.
+Please do not reply to this email to report issues, rather file a bug
+on bugzilla.opensuse.org for more information on filing bugs please
+see https://en.opensuse.org/openSUSE:Submitting_bug_reports
 
 {text}
 """,


### PR DESCRIPTION
Rather then replying to the generated email we would like people to create new issues on bugzilla.opensuse.org