### PR TITLE
metrics/grafana/release: score yaxis max 100.

### DIFF
--- a/metrics/grafana/release.json
+++ b/metrics/grafana/release.json
@@ -136,7 +136,7 @@
           "format": "short",
           "label": null,
           "logBase": 1,
-          "max": null,
+          "max": 100,
           "min": null,
           "show": true
         },


### PR DESCRIPTION
With scores reaching near 100 :) the auto axis is leaving margin.