### PR TITLE
dist/ci/Dockerfile: add python2-pyOpenSSL as dependency.

### DIFF
--- a/dist/ci/Dockerfile
+++ b/dist/ci/Dockerfile
@@ -12,6 +12,7 @@ RUN zypper -n ref && zypper -n dup && zypper -n install \
   obs-service-* \
   osc \
   python-packaging \
+  python2-pyOpenSSL \
   sudo
 
 # `osc build` directories that are effective to cache:


### PR DESCRIPTION
Pending a proper resolution to openSUSE/osc#429.

This has been failing for a few days...

```
Traceback (most recent call last):
  File "/usr/bin/osc", line 10, in <module>
    from osc import commandline, babysitter
  File "/usr/lib/python2.7/site-packages/osc/commandline.py", line 9, in <module>
    from . import conf
  File "/usr/lib/python2.7/site-packages/osc/conf.py", line 44, in <module>
    import ssl
ImportError: No module named ssl
```