### PR TITLE
systemd/metrics-access.timer: skip Monday to avoid conflict with metrics.timer.

### DIFF
--- a/systemd/osrt-metrics-access.timer
+++ b/systemd/osrt-metrics-access.timer
@@ -4,7 +4,9 @@ Description=openSUSE Release Tools: metrics - access logs
 [Timer]
 OnBootSec=120
 # Allow for log rotation to take place on download server.
-OnCalendar=*-*-* 4:00:00
+# Skip Monday during which osrt-metrics@.service are run as openSUSE:Factory
+# takes 5 hours and uses up most of the RAM on machine.
+OnCalendar=Tue..Sun *-*-* 4:00:00
 Unit=osrt-metrics-access.service
 
 [Install]


### PR DESCRIPTION
Since:

> weekly → Mon *-*-* 00:00:00

per https://www.freedesktop.org/software/systemd/man/systemd.time.html and verified logs for length. Hasn't happened yet, but would rather avoid.