### PR TITLE
Fix JeOS snapshotable detection for Factory:ARM

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -777,6 +777,7 @@ class ToTestFactoryARM(ToTestFactory):
                     '000product:openSUSE-ftp-ftp-armv6hl']
 
     livecd_products = ['JeOS']
+    livecd_archs = ['armv7l']
 
     def __init__(self, *args, **kwargs):
         ToTestFactory.__init__(self, *args, **kwargs)


### PR DESCRIPTION
In order to release the live images for Factory:ARM we need
to check if they finished building. Currently JeOS is multibuild
for armv7l and aarch64 but the main package is just building for armv7l,
so thats what we check for now. Without this change it was checking
for the default architectures (i586, x86_64) which did never pass.