### PR TITLE
osclib/stagingapi: attribute_value_load(): ensure using desired value.

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1546,10 +1546,10 @@ class StagingAPI(object):
                 return None
             raise e
         root = ET.parse(f).getroot()
-        root = root.find('./attribute/value')
-        if root is None:
+        root = root.xpath('./attribute[@namespace="OSRT" and @name="{}"]/value/text()'.format(attribute))
+        if not len(root):
             return None
-        return root.text
+        return root[0]
 
     # to create a new attribute 'type' you need to do some manual step
     # create a xml file analoge to what


### PR DESCRIPTION
OBS likes to not follow its API documentation and tends to ignore the
specific attribute option and returns everything. This results in
returning the first element that lxml decide to match to the pattern.

Not sure if OBS broke this recently, or if #1573 was poorly tested.

Documentation: https://build.opensuse.org/apidocs/index#32
Actual result:

```
$ osc api /source/openSUSE:Factory/_attribute/OSRT:Config
```

```xml
<attributes>
  <attribute name="VeryImportantProject" namespace="OBS"/>
  <attribute name="InitializeDevelPackage" namespace="OBS"/>
  <attribute name="ApprovedRequestSource" namespace="OBS"/>
  <attribute name="IgnoredIssues" namespace="OSRT">
    <value>last_seen:
  boo#1062803: '20180506'
  boo#1064836: '20180626'
  boo#1068938: '20180506'
  boo#1076835: '20180603'
  boo#1079320: '20180516'
  boo#1084316: '20180626'
  boo#1087685: '20180606'
  boo#1088562: '20180429'
  boo#1092845: '20180517'
  boo#1093029: '20180523'
  boo#1093039: '20180513'
  boo#1093132: '20180626'
  boo#1093947: '20180626'
  boo#1094584: '20180524'
  boo#1094877: '20180529'
  boo#1094987: '20180626'
  boo#1097425: '20180626'
  boo#1097625: '20180618'
  boo#1099104: '20180626'
  bsc#1049433: '20180506'
  bsc#1055830: '20180527'
  bsc#1079877: '20180626'
  bsc#1093029: '20180626'
  gh#os-autoinst/os-autoinst-distri-opensuse#5015: '20180608'
  poo#17436: '20180625'
  poo#27457: '20180506'
  poo#34090: '20180626'
  poo#34381: '20180504'
  poo#34405: '20180618'
  poo#34717: '20180606'
  poo#34996: '20180623'
  poo#35215: '20180608'
  poo#35302: '20180626'
  poo#35482: '20180507'
  poo#35589: '20180623'
  poo#35604: '20180521'
  poo#35685: '20180620'
  poo#35706: '20180604'
  poo#36231: '20180525'
  poo#36304: '20180626'
  poo#36333: '20180516'
  poo#36363: '20180527'
  poo#36748: '20180613'
  poo#36946: '20180618'
  poo#36949: '20180618'
  poo#36952: '20180623'
  poo#36997: '20180625'
  poo#37000: '20180625'
  poo#37003: '20180606'
  poo#37273: '20180615'
  poo#37306: '20180620'
  poo#37354: '20180620'
  poo#37450: '20180625'
  poo#37501: '20180618'
  poo#37659: '20180622'
  poo#37662: '20180626'
  poo#37710: '20180626'
  poo#37713: '20180626'
  poo#37835: '20180626'
</value>
  </attribute>
  <attribute name="Config" namespace="OSRT">
    <value># restricts what stagings the staging-bot will use, when available, for --try-strategies
splitter-whitelist = B C D E F G H I J

# now just for testing
source_projects_expand = devel:languages:haskell

devel-whitelist = network:messaging server:messaging system:snappy

# Introduced in https://github.com/openSUSE/osc-plugin-factory/pull/1041.
# Preferably as these problems are resolved they should be removed from whitelist
# once all letter stagings have been rebased to include the change.
# No new entries should be added without a very good reason. The intent is that
# these lists are eventually done away with.

repo_checker-binary-whitelist-x86_64 =

# rust-src requires rust, which is a i686 package, not installable on 'plain' i586.
# pcp-pmda-ds389log no longer installable (boo#1086297)
repo_checker-binary-whitelist-i586 = kernel-syms rust-src pcp-pmda-ds389log

# caasp-container-manifests is 'special'; it requires rpms produced in :Containers
repo_checker-binary-whitelist = patterns-caasp-Stack caasp-container-manifests
</value>
  </attribute>
</attributes>
```

So it was loading `OSRT:IgnoredIssues` as the config vs `OBS:MaintenanceIdTemplate` is used from `openSUSE:Maintenance`.