### PR TITLE
Update definitions for openSUSE:Leap:15.0:Images

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -378,7 +378,7 @@ class ToTestBase(object):
             return None
 
         # docker container has no size limit
-        if package == 'opensuse-leap-image':
+        if re.match(r'opensuse-leap-image.*', package):
             return None
 
         if '-Addon-NonOss-ftp-ftp' in package:
@@ -846,7 +846,8 @@ class ToTest150Images(ToTestBaseNew):
         'livecd-leap-gnome',
         'livecd-leap-kde',
         'livecd-leap-x11',
-        'opensuse-leap-image',
+        'opensuse-leap-image:docker',
+        'opensuse-leap-image:lxc',
         'kiwi-templates-Leap15-JeOS:MS-HyperV',
         'kiwi-templates-Leap15-JeOS:OpenStack-Cloud',
         'kiwi-templates-Leap15-JeOS:VMware',

--- a/totest-manager.py
+++ b/totest-manager.py
@@ -847,6 +847,11 @@ class ToTest150Images(ToTestBaseNew):
         'livecd-leap-kde',
         'livecd-leap-x11',
         'opensuse-leap-image',
+        'kiwi-templates-Leap15-JeOS:MS-HyperV',
+        'kiwi-templates-Leap15-JeOS:OpenStack-Cloud',
+        'kiwi-templates-Leap15-JeOS:VMware',
+        'kiwi-templates-Leap15-JeOS:XEN',
+        'kiwi-templates-Leap15-JeOS:kvm-and-xen',
     ]
 
     ftp_products = []


### PR DESCRIPTION
```
fvogt@packagelists:~/osc-plugin-factory> /usr/bin/python2 totest-manager.py --dry --verbose run --interval 5 openSUSE:Leap:15.0:Images
2018-06-28 15:17:50,311 - totest-manager:525 INFO current_snapshot 17.9: passed
2018-06-28 15:17:52,428 - totest-manager:483 INFO Updating snapshot 20.2
2018-06-28 15:17:52,431 - totest-manager:466 INFO release openSUSE:Leap:15.0:Images/livecd-leap-gnome (Snapshot20.2)
2018-06-28 15:17:52,432 - totest-manager:466 INFO release openSUSE:Leap:15.0:Images/livecd-leap-kde (Snapshot20.2)
2018-06-28 15:17:52,432 - totest-manager:466 INFO release openSUSE:Leap:15.0:Images/livecd-leap-x11 (Snapshot20.2)
2018-06-28 15:17:52,432 - totest-manager:466 INFO release openSUSE:Leap:15.0:Images/opensuse-leap-image:docker (Snapshot20.2)
2018-06-28 15:17:52,433 - totest-manager:466 INFO release openSUSE:Leap:15.0:Images/opensuse-leap-image:lxc (Snapshot20.2)
2018-06-28 15:17:52,433 - totest-manager:466 INFO release openSUSE:Leap:15.0:Images/kiwi-templates-Leap15-JeOS:MS-HyperV (Snapshot20.2)
2018-06-28 15:17:52,433 - totest-manager:466 INFO release openSUSE:Leap:15.0:Images/kiwi-templates-Leap15-JeOS:OpenStack-Cloud (Snapshot20.2)
2018-06-28 15:17:52,433 - totest-manager:466 INFO release openSUSE:Leap:15.0:Images/kiwi-templates-Leap15-JeOS:VMware (Snapshot20.2)
2018-06-28 15:17:52,434 - totest-manager:466 INFO release openSUSE:Leap:15.0:Images/kiwi-templates-Leap15-JeOS:XEN (Snapshot20.2)
2018-06-28 15:17:52,434 - totest-manager:466 INFO release openSUSE:Leap:15.0:Images/kiwi-templates-Leap15-JeOS:kvm-and-xen (Snapshot20.2)
2018-06-28 15:17:52,434 - totest-manager:1036 INFO sleeping 5 minutes. Press enter to check now ...
```