### PR TITLE
obs_clone: start from :Rings:1-MinimalX instead of :Rings:2-TestDVD.

### DIFF
--- a/obs_clone.py
+++ b/obs_clone.py
@@ -171,7 +171,7 @@ def clone_do(apiurl_source, apiurl_target, project):
         # the leaf can simple be used to start the chain and works as desired.
         # Disable this when running clone repeatedly during developing as the
         # projects cannot be cleanly re-created without more work.
-        entity_clone(apiurl_source, apiurl_target, ['source', project + ':Rings:2-TestDVD', '_meta'],
+        entity_clone(apiurl_source, apiurl_target, ['source', project + ':Rings:1-MinimalX', '_meta'],
                      clone=project_clone)
 
         entity_clone(apiurl_source, apiurl_target, ['source', project + ':Staging', 'dashboard', '_meta'],


### PR DESCRIPTION
:Rings:2-TestDVD was dropped from Factory and Leap.

Resolves CI failure:

```
$ python ./obs_clone.py --cache --debug --apiurl-target local
clone openSUSE:Factory from https://api.opensuse.org to http://0.0.0.0:3000
clone source/openSUSE:Factory:Rings:2-TestDVD/_meta
CACHE_MISS https://api.opensuse.org/source/openSUSE:Factory:Rings:2-TestDVD/_meta (expired)
GET https://api.opensuse.org/source/openSUSE:Factory:Rings:2-TestDVD/_meta
<status code="unknown_project">
  <summary>openSUSE:Factory:Rings:2-TestDVD</summary>
</status>
```