### PR TITLE
check_source: handle maintenance incident workflow.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -314,9 +314,8 @@ class ReviewBot(object):
 
     def check_action_maintenance_incident(self, req, a):
         dst_package = a.src_package
-        # Ignoring patchinfo package for checking
         if self._is_patchinfo(a.src_package):
-            self.logger.info("package is patchinfo, ignoring")
+            self.logger.debug('ignoring patchinfo action')
             return None
         # dirty obs crap
         if a.tgt_releaseproject is not None:
@@ -328,6 +327,7 @@ class ReviewBot(object):
     def check_action_maintenance_release(self, req, a):
         pkgname = a.src_package
         if self._is_patchinfo(pkgname):
+            self.logger.debug('ignoring patchinfo action')
             return None
         linkpkg = self._get_linktarget_self(a.src_project, pkgname)
         if linkpkg is not None:

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -291,7 +291,7 @@ class ReviewBot(object):
         self.review_messages = self.DEFAULT_REVIEW_MESSAGES.copy()
 
         if self.only_one_action and len(req.actions) != 1:
-            self.review_messages['declined'] = 'Only one action per request'
+            self.review_messages['declined'] = 'Only one action per request supported'
             return False
 
         if self.comment_handler is not False:

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -313,16 +313,26 @@ class ReviewBot(object):
         return pkgname == 'patchinfo' or pkgname.startswith('patchinfo.')
 
     def check_action_maintenance_incident(self, req, a):
-        dst_package = a.src_package
         if self._is_patchinfo(a.src_package):
             self.logger.debug('ignoring patchinfo action')
             return None
-        # dirty obs crap
+
+        # Duplicate src_package as tgt_package since prior to assignment to a
+        # specific incident project there is no target package (odd API). After
+        # assignment it is still assumed the target will match the source. Since
+        # the ultimate goal is the tgt_releaseproject the incident is treated
+        # similar to staging in that the intermediate result is not the final
+        # and thus the true target project (ex. openSUSE:Maintenance) is not
+        # used for check_source_submission().
+        tgt_package = a.src_package
         if a.tgt_releaseproject is not None:
-            ugly_suffix = '.'+a.tgt_releaseproject.replace(':', '_')
-            if dst_package.endswith(ugly_suffix):
-                dst_package = dst_package[:-len(ugly_suffix)]
-        return self.check_source_submission(a.src_project, a.src_package, a.src_rev, a.tgt_releaseproject, dst_package)
+            suffix = '.' + a.tgt_releaseproject.replace(':', '_')
+            if tgt_package.endswith(suffix):
+                tgt_package = tgt_package[:-len(suffix)]
+
+        # Note tgt_releaseproject (product) instead of tgt_project (maintenance).
+        return self.check_source_submission(a.src_project, a.src_package, a.src_rev,
+                                            a.tgt_releaseproject, tgt_package)
 
     def check_action_maintenance_release(self, req, a):
         pkgname = a.src_package

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -299,6 +299,9 @@ class ReviewBot(object):
 
         overall = None
         for a in req.actions:
+            # Store in-case sub-classes need direct access to original values.
+            self.action = a
+
             fn = 'check_action_%s'%a.type
             if not hasattr(self, fn):
                 fn = 'check_action__default'

--- a/check_maintenance_incidents.py
+++ b/check_maintenance_incidents.py
@@ -88,7 +88,7 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
             (linkprj, linkpkg) = self._get_linktarget(a.src_project, pkgname)
             if linkpkg is not None:
                 pkgname = linkpkg
-            if pkgname == 'patchinfo':
+            if self._is_patchinfo(a.src_package):
                 return None
 
             project = a.tgt_releaseproject

--- a/check_source.py
+++ b/check_source.py
@@ -46,6 +46,12 @@ class CheckSource(ReviewBot.ReviewBot):
         self.repo_checker = config.get('repo-checker')
         self.devel_whitelist = config.get('devel-whitelist', '').split()
 
+        if self.action.type == 'maintenance_incident':
+            # The workflow effectively enforces the names to match and the
+            # parent code sets target_package from source_package so this check
+            # becomes useless and awkward to perform.
+            self.in_air_rename_allow = True
+
     def check_source_submission(self, source_project, source_package, source_revision, target_project, target_package):
         super(CheckSource, self).check_source_submission(source_project, source_package, source_revision, target_project, target_package)
         self.target_project_config(target_project)

--- a/check_source.py
+++ b/check_source.py
@@ -56,6 +56,9 @@ class CheckSource(ReviewBot.ReviewBot):
             # settings, but override since real target is not product.
             self.single_action_require = False
 
+            # It might make sense to supersede maintbot, but for now.
+            self.skip_add_reviews = True
+
     def check_source_submission(self, source_project, source_package, source_revision, target_project, target_package):
         super(CheckSource, self).check_source_submission(source_project, source_package, source_revision, target_project, target_package)
         self.target_project_config(target_project)

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -51,6 +51,7 @@ DEFAULT = {
         'main-repo': 'standard',
         'download-baseurl': 'http://download.opensuse.org/tumbleweed/',
         # check_source.py
+        'check-source-single-action-require': 'True',
         'devel-project-enforce': 'True',
         'review-team': 'opensuse-review-team',
         'legal-review-group': 'legal-auto',
@@ -83,6 +84,7 @@ DEFAULT = {
         'review-team': 'opensuse-review-team',
         'legal-review-group': 'legal-auto',
         # check_source.py
+        'check-source-single-action-require': 'True',
         # review-team optionally added by leaper.py.
         'repo-checker': 'repo-checker',
         'repo_checker-arch-whitelist': 'x86_64',


### PR DESCRIPTION
- 4c129bec3ca000f8b989508119cdfc8e19b44ff4:
    check_source: skip adding reviews for incidents in favor of maintbot.

- da36ae99310804273ecfcdc0ffe01bda6c6b8d2e:
    check_source: replace one action limitation with configurable rule.
    
    Allows tool to be used on multi-action requests while still enforcing
    the rule for Factory and Leap which should reject such requests due to
    staging process.

- 6092ff55c8b03128c0f30097103a0ace8eadc7a2:
    check_source: override rename project setting for maintenance_incident.

- bfcc1ddf86ead4213e653366bb99d6f67d8939a5:
    check_source: rework rename check to allow for suffixed :Update packages.
    
    Exact name matching is thus always enforced for projects requiring devel
    project enforcement (ie. Factory), but relaxed to compare without suffix
    for packages coming from an :Update project.

- 85e6205e3ac71cfdf4d81d6c7bf47ca7d1d1bc0e:
    ReviewBot: provide self.action for direct access in sub-classes.

- e4f94b471fab1608fe83fe4267e13138a6720518:
    ReviewBot: check_action_maintenance_incident(): clarify src_package magic.

- df10ee01a961ea6452939d642f8056e4752283f2:
    ReviewBot: downgrade patchinfo message to debug and include for release.

- e308bd6139ab34301caaf43dd2042145d2d2ba13:
    check_maintenance_incidencts: utilize _is_patchinfo().
    
    Pulled out as function in 9a418f780f2c09caaf22c1430b93b1895909bd80, but
    not used in maintenance bot.

Fixes #1571 so @lnussel should be able to remove in-air config override.

As it stands the target project (ex. Leap:15.0:Update) is used for settings instead of `openSUSE:Maintenance`. This is a side-effect of the way the incidents are morphed to look like plain submit requests. It is desirable in that the same rules are real target project are enforced per action (fancy), but has the down-side that the real target project cannot have it's own settings.