### PR TITLE
pkglistgen: remove default-support-status option

### DIFF
--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1235,7 +1235,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
 
             if packages.find('entry[@name="{}"]'.format(release)) is None:
                 if not self.options.dry:
-                    undelete_package(apiurl, opts.project, product, 'revive')
+                    undelete_package(apiurl, opts.project, release, 'revive')
                 print('{} undeleted, skip dvd until next cycle'.format(release))
                 return
 


### PR DESCRIPTION
The OUTPUT groups need to specify the status now or it will default to
unsupported (which should still be fine for leap/factory)