### PR TITLE
repo_checker: Fix the review loop

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1826,3 +1826,16 @@ class StagingAPI(object):
             return meta.find(xpath) is not None
 
         return False
+
+    # recursively detect underlying projects
+    def expand_project_repo(self, project, repo, repos):
+        repos.append([project, repo])
+        url = self.makeurl(['source', project, '_meta'])
+        meta = ET.parse(self.retried_GET(url)).getroot()
+        for path in meta.findall('.//repository[@name="{}"]/path'.format(repo)):
+            self.expand_project_repo(path.get('project', project), path.get('repository'), repos)
+        return repos
+
+    def expanded_repos(self, repo):
+        return self.expand_project_repo(self.project, repo, [])
+        

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -526,16 +526,8 @@ class PkgListGen(ToolBase.ToolBase):
         for e in excludes:
             g.ignore(self.groups[e])
 
-    def expand_project_repo(self, project, repo, repos):
-        repos.append([project, repo])
-        url = makeurl(self.apiurl, ['source', project, '_meta'])
-        meta = ET.parse(http_GET(url)).getroot()
-        for path in meta.findall('.//repository[@name="{}"]/path'.format(repo)):
-            self.expand_project_repo(path.get('project', project), path.get('repository'), repos)
-        return repos
-
     def expand_repos(self, project, repo):
-        return self.expand_project_repo(project, repo, [])
+        return StagingAPI(self.apiurl, project).expanded_repos('standard')
 
     def _check_supplements(self):
         tocheck = set()

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -225,17 +225,6 @@ class RepoChecker(ReviewBot.ReviewBot):
         self.logger.debug('requests: {} skipped, {} queued'.format(
             count_before - len(self.requests), len(self.requests)))
 
-    def expand_project_repo(self, api, project, repo, repos):
-        repos.append([project, repo])
-        url = api.makeurl(['source', project, '_meta'])
-        meta = ET.parse(api.retried_GET(url)).getroot()
-        for path in meta.findall('.//repository[@name="{}"]/path'.format(repo)):
-            self.expand_project_repo(api, path.get('project', project), path.get('repository'), repos)
-        return repos
-
-    def expand_repos(self, api, project, repo):
-        return self.expand_project_repo(api, project, repo, [])
-
     def ensure_group(self, request, action):
         project = action.tgt_project
         group = self.requests_map[int(request.reqid)]
@@ -265,12 +254,12 @@ class RepoChecker(ReviewBot.ReviewBot):
                 continue
 
             # Only bother if staging can match arch, but layered first.
-            repos = self.expand_repos(self.staging_api(project), project, 'standard')
+            repos = self.staging_api(project).expanded_repos('standard')
             for layered_project, repo in reversed(repos):
                 if repo != 'standard':
                     raise "We assume all is standard"
                 directories.insert(0, self.mirror(layered_project, arch))
-                
+
             whitelist = self.binary_whitelist(project, arch, group)
 
             # Perform checks on group.

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -164,12 +164,9 @@ class RepoChecker(ReviewBot.ReviewBot):
                 # Not in a "ready" state.
                 openQA_only = False # Not relevant so set to False.
                 if status and str(status['overall_state']) == 'failed':
-                    # Exception to the rule is openQA only in failed state.
-                    openQA_only = True
-                    if len(status['broken_packages']):
-                        # Broken packages so not just openQA.
-                        openQA_only = False
-                        break
+                    # Exception to the rule is openQA only in failed state,
+                    # Broken packages so not just openQA.
+                    openQA_only = (len(status['broken_packages']) == 0)
 
                 if not self.force and not openQA_only:
                     self.logger.debug('{}: {} not ready'.format(request.reqid, group))


### PR DESCRIPTION
The break on openQA failures is a left over from 93ee829260a6abf094cbbc31e26eb21bf45e8f15
where we stopped the loop over subprojects. We don't want to break out of
the review loop on openQA failures