### PR TITLE
Revert "dist/ci/Dockerfile: add python2-pyOpenSSL as dependency."

### DIFF
--- a/dist/ci/Dockerfile
+++ b/dist/ci/Dockerfile
@@ -12,7 +12,6 @@ RUN zypper -n ref && zypper -n dup && zypper -n install \
   obs-service-* \
   osc \
   python-packaging \
-  python2-pyOpenSSL \
   sudo
 
 # `osc build` directories that are effective to cache:


### PR DESCRIPTION
This reverts commit c3df9508696dbca3b8e0835704814442ac1871dc.

Fixed upstream in openSUSE/osc#429.