### PR TITLE
WIP: Simplify the repo_checker handling overlays

### DIFF
--- a/osclib/cache.py
+++ b/osclib/cache.py
@@ -90,7 +90,7 @@ class Cache(object):
         '/source/([^/]+)/_meta$': TTL_LONG,
         '/source/([^/]+)/(?:[^/]+)/(?:_meta|_link)$': TTL_LONG,
         '/source/([^/]+)/dashboard/[^/]+': TTL_LONG,
-        '/source/([^/]+)/_attribute/[^/]+': TTL_MEDIUM,
+        '/source/([^/]+)/_attribute/[^/]+': TTL_SHORT,
         # Handles clearing local cache on package deletes. Lots of queries like
         # updating project info, comment, and package additions.
         '/source/([^/]+)/(?:[^/?]+)(?:\?[^/]+)?$': TTL_LONG,


### PR DESCRIPTION
So far we had one repo directory (having the staging prj) and other
directories (having the target project). Additionally the staging prj's
binaries were added to to_ignore, which led to improper overlay handling
for service packs where we have 4 projects to look at - for sp1 (2 more
for sp2...)

Now passing the projects in expansion order as in OBS, so we can ignore
overlayed binaries later on and stop handling staging prj any different.