### PR TITLE
Rename superseded_by_id to superseded_by

### DIFF
--- a/osclib/check_command.py
+++ b/osclib/check_command.py
@@ -35,7 +35,7 @@ class CheckCommand(object):
         report = []
 
         # Check for superseded requests
-        report.extend('   - Request %s is superseded by %s' % (r['number'], r['superseded_by_id'])
+        report.extend('   - Request %s is superseded by %s' % (r['number'], r['superseded_by'])
                       for r in project['obsolete_requests'] if r['state'] == 'superseded')
 
         # Untracked requests

--- a/tests/fixtures/project/staging_projects/openSUSE:Factory.json
+++ b/tests/fixtures/project/staging_projects/openSUSE:Factory.json
@@ -1072,7 +1072,7 @@
         "obsolete_requests": [
             {
                 "accept_at": null,
-                "superseded_by_id": null,
+                "superseded_by": null,
                 "description": "",
                 "creator": "alois",
                 "created_at": "2017-05-02T10:24:19.000Z",
@@ -1084,7 +1084,7 @@
             },
             {
                 "accept_at": null,
-                "superseded_by_id": 492518,
+                "superseded_by": 492518,
                 "description": "",
                 "creator": "alois",
                 "created_at": "2017-05-02T10:24:19.000Z",
@@ -1096,7 +1096,7 @@
             },
             {
                 "accept_at": null,
-                "superseded_by_id": 592518,
+                "superseded_by": 592518,
                 "description": "",
                 "creator": "alois",
                 "created_at": "2017-05-02T10:24:19.000Z",
@@ -1108,7 +1108,7 @@
             },
             {
                 "accept_at": null,
-                "superseded_by_id": null,
+                "superseded_by": null,
                 "description": "",
                 "creator": "alois",
                 "created_at": "2017-05-02T10:24:19.000Z",
@@ -1120,7 +1120,7 @@
             },
             {
                 "accept_at": null,
-                "superseded_by_id": null,
+                "superseded_by": null,
                 "description": "",
                 "creator": "leaper",
                 "created_at": "2017-05-02T10:24:19.000Z",
@@ -1132,7 +1132,7 @@
             },
             {
                 "accept_at": null,
-                "superseded_by_id": null,
+                "superseded_by": null,
                 "description": "",
                 "creator": "alois",
                 "created_at": "2017-05-02T10:24:19.000Z",
@@ -1144,7 +1144,7 @@
             },
             {
                 "accept_at": null,
-                "superseded_by_id": null,
+                "superseded_by": null,
                 "description": "",
                 "creator": "alois",
                 "created_at": "2017-05-02T10:24:19.000Z",


### PR DESCRIPTION
OBS is going to drop the superseded_by_id attribute soon as it is just
an alias for superseded_by.