### PR TITLE
leaper: provide maintenance_incident support.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -330,7 +330,7 @@ class ReviewBot(object):
         if self.comment_handler is not False:
             self.comment_handler_add()
 
-        overall = None
+        overall = True
         for a in req.actions:
             # Store in-case sub-classes need direct access to original values.
             self.action = a
@@ -340,8 +340,14 @@ class ReviewBot(object):
                 fn = 'check_action__default'
             func = getattr(self, fn)
             ret = func(req, a)
-            if ret == False or overall is None and ret is not None:
-                overall = ret
+
+            # In the case of multiple actions take the "lowest" result where the
+            # order from lowest to highest is: False, None, True.
+            if overall is not False:
+                if ((overall is True and ret is not True) or
+                    (overall is None and ret is False)):
+                    overall = ret
+
         return overall
 
     @staticmethod

--- a/leaper.py
+++ b/leaper.py
@@ -48,7 +48,6 @@ class Leaper(ReviewBot.ReviewBot):
         ReviewBot.ReviewBot.__init__(self, *args, **kwargs)
 
         # ReviewBot options.
-        self.only_one_action = True
         self.request_default_return = True
         self.comment_handler = True
 

--- a/leaper.py
+++ b/leaper.py
@@ -225,6 +225,27 @@ class Leaper(ReviewBot.ReviewBot):
 
             return review_result
 
+        if target_project.endswith(':Update'):
+            self.logger.info("expected origin is '%s' (%s)", origin,
+                             "unchanged" if origin_same else "changed")
+
+            if origin_same:
+                return True
+
+            good = self._check_matching_srcmd5(origin, target_package, src_srcinfo.verifymd5)
+            if good:
+                self.logger.info('submission source found in origin ({})'.format(origin))
+                return good
+            good = self.factory._check_requests(origin, target_package, src_srcinfo.verifymd5)
+            if good or good == None:
+                self.logger.info('found pending submission against origin ({})'.format(origin))
+                return good
+
+            return None
+        elif self.action.type == 'maintenance_incident':
+            self.logger.debug('unhandled incident pattern (targetting non :Update project)')
+            return True
+
         # obviously
         if src_project in ('openSUSE:Factory', 'openSUSE:Factory:NonFree'):
             self.source_in_factory = True


### PR DESCRIPTION
- aad8e611ef15066b0552c4f804d22ea94e76dac0:
    ReviewBot: check_one_request(): correct logic to return "lowest" result.
    
    Without this change if two actions return True and None, True is returned
    which is not desirable.

- f4460ebb146bdd8bccb44ea9eaf9ea8be5bc6548:
    leaper: remove only_one_action limitation.
    
    Leaper will now be used on maintenance incidents which commonly have
    multiple actions. A similar change was done to check_source.py where the
    restriction was moved to a review setting which is more appropriate rather
    than a hard limitation. Going forward it makes sense to lift the limitation
    and have only one bot enforce the rule where appropriate.

- 5e06287ac8a5e5fb5aec1bb6dd4be01808899fe5:
    leaper: provide maintenance_incident support.

Initial stab at #1635, but some questions are outstanding.

- Due to maintenance workflow submissions are rarely, if ever?, from `origin`. Is that actually what we are expecting? Running on a variety of the requests in queue they all fail (except for new package submissions).
- Confirm that `manager_42` handled `:Update` projects properly and does not need an update?
- Not going to advertise override functionality like we discussed?