### PR TITLE
repo_checker: properly support multi-layer projects

### DIFF
--- a/repo_checker.pl
+++ b/repo_checker.pl
@@ -21,6 +21,7 @@ my $arch = shift @ARGV;
 my @directories = split(/\,/, shift @ARGV);
 my %toignore;
 my %whitelist;
+my $filter = 1;
 while (@ARGV) {
     my $switch = shift @ARGV;
     if ( $switch eq "-f" ) {
@@ -34,6 +35,9 @@ while (@ARGV) {
     }
     elsif ( $switch eq "-w" ) {
         %whitelist = map { $_ => 1 } split(/\,/, shift @ARGV);
+    }
+    elsif ( $switch eq "--no-filter" ) {
+        $filter = 0;
     }
     else {
         print "read the source luke: $switch ? \n";
@@ -109,7 +113,7 @@ while (<INSTALL>) {
         $inc = 0;
     }
     if ( $_ =~ /^can't install (.*)-[^-]+-[^-]+:$/ ) {
-        if ( defined $targets{$1} ) {
+        if ( !$filter || defined $targets{$1} ) {
             $inc = 1;
             $ret = 1;
         }
@@ -138,7 +142,7 @@ while (<CONFLICTS>) {
         $inc = 0;
     }
     if ( $_ =~ /^found conflict of (.*)-[^-]+-[^-]+ with (.*)-[^-]+-[^-]+:$/ ) {
-        if ( defined $targets{$1} || defined $targets{$2} ) {
+        if ( !$filter || defined $targets{$1} || defined $targets{$2} ) {
             $inc = 1;
             $ret = 1;
         }

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -255,10 +255,10 @@ class RepoChecker(ReviewBot.ReviewBot):
 
             # Only bother if staging can match arch, but layered first.
             repos = self.staging_api(project).expanded_repos('standard')
-            for layered_project, repo in reversed(repos):
+            for layered_project, repo in repos:
                 if repo != 'standard':
                     raise "We assume all is standard"
-                directories.insert(0, self.mirror(layered_project, arch))
+                directories.append(self.mirror(layered_project, arch))
 
             whitelist = self.binary_whitelist(project, arch, group)
 
@@ -355,14 +355,10 @@ class RepoChecker(ReviewBot.ReviewBot):
                 ignore_file.write(item + '\n')
             ignore_file.flush()
 
-            directory_project = directories.pop(0) if len(directories) > 1 else None
-
             # Invoke repo_checker.pl to perform an install check.
             script = os.path.join(SCRIPT_PATH, 'repo_checker.pl')
             parts = ['LC_ALL=C', 'perl', script, arch, ','.join(directories),
                      '-f', ignore_file.name, '-w', ','.join(whitelist)]
-            if directory_project:
-                parts.extend(['-r', directory_project])
 
             parts = [pipes.quote(part) for part in parts]
             p = subprocess.Popen(' '.join(parts), shell=True,


### PR DESCRIPTION
- a1cf089572535b7ea5e839d32c649c33b35d9f3d:
    repo_checker: support multi-layer projects during project_only run.
    
    Include problems from all the layers instead of just the top layer as this
    is effectively what the end-user would see.

- 9e862efeb7488fb81f1c14bb60d402fe8feacf13:
    repo_checker: properly support multi-layer projects during request mode.
    
    Previously, the additional layers supported added by coolo treated them
    like staging projects which meant that everything except the bottom
    override the bottom. Obviously, for SLE service packs this is not correct.
    
    This rewrorks the underlying perl script to support a stack of directories
    where the second directory is assumed the be the target project for the
    purposes of the toignore (-f) argument and the top layer is the only
    one for which problems are reported.

Proper implementation of #1624 and add support during `project_only`.