### PR TITLE
repo_checker: whitelist_clean(): correct attribute_value_save().

### DIFF
--- a/repo_checker.py
+++ b/repo_checker.py
@@ -594,7 +594,7 @@ class RepoChecker(ReviewBot.ReviewBot):
         else:
             print('y')
 
-        api.attribute_value_save('Config', ''.join(config_new), 'repo_checker whitelist clean')
+        api.attribute_value_save('Config', ''.join(config_new))
 
     def whitelist_clean_set(self, config, key, value):
         # Unfortunately even OscConfigParser does not preserve empty lines.


### PR DESCRIPTION
@coolo decided to miss this the first time around then "fix" it (#1593) without running even once. Wrong number of arguments.

Actually fixes #1587.

Otherwise, you get this lovely error.
```
Traceback (most recent call last):
  File "./repo_checker.py", line 648, in <module>
    sys.exit(app.main())
  File "/usr/lib/python2.7/site-packages/cmdln.py", line 261, in main
    return self.cmd(args)
  File "/usr/lib/python2.7/site-packages/cmdln.py", line 284, in cmd
    retval = self.onecmd(argv)
  File "/usr/lib/python2.7/site-packages/cmdln.py", line 422, in onecmd
    return self._dispatch_cmd(handler, argv)
  File "/usr/lib/python2.7/site-packages/cmdln.py", line 1123, in _dispatch_cmd
    return handler(argv[0], opts, *args)
  File "./repo_checker.py", line 640, in do_project_only
    self.checker.project_only(project, opts.post_comments)
  File "./repo_checker.py", line 92, in project_only
    self.whitelist_clean(project)
  File "./repo_checker.py", line 600, in whitelist_clean
    api.attribute_value_save('Config', ''.join(config_new), 'repo_checker whitelist clean')
TypeError: attribute_value_save() takes exactly 3 arguments (4 given)
```