### PR TITLE
osclib/core: maintainers_get(): rework to properly supports groups.

### DIFF
--- a/devel-project.py
+++ b/devel-project.py
@@ -92,7 +92,7 @@ def maintainer(args):
     apiurl = osc.conf.config['apiurl']
     devel_projects = devel_projects_load(args)
     for devel_project in devel_projects:
-        meta = ET.fromstring(''.join(show_project_meta(apiurl, devel_project)))
+        meta = ET.fromstringlist(show_project_meta(apiurl, devel_project))
         groups = meta.xpath('group[@role="maintainer"]/@groupid')
         intersection = set(groups).intersection(desired)
         if len(intersection) != len(desired):
@@ -207,7 +207,7 @@ def maintainers_get(apiurl, project, package=None):
                 meta = show_project_meta(apiurl, project)
     else:
         meta = show_project_meta(apiurl, project)
-    meta = ET.fromstring(''.join(meta))
+    meta = ET.fromstringlist(meta)
 
     userids = []
     for person in meta.findall('person[@role="maintainer"]'):

--- a/fcc_submitter.py
+++ b/fcc_submitter.py
@@ -187,7 +187,7 @@ class FccSubmitter(object):
         """
 
         f = osc.core.show_prj_results_meta(self.apiurl, project)
-        root = ET.fromstring(''.join(f))
+        root = ET.fromstringlist(f)
         #print ET.dump(root)
 
         failed_multibuild_pacs = []

--- a/manager_42.py
+++ b/manager_42.py
@@ -197,8 +197,8 @@ class Manager42(object):
         if (self.sle_workarounds and not self.sle_workarounds_sourced and
             package in self.packages[self.sle_workarounds]):
             # Determine how recently the package was updated.
-            root = ET.fromstring(''.join(
-                get_commitlog(self.apiurl, self.sle_workarounds, package, None, format='xml')))
+            root = ET.fromstringlist(
+                get_commitlog(self.apiurl, self.sle_workarounds, package, None, format='xml'))
             updated_last = date_parse(root.find('logentry/date').text)
             age = datetime.now() - updated_last
             if age.total_seconds() < 3600 * 24:

--- a/metrics.py
+++ b/metrics.py
@@ -355,8 +355,8 @@ def revision_index(api):
         revision_index.index = {}
 
         try:
-            root = ET.fromstring(''.join(
-                get_commitlog(api.apiurl, api.cstaging, 'dashboard', None, format='xml')))
+            root = ET.fromstringlist(
+                get_commitlog(api.apiurl, api.cstaging, 'dashboard', None, format='xml'))
         except HTTPError as e:
             return revision_index.index
 

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -35,6 +35,14 @@ def group_members(apiurl, group, maintainers=False):
 
     return root.xpath('person/person/@userid')
 
+def groups_members(apiurl, groups):
+    members = []
+
+    for group in groups:
+        members.extend(group_members(apiurl, group))
+
+    return members
+
 @memoize(session=True)
 def owner_fallback(apiurl, project, package):
     root = owner(apiurl, package, project=project)

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -47,7 +47,7 @@ def owner_fallback(apiurl, project, package):
 @memoize(session=True)
 def maintainers_get(apiurl, project, package=None):
     if package is None:
-        meta = ET.fromstring(''.join(show_project_meta(apiurl, project)))
+        meta = ET.fromstringlist(show_project_meta(apiurl, project))
         return [p.get('userid') for p in meta.findall('.//person') if p.get('role') == 'maintainer']
 
     root = owner_fallback(apiurl, project, package)
@@ -71,7 +71,7 @@ def package_list(apiurl, project):
 @memoize(session=True)
 def target_archs(apiurl, project):
     meta = show_project_meta(apiurl, project)
-    meta = ET.fromstring(''.join(meta))
+    meta = ET.fromstringlist(meta)
     archs = []
     for arch in meta.findall('repository[@name="standard"]/arch'):
         archs.append(arch.text)
@@ -167,7 +167,7 @@ def binary_src_debug(binary):
 @memoize(session=True)
 def devel_project_get(apiurl, target_project, target_package):
     try:
-        meta = ET.fromstring(''.join(show_package_meta(apiurl, target_project, target_package)))
+        meta = ET.fromstringlist(show_package_meta(apiurl, target_project, target_package))
         node = meta.find('devel')
         if node is not None:
             return node.get('project'), node.get('package')

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -483,7 +483,7 @@ class StrategyQuick(StrategyNone):
         # Only allow reviews by whitelisted groups and users as all others will
         # be considered non-quick (like @by_group="legal-auto"). The allowed
         # groups are only those configured as reviewers on the target project.
-        meta = ET.fromstring(''.join(show_project_meta(splitter.api.apiurl, splitter.api.project)))
+        meta = ET.fromstringlist(show_project_meta(splitter.api.apiurl, splitter.api.project))
         allowed_groups = meta.xpath('group[@role="reviewer"]/@groupid')
         allowed_users = []
         if 'repo-checker' in splitter.config:

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -690,12 +690,12 @@ class StagingAPI(object):
 
     def get_prj_meta_revision(self, project):
         log = get_commitlog(self.apiurl, project, '_project', None, format='xml', meta=True)
-        root = ET.fromstring(''.join(log))
+        root = ET.fromstringlist(log)
         return int(root.find('logentry').get('revision'))
 
     def get_prj_meta(self, project, revision=None):
         meta = show_project_meta(self.apiurl, project, rev=revision)
-        return ET.fromstring(''.join(meta))
+        return ET.fromstringlist(meta)
 
     def load_prj_pseudometa(self, description_text):
         try:
@@ -867,7 +867,7 @@ class StagingAPI(object):
 
     def is_package_disabled(self, project, package, store=False):
         meta = show_package_meta(self.apiurl, project, package)
-        meta = ET.fromstring(''.join(meta))
+        meta = ET.fromstringlist(meta)
         disabled = len(meta.xpath('build/disable[not(@*)]')) > 0
         if store:
             self._package_disabled['/'.join([project, package])] = disabled


### PR DESCRIPTION
- ffcee027c011a2870eeb2dfb7e18e809ffc04d1e:
    osclib/core: maintainers_get(): rework to properly supports groups.
    
    Previously, group members were only added if no maintainers were present
    whereas group members should always be considered. Additionally, project
    queries never included group members. Now groups are included in both.

- 038bec6113c6a1a0b9653ab3e4402beb3a7d663d:
    osclib/core: provide groups_members() to expand muliple groups users.

- 600a48674544034ea84affc30318042a9f43dc4f:
    Utilize ET.fromstringlist() intead of joining strings.

Fixes #1293.

Verified new logic using:
- `server:php:applications`: `['jbroedelGB', 'weberho', 'ralflangb1', 'poeml', 'computersalat', 'lrupp', 'arclyde', 'maxlin_factory', 'elvigia', 'dstoecker', 'asemen', 'lnussel_factory', 'dimstar_suse', 'factory-maintainer', 'aeneas_jaissle', 'peternixon', 'Marcus_H']`
- `server:php:applications/apache-rpm-macros`: `['poeml', 'factory-maintainer', 'maxlin_factory', 'elvigia', 'sr_hosseini', 'lnussel_factory', 'pgajdos', 'dimstar_suse', 'anicka', 'draht', 'kstreitova', 'darix']`
- `server:php:applications/adminer`: `['boombatower']`
- request `627699` for `libconfuse0`: `['darix']`

The discrepancy between `server:php:applications` packages is odd, but that's what OBS returns. Short of reading the meta directly (as is done for project only) the `/search/owner` call returns those values.