### PR TITLE
osclib/prio: support non-important priority.

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -349,7 +349,7 @@ def do_staging(self, subcmd, opts, *args):
         osc staging unlock
         osc staging rebuild [--force] [STAGING...]
         osc staging repair [--cleanup] [REQUEST...]
-        osc staging setprio [STAGING...]
+        osc staging setprio [STAGING...] [priority]
         osc staging supersede [REQUEST...]
     """
     if opts.version:
@@ -669,7 +669,17 @@ def do_staging(self, subcmd, opts, *args):
         elif cmd == 'repair':
             RepairCommand(api).perform(args[1:], opts.cleanup)
         elif cmd == 'setprio':
-            PrioCommand(api).perform(args[1:])
+            stagings = []
+            priority = None
+
+            priorities = ['critical', 'important', 'moderate', 'low']
+            for arg in args[1:]:
+                if arg in priorities:
+                    priority = arg
+                else:
+                    stagings.append(arg)
+
+            PrioCommand(api).perform(stagings, priority)
         elif cmd == 'supersede':
             SupersedeCommand(api).perform(args[1:])
         elif cmd == 'unlock':

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -321,6 +321,11 @@ def do_staging(self, subcmd, opts, *args):
         If the force option is included the rebuild checks will be ignored and
         all packages failing to build will be triggered.
 
+    "setprio" will set priority of requests withing stagings
+        If no stagings are specified all stagings will be used.
+        The default priority is important, but the possible values are:
+          "critical", "important", "moderate" or "low".
+
     "supersede" will supersede requests were applicable.
         A request list can be used to limit what is superseded.
 

--- a/osclib/prio_command.py
+++ b/osclib/prio_command.py
@@ -22,7 +22,7 @@ class PrioCommand(object):
     def __init__(self, api):
         self.api = api
 
-    def _setprio(self, project):
+    def _setprio(self, project, priority):
         """
         Set prios for requests that are still in review
         :param project: project to check
@@ -35,9 +35,7 @@ class PrioCommand(object):
         for r in project['missing_reviews']:
             reqid = str(r['request'])
             req = osc.core.get_request(self.api.apiurl, reqid)
-            priority = req.priority
-            if priority is None:
-                priority = 'important'
+            if req.priority != priority:
                 query = { 'cmd': 'setpriority', 'priority': priority }
                 url = osc.core.makeurl(self.api.apiurl, ['request', reqid], query)
                 print reqid, message
@@ -48,7 +46,7 @@ class PrioCommand(object):
                     print e
 
 
-    def perform(self, projects=None):
+    def perform(self, projects=None, priority=None):
         """
         Set priority on specific stagings or all of them at once
         :param projects: projects on which to set priority, None for all
@@ -59,10 +57,13 @@ class PrioCommand(object):
             aggregate = True
             projects = self.api.get_staging_projects()
 
+        if not priority:
+            priority = 'important'
+
         for project in projects:
             info = self.api.project_status(project, aggregate)
             if not info['selected_requests']:
                 continue
-            self._setprio(info)
+            self._setprio(info, priority)
 
         return True


### PR DESCRIPTION
- a90bf0e07b830b415b8da9c308f142e77040d15b:
    osc-staging: add documentation for setprio command.

- 9c0eb82f512ebf875e890dbb82645cf8515bf3aa:
    osclib/prio: support non-important priority.

Fixes #971.