### PR TITLE
osclib/conf: decouple from StagingAPI and always fetch remote config.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -141,10 +141,8 @@ class ReviewBot(object):
 
     def staging_api(self, project):
         if project not in self.staging_apis:
-            config = Config(project)
+            Config(self.apiurl, project)
             self.staging_apis[project] = StagingAPI(self.apiurl, project)
-
-            config.apply_remote(self.staging_apis[project])
             self.staging_config[project] = conf.config[project].copy()
 
         return self.staging_apis[project]

--- a/devel-project.py
+++ b/devel-project.py
@@ -40,8 +40,9 @@ osc.core._search = osc.core.search
 osc.core.search = search
 
 def staging_api(args):
-    Config(args.project)
-    return StagingAPI(osc.conf.config['apiurl'], args.project)
+    apiurl = osc.conf.config['apiurl']
+    Config(apiurl, args.project)
+    return StagingAPI(apiurl, args.project)
 
 def devel_projects_get(apiurl, project):
     """
@@ -116,7 +117,7 @@ def notify(args):
                 maintainer_map.setdefault(userid, set())
                 maintainer_map[userid].add(devel_package_identifier)
 
-    Config(args.project) # Ensure mail-* options are loaded for mail_send().
+    Config(apiurl, args.project) # Ensure mail-* options are loaded for mail_send().
     subject = 'Packages you maintain are present in {}'.format(args.project)
     for userid, package_identifiers in maintainer_map.items():
         email = entity_email(apiurl, userid)

--- a/metrics.py
+++ b/metrics.py
@@ -549,9 +549,9 @@ def main(args):
     Cache.PATTERNS['/source/[^/]+/dashboard/[^/]+\?rev=.*'] = sys.maxint
     Cache.init()
 
-    config = Config(args.project)
-    api = StagingAPI(osc.conf.config['apiurl'], args.project)
-    config.apply_remote(api)
+    apiurl = osc.conf.config['apiurl']
+    Config(apiurl, args.project)
+    api = StagingAPI(apiurl, args.project)
 
     print('dashboard: wrote {:,} points'.format(ingest_dashboard(api)))
 

--- a/openqa-comments.py
+++ b/openqa-comments.py
@@ -211,9 +211,9 @@ if __name__ == '__main__':
     if args.force:
         MARGIN_HOURS = 0
 
-    config = Config(args.project)
-    api = StagingAPI(osc.conf.config['apiurl'], args.project)
-    config.apply_remote(api)
+    apiurl = osc.conf.config['apiurl']
+    Config(apiurl, args.project)
+    api = StagingAPI(apiurl, args.project)
     openQA = OpenQAReport(api)
 
     if args.staging:

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -407,7 +407,7 @@ def do_staging(self, subcmd, opts, *args):
     opts.project = self._full_project_name(opts.project)
     opts.apiurl = self.get_api_url()
     opts.verbose = False
-    config = Config(opts.project)
+    Config(opts.apiurl, opts.project)
 
     colorama.init(autoreset=True,
         strip=(opts.no_color or not bool(int(conf.config.get('staging.color', True)))))
@@ -423,8 +423,6 @@ def do_staging(self, subcmd, opts, *args):
         Cache.delete_all()
 
     api = StagingAPI(opts.apiurl, opts.project)
-    config.apply_remote(api)
-
     needed = lock_needed(cmd, opts)
     with OBSLock(opts.apiurl, opts.project, reason=cmd, needed=needed) as lock:
 

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -24,6 +24,7 @@ import operator
 import re
 
 from osc import conf
+from osclib.core import attribute_value_load
 
 
 # Sane defatuls for openSUSE and SUSE.  The string interpolation rule
@@ -234,7 +235,7 @@ class Config(object):
     def apply_remote(self, api):
         """Fetch remote config and re-process (defaults, remote, .oscrc)."""
 
-        config = api.attribute_value_load('Config')
+        config = attribute_value_load(api.apiurl, self.project, 'Config')
         if config:
             cp = ConfigParser()
             config = '[remote]\n' + config

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -231,29 +231,10 @@ class Config(object):
         else:
             return defaults
 
-    def _migrate_staging_config(self, api):
-        # first try staging project's dashboard. Can't rely on cstaging as it's
-        # defined by config
-        config = api.load_file_content(self.project + ':Staging', 'dashboard', 'config')
-        if not config:
-            config = api.load_file_content(self.project, 'dashboard', 'config')
-        if not config:
-            return None
-
-        print("Found config in staging dashboard - migrate now [y/n] (y)? ", end='')
-        response = raw_input().lower()
-        if response != '' and response != 'y':
-            return config
-
-        api.attribute_value_save('Config', config)
-
     def apply_remote(self, api):
         """Fetch remote config and re-process (defaults, remote, .oscrc)."""
 
         config = api.attribute_value_load('Config')
-        if not config:
-            # try the old way
-            config = self._migrate_staging_config(api)
         if config:
             cp = ConfigParser()
             config = '[remote]\n' + config

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1159,10 +1159,9 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
         # Store target project as opts.project will contain subprojects.
         target_project = opts.project
 
-        config = Config(target_project)
         apiurl = conf.config['apiurl']
+        config = Config(apiurl, target_project)
         api = StagingAPI(apiurl, target_project)
-        config.apply_remote(api)
 
         target_config = conf.config[target_project]
         if opts.scope == 'ports':
@@ -1387,7 +1386,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
             project_family.extend(project_list_family(apiurl, family_include))
 
         for project in project_family:
-            config = Config(project)
+            config = Config(apiurl, project)
             project_config = conf.config[project]
 
             baseurl = project_config.get('download-baseurl')

--- a/suppkg_rebuild.py
+++ b/suppkg_rebuild.py
@@ -47,7 +47,7 @@ class StagingHelper(object):
     def __init__(self, project):
         self.project = project
         self.apiurl = osc.conf.config['apiurl']
-        Config(self.project)
+        Config(self.apiurl, self.project)
         self.api = StagingAPI(self.apiurl, self.project)
 
     def get_support_package_list(self, project, repository):

--- a/tests/accept_tests.py
+++ b/tests/accept_tests.py
@@ -31,7 +31,7 @@ class TestAccept(unittest.TestCase):
         Initialize the configuration
         """
         self.obs = OBS()
-        Config('openSUSE:Factory')
+        Config(APIURL, 'openSUSE:Factory')
         self.api = StagingAPI(APIURL, 'openSUSE:Factory')
 
     def test_accept_comments(self):

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -43,7 +43,7 @@ class TestApiCalls(unittest.TestCase):
         """
 
         self.obs = OBS()
-        Config('openSUSE:Factory')
+        Config(APIURL, 'openSUSE:Factory')
         self.api = StagingAPI(APIURL, 'openSUSE:Factory')
 
     def tearDown(self):

--- a/tests/check_tests.py
+++ b/tests/check_tests.py
@@ -63,7 +63,7 @@ class TestCheckCommand(unittest.TestCase):
         """Initialize the configuration."""
 
         self.obs = OBS()
-        Config('openSUSE:Factory')
+        Config(APIURL, 'openSUSE:Factory')
         self.stagingapi = StagingAPI(APIURL, 'openSUSE:Factory')
         self.checkcommand = CheckCommand(self.stagingapi)
 

--- a/tests/freeze_tests.py
+++ b/tests/freeze_tests.py
@@ -33,7 +33,7 @@ class TestFreeze(unittest.TestCase):
         Initialize the configuration
         """
         self.obs = OBS()
-        Config('openSUSE:Factory')
+        Config(APIURL, 'openSUSE:Factory')
         self.api = StagingAPI(APIURL, 'openSUSE:Factory')
 
     def _get_fixture_path(self, filename):

--- a/tests/obs.py
+++ b/tests/obs.py
@@ -274,7 +274,7 @@ class OBS(object):
             'openSUSE:Factory': {
                 'OSRT': {
                     'Config': 'overridden-by-local = remote-nope\n'
-                    'remote-only = remote-indeed'
+                              'remote-only = remote-indeed\n'
                 }
             }
         }

--- a/tests/obslock_tests.py
+++ b/tests/obslock_tests.py
@@ -11,7 +11,7 @@ from obs import OBS
 class TestOBSLock(unittest.TestCase):
     def setUp(self):
         self.obs = OBS()
-        Config(PROJECT)
+        Config(APIURL, PROJECT)
 
     def obs_lock(self, reason='list'):
         return OBSLock(APIURL, PROJECT, reason=reason)

--- a/tests/select_tests.py
+++ b/tests/select_tests.py
@@ -32,7 +32,7 @@ class TestSelect(unittest.TestCase):
         Initialize the configuration
         """
         self.obs = OBS()
-        Config('openSUSE:Factory')
+        Config(APIURL, 'openSUSE:Factory')
         self.api = StagingAPI(APIURL, 'openSUSE:Factory')
 
     def test_old_frozen(self):

--- a/tests/unselect_tests.py
+++ b/tests/unselect_tests.py
@@ -11,7 +11,7 @@ from obs import OBS
 class TestUnselect(unittest.TestCase):
     def setUp(self):
         self.obs = OBS()
-        Config(PROJECT)
+        Config(APIURL, PROJECT)
         self.api = StagingAPI(APIURL, PROJECT)
 
     def test_cleanup_filter(self):

--- a/totest-manager.py
+++ b/totest-manager.py
@@ -1040,7 +1040,7 @@ class CommandlineInterface(cmdln.Cmdln):
         if not self.options.obs_api_url:
             self.options.obs_api_url = self.api_url[project_base]
 
-        Config(project)
+        Config(self.options.obs_api_url, project)
         if project not in self.totest_class:
             msg = 'Project %s not recognized. Possible values [%s]' % (
                 project, ', '.join(self.totest_class))

--- a/update_crawler.py
+++ b/update_crawler.py
@@ -329,7 +329,7 @@ def main(args):
     osc.conf.config['debug'] = args.osc_debug
 
     # initialize stagingapi config
-    Config(args.to_prj)
+    Config(osc.conf.config['apiurl'], args.to_prj)
 
     uc = UpdateCrawler(args.from_prj, args.to_prj)
     uc.caching = args.cache_requests


### PR DESCRIPTION
- 0696a0fe6c47f93b0535c3ba88744e0898c925cd:
    osclib/stagingapi: utilize osclib.core.attribute_value_*() implementations.
    
    Provides convenience aliases that require less arguments.

- dace1c3997345968a5e560119a887c169e9fb655:
    tests/obs: improve format of default Config attribute.

- 760ddf39e69bf376266ed8d6669b8bfd03847b83:
    **osclib/conf: decouple from StagingAPI and always fetch remote config.**
    
    As the remote config is no longer optional for SLE and is utilized by
    openSUSE to the point were it is dangerous not to load the remote config
    it should be required. Currently only certain users call apply_remote()
    while this will make it built-in during construction and thus makes the
    usage consistent and no longer require StagingAPI.

- 68c315006996d4dfb9494c9f139f8c9d9162f64e:
    osclib/conf: utilize osclib.core.attribute_value_load() instead of StagingAPI.

- 65be7146328391b5e4592491baa4b6bdc358278f:
    osclib/conf: drop dashboard/config migration to attribute.
    
    Should no longer be needed and provides one less dependency on StagingAPI
    which will be removed from Config class.

- 8bdf571154c0ab0b3da4157d99087d62e8e66474:
    osclib/core: provide attribute_value_(load|save) adapted from StagingAPI.

This is something that bothered me when I originally added remote config, but wasn't comfortable making it required and had to resolve dependency chain with StagingAPI. Now that it is required we have the problem that not all our tools utilize it and when looking to make tools work on projects that do not utilize the staging process it makes very little sense to initialize `StagingAPI`.

Part of the work I've been doing placing lower functions in `osclib.core`. Next steps are to abstract dashboard container access and allow the location to be configurable. This will allow repo_checker project_only mode to cleanly write to a different location for `:Update` projects and devel projects.