### PR TITLE
osclib/conf: provide cached get() method to supersede ReviewBot cache.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -201,8 +201,7 @@ class ReviewBot(object):
     @memoize(session=True)
     def request_override_check_users(self, project):
         """Determine users allowed to override review in a comment command."""
-        self.staging_api(project)
-        config = self.staging_config[project]
+        config = Config.get(self.apiurl, project)
 
         users = []
         group = config.get('staging-group')

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -143,7 +143,6 @@ class ReviewBot(object):
         if project not in self.staging_apis:
             Config(self.apiurl, project)
             self.staging_apis[project] = StagingAPI(self.apiurl, project)
-            self.staging_config[project] = conf.config[project].copy()
 
         return self.staging_apis[project]
 
@@ -172,7 +171,6 @@ class ReviewBot(object):
 
     def check_requests(self):
         self.staging_apis = {}
-        self.staging_config = {}
 
         # give implementations a chance to do something before single requests
         self.prepare_review()

--- a/check_source.py
+++ b/check_source.py
@@ -13,6 +13,7 @@ except ImportError:
 
 import osc.conf
 import osc.core
+from osclib.conf import Config
 from osclib.core import devel_project_get
 from osclib.core import devel_project_fallback
 import urllib2
@@ -36,8 +37,7 @@ class CheckSource(ReviewBot.ReviewBot):
 
     def target_project_config(self, project):
         # Load project config and allow for remote entries.
-        self.staging_api(project)
-        config = self.staging_config[project]
+        config = Config.get(self.apiurl, project)
 
         self.single_action_require = str2bool(config.get('check-source-single-action-require', 'False'))
         self.ignore_devel = not str2bool(config.get('devel-project-enforce', 'False'))

--- a/check_source.py
+++ b/check_source.py
@@ -44,6 +44,7 @@ class CheckSource(ReviewBot.ReviewBot):
         self.in_air_rename_allow = str2bool(config.get('check-source-in-air-rename-allow', 'False'))
         self.add_review_team = str2bool(config.get('check-source-add-review-team', 'True'))
         self.review_team = config.get('review-team')
+        self.staging_group = config.get('staging-group')
         self.repo_checker = config.get('repo-checker')
         self.devel_whitelist = config.get('devel-whitelist', '').split()
 
@@ -175,24 +176,14 @@ class CheckSource(ReviewBot.ReviewBot):
 
             if self.only_changes():
                 self.logger.debug('only .changes modifications')
-                staging_group = self.staging_group(target_project)
-                if staging_group and not self.dryrun:
+                if self.staging_group and not self.dryrun:
                     osc.core.change_review_state(self.apiurl, str(self.request.reqid), 'accepted',
-                        by_group=staging_group,
+                        by_group=self.staging_group,
                         message='skipping the staging process since only .changes modifications')
             elif self.repo_checker is not None:
                 self.add_review(self.request, by_user=self.repo_checker, msg='Please review build success')
 
         return True
-
-    def staging_group(self, project):
-        try:
-            return self.staging_api(project).cstaging_group
-        except urllib2.HTTPError as e:
-            if e.code != 404:
-                raise e
-
-        return None
 
     def is_devel_project(self, source_project, target_project):
         if source_project in self.devel_whitelist:

--- a/leaper.py
+++ b/leaper.py
@@ -33,8 +33,8 @@ try:
 except ImportError:
     import cElementTree as ET
 
-import osc.conf
 import osc.core
+from osclib.conf import Config
 from osclib.core import devel_project_get
 import urllib2
 import yaml
@@ -468,8 +468,7 @@ class Leaper(ReviewBot.ReviewBot):
         return False
 
     def check_one_request(self, req):
-        api = self.staging_api(req.actions[0].tgt_project)
-        config = self.staging_config[api.project]
+        config = Config.get(self.apiurl, req.actions[0].tgt_project)
         self.needs_legal_review = False
         self.needs_reviewteam = False
         self.needs_release_manager = False

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -25,6 +25,7 @@ import re
 
 from osc import conf
 from osclib.core import attribute_value_load
+from osclib.memoize import memoize
 
 
 # Sane defatuls for openSUSE and SUSE.  The string interpolation rule
@@ -180,6 +181,13 @@ class Config(object):
 
         # Populate the configuration dictionary
         self.populate_conf()
+
+    @staticmethod
+    @memoize(session=True) # Allow reset by memoize_session_reset() for ReviewBot.
+    def get(apiurl, project):
+        """Cached version for directly accessing project config."""
+        Config(apiurl, project)
+        return conf.config.get(project, [])
 
     @property
     def conf(self):

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -16,6 +16,7 @@ import tempfile
 
 from osclib.comments import CommentAPI
 from osclib.conf import Config
+from osclib.conf import str2bool
 from osclib.core import binary_list
 from osclib.core import BINARY_REGEX
 from osclib.core import depends_on
@@ -101,7 +102,7 @@ class RepoChecker(ReviewBot.ReviewBot):
         self.logger.info('{} package comments'.format(len(self.package_results)))
 
         for package, sections in self.package_results.items():
-            if bool(Config.get(self.apiurl, project).get('repo_checker-package-comment-devel', True)):
+            if str2bool(Config.get(self.apiurl, project).get('repo_checker-package-comment-devel', 'True')):
                 bot_name_suffix = project
                 comment_project, comment_package = devel_project_fallback(self.apiurl, project, package)
                 if comment_project is None or comment_package is None:

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 
 from osclib.comments import CommentAPI
+from osclib.conf import Config
 from osclib.core import binary_list
 from osclib.core import BINARY_REGEX
 from osclib.core import depends_on
@@ -54,7 +55,6 @@ class RepoChecker(ReviewBot.ReviewBot):
         return not len(root.xpath('result[@state!="published"]'))
 
     def project_only(self, project, post_comments=False):
-        # self.staging_config needed by target_archs().
         api = self.staging_api(project)
 
         if not self.force and not self.repository_published(project):
@@ -101,7 +101,7 @@ class RepoChecker(ReviewBot.ReviewBot):
         self.logger.info('{} package comments'.format(len(self.package_results)))
 
         for package, sections in self.package_results.items():
-            if bool(self.staging_config[project].get('repo_checker-package-comment-devel', True)):
+            if bool(Config.get(self.apiurl, project).get('repo_checker-package-comment-devel', True)):
                 bot_name_suffix = project
                 comment_project, comment_package = devel_project_fallback(self.apiurl, project, package)
                 if comment_project is None or comment_package is None:
@@ -302,7 +302,7 @@ class RepoChecker(ReviewBot.ReviewBot):
 
         # Check for arch whitelist and use intersection.
         product = project.split(':Staging:', 1)[0]
-        whitelist = self.staging_config[product].get('repo_checker-arch-whitelist')
+        whitelist = Config.get(self.apiurl, product).get('repo_checker-arch-whitelist')
         if whitelist:
             archs = list(set(whitelist.split(' ')).intersection(set(archs)))
 

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -2,8 +2,8 @@ import unittest
 from osc import conf
 from osclib.conf import DEFAULT
 from osclib.conf import Config
-#from osclib.core import attribute_value_load
 from osclib.core import attribute_value_save
+from osclib.memoize import memoize_session_reset
 from osclib.stagingapi import StagingAPI
 
 from obs import APIURL
@@ -63,3 +63,12 @@ class TestConfig(unittest.TestCase):
             patterns.add(conf.config[project]['pattern'])
 
         self.assertEqual(len(patterns), len(DEFAULT))
+
+    def test_get_memoize_reset(self):
+        """Ensure memoize_session_reset() properly forces re-fetch of config."""
+        self.assertEqual('remote-indeed', Config.get(APIURL, PROJECT)['remote-only'])
+
+        attribute_value_save(APIURL, PROJECT, 'Config', 'remote-only = new value\n')
+        memoize_session_reset()
+
+        self.assertEqual('new value', Config.get(APIURL, PROJECT)['remote-only'])


### PR DESCRIPTION
- 2180c4a2c68397a1a819e9b55b72423d99f63ad3:
    ReviewBot: drop self.staging_config post switch to Config.get().

- 8cffc2e553534a8e93df0cbbcf33cc1a3c6afc25:
    repo_checker: use osclib.conf.str2bool() instead of bool().

- 1012b62830673c97674586f83d9ab5b62f4f5dbb:
    ReviewBots: utilize Config.get() instead of self.staging_config.

- 5b5d9170741ca265663f60d4c5f25ceade63abe6:
    osclib/conf: provide cached get() method to supersede ReviewBot cache.
    
    Given the slow migration of everything to the shared project config in
    tools that change project contexts multiple times a consistent way of
    accessing the config without forcing remote calls is needed.

- 343213fb4869bafa03f0f862ddfd3a7e0b03aabe:
    check_source: drop staging_group() for target_project_config().
    
    The staging_group() method pre-dates the target_project_config(), but
    essentially accomplishes the same for a single value.

Related fixes, but primary goal being to provide a standardized way to access project config as this becomes more important with plans surrounding maintenance and is sub-optimal to only halve for ReviewBot at this point.

Wait for rebase on #1648.