### PR TITLE
osclib/conf: exclude sub-projects from matching project patterns (and Leap:N:Update defaults)

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -108,6 +108,11 @@ DEFAULT = {
         'mail-noreply': 'noreply@opensuse.org',
         'mail-release-list': 'opensuse-releaseteam@opensuse.org',
     },
+    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+):Update)$': {
+        'main-repo': 'standard',
+        'leaper-override-group': 'leap-reviewers',
+        'repo_checker-arch-whitelist': 'x86_64',
+    },
     r'openSUSE:(?P<project>Backports:(?P<version>[^:]+))$': {
         'staging': 'openSUSE:%(project)s:Staging',
         'staging-group': 'factory-staging',

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -34,7 +34,7 @@ from osc import conf
 #   the project.
 
 DEFAULT = {
-    r'openSUSE:(?P<project>Factory)': {
+    r'openSUSE:(?P<project>Factory(?::Ports)?)$': {
         'staging': 'openSUSE:%(project)s:Staging',
         'staging-group': 'factory-staging',
         'staging-archs': 'i586 x86_64',
@@ -62,7 +62,7 @@ DEFAULT = {
         'mail-noreply': 'noreply@opensuse.org',
         'mail-release-list': 'opensuse-releaseteam@opensuse.org',
     },
-    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+))': {
+    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+)(?::Ports)?)$': {
         'staging': 'openSUSE:%(project)s:Staging',
         'staging-group': 'factory-staging',
         'staging-archs': 'i586 x86_64',
@@ -108,7 +108,7 @@ DEFAULT = {
         'mail-noreply': 'noreply@opensuse.org',
         'mail-release-list': 'opensuse-releaseteam@opensuse.org',
     },
-    r'openSUSE:(?P<project>Backports:(?P<version>[^:]+))': {
+    r'openSUSE:(?P<project>Backports:(?P<version>[^:]+))$': {
         'staging': 'openSUSE:%(project)s:Staging',
         'staging-group': 'factory-staging',
         'staging-archs': 'x86_64',

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -47,6 +47,7 @@ class TestConfig(unittest.TestCase):
         projects = (
             'openSUSE:Factory',
             'openSUSE:Leap:15.0',
+            'openSUSE:Leap:15.0:Update',
             'openSUSE:Backports:SLE-15',
             'SUSE:SLE-15:GA',
             'SUSE:SLE-12:GA',


### PR DESCRIPTION
- 5b44ea188d11415b1dc6a4f1de7536ccb769a0cb:
    osclib/conf: provide Leap:N:Update default settings.

- 77e27fae9eea59e945034efc58ab02f1d207f06a:
    osclib/conf: exclude sub-projects from matching project patterns.
    
    Otherwise, :Update projects match the primary product settings which
    gives the wrong impression to tools as things like :Update:Staging do
    not exist. Since :Update and other sub-projects are in a different phase
    of development they should really have separate settings. :Ports however
    does have stagings and in theory should act like parent product. If it
    becomes desirable to split that can be done in the future.
    
    Some policy settings related to ReviewBots likely are desirable to carry
    over, but that can be resolved in follow-up as they are not currently used.

@lnussel We've discussed the topic a few times, but would you like to be involved in leaper overrides for maintenance (ie. `leaper-override-group` setting included in this PR)?

I'll need to double check some of staging tools to make sure they are not accessing the target project's settings via `:Staging:...` anywhere or somesuch.