### PR TITLE
osclib/conf: remove staging default for generic projects.

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -132,7 +132,7 @@ DEFAULT = {
     # Allows devel projects to utilize tools that require config, but not
     # complete StagingAPI support.
     r'(?P<project>.*$)': {
-        'staging': '%(project)s', # Allows for dashboard/config if desired.
+        'staging': None,
         'staging-group': None,
         'staging-archs': '',
         'staging-dvd-archs': '',


### PR DESCRIPTION
The original case was to enable remote config, but in general and with
up-coming changes having the staging setting falsely set like this is not
ideal. Since the remote config is loaded via attribute this does not even
affect it anymore. The proper change is to make the "dashboard" container
configurable which is planned.

Unless anyone knows of a case using this, but I cannot imagine one.