### PR TITLE
repo_checker: complete rework to handle arbitrary repos and maintenance (and related)

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -141,7 +141,7 @@ class ReviewBot(object):
 
     def staging_api(self, project):
         if project not in self.staging_apis:
-            Config(self.apiurl, project)
+            Config.get(self.apiurl, project)
             self.staging_apis[project] = StagingAPI(self.apiurl, project)
 
         return self.staging_apis[project]

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -26,6 +26,7 @@ from optparse import OptionParser
 import cmdln
 from collections import namedtuple
 from collections import OrderedDict
+from osclib.cache import Cache
 from osclib.comments import CommentAPI
 from osclib.conf import Config
 from osclib.core import group_members
@@ -680,6 +681,7 @@ class CommentFromLogHandler(logging.Handler):
 class CommandLineInterface(cmdln.Cmdln):
     def __init__(self, *args, **kwargs):
         cmdln.Cmdln.__init__(self, args, kwargs)
+        Cache.init()
         self.clazz = ReviewBot
 
     def get_optparser(self):

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -153,7 +153,6 @@ DEFAULT = {
         'lock': None,
         'lock-ns': None,
         'delreq-review': None,
-        'main-repo': 'openSUSE_Factory',
         '_priority': '0', # Apply defaults first
     },
 }

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -58,6 +58,7 @@ DEFAULT = {
         'review-team': 'opensuse-review-team',
         'legal-review-group': 'legal-auto',
         'repo-checker': 'repo-checker',
+        'repo_checker-no-filter': 'True',
         'pkglistgen-product-family-include': 'openSUSE:Leap:N',
         'mail-list': 'opensuse-factory@opensuse.org',
         'mail-maintainer': 'Dominique Leuenberger <dimstar@suse.de>',
@@ -91,6 +92,7 @@ DEFAULT = {
         # review-team optionally added by leaper.py.
         'repo-checker': 'repo-checker',
         'repo_checker-arch-whitelist': 'x86_64',
+        'repo_checker-no-filter': 'True',
         # 16 hour staging window for follow-ups since lower throughput.
         'splitter-staging-age-max': '57600',
         # No special packages since they will pass through SLE first.
@@ -115,6 +117,7 @@ DEFAULT = {
         'main-repo': 'standard',
         'leaper-override-group': 'leap-reviewers',
         'repo_checker-arch-whitelist': 'x86_64',
+        'repo_checker-no-filter': 'True',
     },
     r'openSUSE:(?P<project>Backports:(?P<version>[^:]+))$': {
         'staging': 'openSUSE:%(project)s:Staging',

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -22,6 +22,7 @@ from osc.core import owner
 from osc.core import Request
 from osc.core import show_package_meta
 from osc.core import show_project_meta
+from osc.core import show_results_meta
 from osclib.conf import Config
 from osclib.memoize import memoize
 
@@ -387,3 +388,27 @@ def repository_path_search(apiurl, project, search_project, search_repository):
             queue.append((repository_top, path.get('project'), path.get('repository')))
 
     return None
+
+def repository_state(apiurl, project, repository):
+    return ET.fromstringlist(show_results_meta(
+        apiurl, project, multibuild=True, repository=[repository])).get('state')
+
+def repositories_states(apiurl, repository_pairs):
+    states = []
+
+    for project, repository in repository_pairs:
+        states.append(repository_state(apiurl, project, repository))
+
+    return states
+
+def repository_published(apiurl, project, repository):
+    root = ETL.fromstringlist(show_results_meta(
+        apiurl, project, multibuild=True, repository=[repository]))
+    return not len(root.xpath('result[@state!="published" and @state!="unpublished"]'))
+
+def repositories_published(apiurl, repository_pairs):
+    for project, repository in repository_pairs:
+        if not repository_published(apiurl, project, repository):
+            return (project, repository)
+
+    return True

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -112,18 +112,6 @@ def request_when_staged(request, project, first=False):
 
     return date_parse(when)
 
-def request_staged(request):
-    for review in request.reviews:
-        if (review.state == 'new' and review.by_project and
-            review.by_project.startswith(request.actions[0].tgt_project)):
-
-            # Allow time for things to settle.
-            when = request_when_staged(request, review.by_project)
-            if (datetime.utcnow() - when).total_seconds() > 10 * 60:
-                return review.by_project
-
-    return None
-
 def binary_list(apiurl, project, repository, arch, package=None):
     parsed = []
     for binary in get_binarylist(apiurl, project, repository, arch, package):

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -13,6 +13,7 @@ except ImportError:
     from urllib2 import HTTPError
 
 from osc.core import get_binarylist
+from osc.core import get_commitlog
 from osc.core import get_dependson
 from osc.core import http_GET
 from osc.core import http_POST
@@ -412,3 +413,8 @@ def repositories_published(apiurl, repository_pairs):
             return (project, repository)
 
     return True
+
+def project_meta_revision(apiurl, project):
+    root = ET.fromstringlist(get_commitlog(
+        apiurl, project, '_project', None, format='xml', meta=True))
+    return int(root.find('logentry').get('revision'))

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -89,18 +89,14 @@ def package_list(apiurl, project):
     return sorted(packages)
 
 @memoize(session=True)
-def target_archs(apiurl, project):
-    meta = show_project_meta(apiurl, project)
-    meta = ET.fromstringlist(meta)
-    archs = []
-    for arch in meta.findall('repository[@name="standard"]/arch'):
-        archs.append(arch.text)
-    return archs
+def target_archs(apiurl, project, repository='standard'):
+    meta = ETL.fromstringlist(show_project_meta(apiurl, project))
+    return meta.xpath('repository[@name="{}"]/arch/text()'.format(repository))
 
 @memoize(session=True)
 def depends_on(apiurl, project, repository, packages=None, reverse=None):
     dependencies = set()
-    for arch in target_archs(apiurl, project):
+    for arch in target_archs(apiurl, project, repository):
         root = ET.fromstring(get_dependson(apiurl, project, repository, arch, packages, reverse))
         dependencies.update(pkgdep.text for pkgdep in root.findall('.//pkgdep'))
 

--- a/osclib/cycle.py
+++ b/osclib/cycle.py
@@ -202,15 +202,12 @@ class CycleDetector(object):
         graph.subpkgs = subpkgs
         return graph
 
-    def cycles(self, staging, project=None, repository='standard', arch='x86_64'):
+    def cycles(self, override_pair, overridden_pair, arch):
         """Detect cycles in a specific repository."""
 
-        if not project:
-            project = self.api.project
-
         # Detect cycles - We create the full graph from _builddepinfo.
-        project_graph = self._get_builddepinfo_graph(project, repository, arch)
-        current_graph = self._get_builddepinfo_graph(staging, repository, arch)
+        project_graph = self._get_builddepinfo_graph(overridden_pair[0], overridden_pair[1], arch)
+        current_graph = self._get_builddepinfo_graph(override_pair[0], override_pair[1], arch)
 
         # Sometimes, new cycles have only new edges, but not new
         # packages.  We need to inform about this, so this can become

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1792,15 +1792,3 @@ class StagingAPI(object):
             return meta.find(xpath) is not None
 
         return False
-
-    # recursively detect underlying projects
-    def expand_project_repo(self, project, repo, repos):
-        repos.append([project, repo])
-        url = self.makeurl(['source', project, '_meta'])
-        meta = ET.parse(self.retried_GET(url)).getroot()
-        for path in meta.findall('.//repository[@name="{}"]/path'.format(repo)):
-            self.expand_project_repo(path.get('project', project), path.get('repository'), repos)
-        return repos
-
-    def expanded_repos(self, repo):
-        return self.expand_project_repo(self.project, repo, [])

--- a/osclib/util.py
+++ b/osclib/util.py
@@ -104,3 +104,11 @@ def mail_send(project, to, subject, body, from_key='maintainer', followup_to_key
     s = smtplib.SMTP(config.get('mail-relay', 'relay.suse.de'))
     s.sendmail(msg['From'], [msg['To']], msg.as_string())
     s.quit()
+
+def sha1_short(data):
+    import hashlib
+
+    if isinstance(data, list):
+        data = '::'.join(data)
+
+    return hashlib.sha1(data).hexdigest()[:7]

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -40,6 +40,7 @@ from osc.core import show_results_meta
 from osc.core import undelete_package
 from osc import conf
 from osclib.conf import Config, str2bool
+from osclib.core import repository_path_expand
 from osclib.stagingapi import StagingAPI
 from osclib.util import project_list_family
 from osclib.util import project_list_family_prior
@@ -525,7 +526,7 @@ class PkgListGen(ToolBase.ToolBase):
             g.ignore(self.groups[e])
 
     def expand_repos(self, project, repo='standard'):
-        return StagingAPI(self.apiurl, project).expanded_repos(repo)
+        return repository_path_expand(self.apiurl, project, repo)
 
     def _check_supplements(self):
         tocheck = set()


### PR DESCRIPTION
- af0d74a2df5f65403c9ff0b394d3088ae9b4b910:
    StagingAPI: drop inferior expanded_repos() implementation for osclib.core.

- 36a5a6c2e4b8836f534b6d1020acd2e39927a251:
    pkglistgen: utilize osclib.core.repository_path_expand().

- a57fe7ba4e7e1493ac6487e00e98423e21cba2a2:
    repo_checker: complete rework to handle arbitrary repos and maintenance.
    
    The rework includes a variety of changes:
    
    - multiple actions per request supported
    - automatically detecting "main" repo (useful for devel/home projects)
    - full layered repository path state and published taken into account
    - arbitrary repository name (ie. not just standard) supported
    - intermediate results (used for staging) no longer accept (even if no
      problems detected) until all layers are published
    - no longer tied to staging process, but still supports staging workflow
    - robust handling of repository state changes during review cycle
    - multiple repositories supported for project_only output (ie. file name)
    - project_only run supports any OBS project instead of only products
    - maintenance_release requests supported with alternate staging approach

- 341301fd0dcdcf55dd31112c046c6a297713fee0:
    osclib/util: provide sha1_short() adapted from repo_checker.

- 7cb40bbe21d06b0365fb4ff01f256c7f9607c30a:
    osclib/core: provide project_meta_revision() adapted from repo_checker.

- 9f89eaad04aea13c4992406b6d0938df04875fa9:
    osclib/core: provide repository state and published functions.

- 6e28fc4ec84f77eecbdfdac4de1f2896307c5f1d:
    osclib/core: provide repository_path_search().

- 37540add5f50d6904b7687c1bf2604ba7c91ac21:
    osclib/core: provide repository_path_expand() adapted from StagingAPI.

- b6ab577a7f450972dfaef186981ec45685ff58dc:
    osclib/core: target_archs(): expose repository argument.

- 6f9a81ff737d822a5fd4497f1ac50338100917ce:
    osclib/conf: drop main-repo default for all projects.

- 53f7f4218317a01762340b8970c8d2a276874479:
    ReviewBot: utilize osclib.Cache for all bots by default.
    
    Half the bots already utilize the Cache since it is used by StagingAPI
    which they call, but really no reason for all of them not to use it by
    default. With planned repo_checker changes the StagingAPI is not always
    utilized, but it is desirable for the cache to always be used.
    
    No sense calling Cache.init() in ReviewBot constructor as useless extra
    calls when bots embed each other.

- 3ece452a03b696e0f91bff894eb22f3788d787b9:
    ReviewBot: utilize memoize cached config.

Fixes #1634.
Obsoletes PR #1632 as build failures are no longer blocking.
Partial fix for #1384.
Partial fix for #1291 small follow-up needed to solve remaining potential change.
Fixes #1210.

For example, a home project!!:

```
$ ./repo_checker.py --debug --dry project_only home:jberry:repo-checker            
[D] no main-repo defined for home:jberry:repo-checker
[D] found chain to openSUSE:Factory/snapshot via openSUSE_Tumbleweed
[I] checking home:jberry:repo-checker/openSUSE_Tumbleweed@db22364[2]
[I] mirroring home:jberry:repo-checker/openSUSE_Tumbleweed/x86_64
[I] mirroring openSUSE:Factory/snapshot/x86_64
[I] install check: start (ignore:False, whitelist:0, parse:False, no_filter:False)
[I] install check: failed
db22364
## openSUSE_Tumbleweed/x86_64

### [install check & file conflicts](/package/view_file/home:jberry:repo-checker/00Meta/repo_checker.openSUSE_Tumbleweed)

<pre>
can't install uninstallable-monster-17-5.1.x86_64:
  nothing provides uninstallable-monster-child needed by uninstallable-monster-17-5.1.x86_64
</pre>
```

And a maintenance_release request:

```
./repo_checker.py --debug --dry id 628794
[I] checking 628794
[I] checking openSUSE:Maintenance:8582/openSUSE_Leap_15.0_Update@2246126[3]
[I] mirroring openSUSE:Maintenance:8582/openSUSE_Leap_15.0_Update/x86_64
[I] mirroring openSUSE:Leap:15.0:Update/standard/x86_64
[I] mirroring openSUSE:Leap:15.0/standard/x86_64
[W] no project_only run from which to extract existing problems
[I] cycle check: start
[I] cycle check: passed
[I] install check: start (ignore:True, whitelist:0, parse:False, no_filter:False)
[I] install check: passed
[D] broadening search to include any state on openSUSE:Maintenance:8582
[D] no previous comment to replace on openSUSE:Maintenance:8582
[I] 628794 accepted: cycle and install check passed
[D] 628794 review not changed
```

^^ all actions were reviewed independently, but since for same source and target project only triggered one repository check, but if they were different multiple independent reviews would have been triggered.

All previous requests are supported in the same way.