### PR TITLE
repo_checker: project_only: hook up --post-comments flag.

### DIFF
--- a/repo_checker.py
+++ b/repo_checker.py
@@ -64,7 +64,7 @@ class RepoChecker(ReviewBot.ReviewBot):
 
         repository_pairs = repository_path_expand(self.apiurl, project, repository)
         state_hash = self.repository_state(repository_pairs)
-        self.repository_check(repository_pairs, state_hash, False)
+        self.repository_check(repository_pairs, state_hash, False, post_comments)
 
     def package_comments(self, project):
         self.logger.info('{} package comments'.format(len(self.package_results)))


### PR DESCRIPTION
The code is all there, but in the rework missed wiring it up.

Missed after #1656.