### PR TITLE
ReviewBot: add devel_project_review_*() methods adapted from maintbot (and port users)

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -18,7 +18,6 @@ from osclib.core import devel_project_get
 from osclib.core import devel_project_fallback
 import urllib2
 import ReviewBot
-from check_maintenance_incidents import MaintenanceChecker
 from osclib.conf import str2bool
 
 class CheckSource(ReviewBot.ReviewBot):
@@ -30,8 +29,6 @@ class CheckSource(ReviewBot.ReviewBot):
 
         # ReviewBot options.
         self.request_default_return = True
-
-        self.maintbot = MaintenanceChecker(*args, **kwargs)
 
         self.skip_add_reviews = False
 
@@ -286,8 +283,7 @@ class CheckSource(ReviewBot.ReviewBot):
         links = root.findall('sourceinfo/linked')
         if links is None or len(links) == 0:
             if not self.ignore_devel:
-                # Utilize maintbot to add devel project review if necessary.
-                self.maintbot.check_one_request(request)
+                self.devel_project_review_ensure(request, action.tgt_project, action.tgt_package)
 
             if not self.skip_add_reviews and self.repo_checker is not None:
                 self.add_review(self.request, by_user=self.repo_checker, msg='Is this delete request safe?')

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -133,8 +133,6 @@ Group:          Development/Tools/Other
 BuildArch:      noarch
 Requires:       %{name} = %{version}
 Requires:       osclib = %{version}
-# osrt-leaper-review needs check_maintenance_incidents.py
-Requires:       %{name}-maintenance = %{version}
 Requires(pre):  shadow
 
 %description leaper


### PR DESCRIPTION
- dab65356d755746c93269adba1d5cc7e19637b3e:
    leaper: replace maintbot usage with ReviewBot methods.
    
    The maintenance_incident logic is always updated to mimic the maintbot
    behavior in regards to when to add devel project review.

- 31d6a872c7a3a09ccb24f93284e374ba989375fe:
    check_source: replace maintbot usage with ReviewBot methods.

- a1c13348037a82d37356b97d7042808d852a263b:
    ReviewBot: add devel_project_review_*() methods adapted from maintbot.
    
    The owner logic surrounding a package removed from Factory does not appear
    to make sense as the current behavior of OBS never returns another owner
    pair for such packages. As such the existing devel project lookup makes
    more sense and is more straight forward.

This code causes headaches and takes far longer to figure out how to change than to write from scratch. :(((((((((

This should bring the maintenance workflow fully into line on the new tools. Any workflow changes should be done in leaper. Since the maintbot is not ported and deployed out of package it will continue running out of separate checkout and should be disabled once happy with new tools.

Fixes #1645.