### PR TITLE
leaper: remove duplicate maintainer review check for IBS in default action.

### DIFF
--- a/leaper.py
+++ b/leaper.py
@@ -535,8 +535,6 @@ class Leaper(ReviewBot.ReviewBot):
 
     def check_action__default(self, req, a):
         self.needs_release_manager = True
-        if self.ibs:
-            self.do_check_maintainer_review = False
         return super(Leaper, self).check_action__default(req, a)
 
 class CommandLineInterface(ReviewBot.CommandLineInterface):


### PR DESCRIPTION
```
The default is already set in check_one_request() (called before) to
  self.do_check_maintainer_review = not self.ibs
```