### PR TITLE
repo_checker: change package comment default to be direct instead of devel.

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -59,6 +59,7 @@ DEFAULT = {
         'legal-review-group': 'legal-auto',
         'repo-checker': 'repo-checker',
         'repo_checker-no-filter': 'True',
+        'repo_checker-package-comment-devel': 'True',
         'pkglistgen-product-family-include': 'openSUSE:Leap:N',
         'mail-list': 'opensuse-factory@opensuse.org',
         'mail-maintainer': 'Dominique Leuenberger <dimstar@suse.de>',
@@ -93,6 +94,7 @@ DEFAULT = {
         'repo-checker': 'repo-checker',
         'repo_checker-arch-whitelist': 'x86_64',
         'repo_checker-no-filter': 'True',
+        'repo_checker-package-comment-devel': 'True',
         # 16 hour staging window for follow-ups since lower throughput.
         'splitter-staging-age-max': '57600',
         # No special packages since they will pass through SLE first.
@@ -118,6 +120,7 @@ DEFAULT = {
         'leaper-override-group': 'leap-reviewers',
         'repo_checker-arch-whitelist': 'x86_64',
         'repo_checker-no-filter': 'True',
+        'repo_checker-package-comment-devel': 'True',
     },
     r'openSUSE:(?P<project>Backports:(?P<version>[^:]+))$': {
         'staging': 'openSUSE:%(project)s:Staging',

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -70,7 +70,7 @@ class RepoChecker(ReviewBot.ReviewBot):
         self.logger.info('{} package comments'.format(len(self.package_results)))
 
         for package, sections in self.package_results.items():
-            if str2bool(Config.get(self.apiurl, project).get('repo_checker-package-comment-devel', 'True')):
+            if str2bool(Config.get(self.apiurl, project).get('repo_checker-package-comment-devel', 'False')):
                 bot_name_suffix = project
                 comment_project, comment_package = devel_project_fallback(self.apiurl, project, package)
                 if comment_project is None or comment_package is None:


### PR DESCRIPTION
Since the tool has been expanded to work on any repository, there are more
repositories that would want direct comments than devel. Set the value
to be devel for the openSUSE products which are the places where that is
desirable.