### PR TITLE
repo_checker: CreatePackageDescr: exclude build-env requirement.

### DIFF
--- a/CreatePackageDescr.pm
+++ b/CreatePackageDescr.pm
@@ -121,6 +121,7 @@ sub package_snippet($) {
     $out .= "-Con:\n";
     $out .= "+Req:\n";
     foreach my $prv ( @{ $qq{1049} || [] } ) {
+        next if ( $prv eq "this-is-only-for-build-envs" );
         # Completely disgusting, but maintainers have no interest in fixing,
         # see #1153 for more details.
         next


### PR DESCRIPTION
Drop in #1644, but as suspected it is needed. The reason the side-effect
was not notice right away is the package description cache for a package
making use of the requirement must be rebuilt. This means the package
must be updated since the last time cache was built.

After completely a force rebuild of entire cache the behavior is correct
by only adding this back. Unlike the case below these binaries are not
published to the end-user so this is more a quirk of the data present in
OBS for staging projects.