### PR TITLE
repo_checker: change build to state in comment info.

### DIFF
--- a/repo_checker.py
+++ b/repo_checker.py
@@ -361,7 +361,7 @@ class RepoChecker(ReviewBot.ReviewBot):
             comments = self.comment_api.get_comments(project_name=project)
             _, info = self.comment_api.comment_find(comments, self.bot_name)
             if info:
-                return info.get('build')
+                return info.get('state')
 
         return None
 
@@ -440,7 +440,7 @@ class RepoChecker(ReviewBot.ReviewBot):
                 self.result_comment(repository, arch, results, comment)
 
         if simulate_merge:
-            info_extra = {'build': state_hash}
+            info_extra = {'state': state_hash}
             if not result:
                 # Some checks in group did not pass, post comment.
                 # Avoid identical comments with different build hash during


### PR DESCRIPTION
The more accurately reflects what the hash represents since it grew to
include the staging project meta revision and may end up including more.