### PR TITLE
repo_checker: provide repo_checker-project-skip option (and utilize for OBS SLE projects)

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -131,7 +131,7 @@ DEFAULT = {
         'legal-review-group': 'legal-auto',
         # review-team optionally added by leaper.py.
         'repo-checker': 'repo-checker',
-        'repo_checker-arch-whitelist': 'x86_64',
+        'repo_checker-project-skip': 'True',
         # 16 hour staging window for follow-ups since lower throughput.
         'splitter-staging-age-max': '57600',
         # No special packages since they will pass through Leap first.
@@ -139,6 +139,13 @@ DEFAULT = {
         # Allow `unselect --cleanup` to operate immediately on:
         # - Update crawler requests (leaper)
         'unselect-cleanup-whitelist': 'leaper',
+    },
+    r'openSUSE:(?P<project>Backports:SLE-[^:]+(?::Update)?)$': {
+        # Skip SLE related projects maintenance projects to avoid processing
+        # them during multi-target requests including an openSUSE project. The
+        # SLE projects cannot be processed since the repo cannot be mirrored.
+        'repo_checker-project-skip': 'True',
+        '_priority': '101',
     },
     # Allows devel projects to utilize tools that require config, but not
     # complete StagingAPI support.

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -493,6 +493,13 @@ class RepoChecker(ReviewBot.ReviewBot):
 
     @memoize(ttl=60, session=True)
     def request_repository_pairs(self, request, action):
+        if str2bool(Config.get(self.apiurl, action.tgt_project).get('repo_checker-project-skip', 'False')):
+            # Do not change message as this should only occur in requests
+            # targeting multiple projects such as in maintenance workflow in
+            # which the message should be set by other actions.
+            self.logger.debug('skipping review of action targeting {}'.format(action.tgt_project))
+            return True
+
         repository = self.project_repository(action.tgt_project)
         if not repository:
             self.review_messages['declined'] = ERROR_REPO_SPECIFIED.format(action.tgt_project)

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -52,6 +52,7 @@ class TestConfig(unittest.TestCase):
             'openSUSE:Leap:15.0',
             'openSUSE:Leap:15.0:Update',
             'openSUSE:Backports:SLE-15',
+            'openSUSE:Backports:SLE-15:Update',
             'SUSE:SLE-15:GA',
             'SUSE:SLE-12:GA',
             'GNOME:Factory',


### PR DESCRIPTION
- dbfafe8e854ede1f38e8a9cb9efe1e0943651105:
    osclib/conf: utilize repo_checker-project-skip for OBS SLE projects.

- bf694199969ce572c004103f753d2b75d48a954a:
    repo_checker: provide repo_checker-project-skip option.
    
    Allows for skipping review of an action based on the target project config.

This is another fun problem created by multi-action requests with the bonus of being multi-target. repo-checker can pick them up due to targeting `openSUSE:Leap:15.0:Update` and end up reviewing them for other projects. Since this was never apossibility before there is no "project fencing" which may be something we need to consider for other reasons as well. Lets hope maintenance appreciates this. :)

For example without this change (scary 20 level repository stack too!?!?!?):

```
$ ./repo_checker.py --debug --dry --skip-cycle id 630974
[I] checking 630974
[I] checking openSUSE:Maintenance:8649/openSUSE_Backports_SLE-15_Update@83c0f6c[20]
[I] mirroring openSUSE:Maintenance:8649/openSUSE_Backports_SLE-15_Update/x86_64
[I] mirroring openSUSE:Backports:SLE-15:Update/standard/x86_64
[I] mirroring openSUSE:Backports:SLE-15/standard/x86_64
[I] mirroring openSUSE:Backports:SLE-15:Checks/standard/x86_64
[I] mirroring SUSE:SLE-15:GA/standard/x86_64
[I] mirroring SUSE:SLE-15:GA/SLE-Module-Basesystem/x86_64
400 remote error: will not get all dod packages
Traceback (most recent call last):
  File "./repo_checker.py", line 630, in <module>
    sys.exit(app.main())
  File "/usr/lib/python2.7/site-packages/cmdln.py", line 261, in main
    return self.cmd(args)
  File "/usr/lib/python2.7/site-packages/cmdln.py", line 284, in cmd
    retval = self.onecmd(argv)
  File "/usr/lib/python2.7/site-packages/cmdln.py", line 422, in onecmd
    return self._dispatch_cmd(handler, argv)
  File "/usr/lib/python2.7/site-packages/cmdln.py", line 1123, in _dispatch_cmd
    return handler(argv[0], opts, *args)
  File "/home/jberry/openSUSE-release-tools/ReviewBot.py", line 787, in do_id
    self.checker.check_requests()
  File "/home/jberry/openSUSE-release-tools/ReviewBot.py", line 188, in check_requests
    good = self.check_one_request(req)
  File "/home/jberry/openSUSE-release-tools/ReviewBot.py", line 370, in check_one_request
    ret = func(req, a)
  File "./repo_checker.py", line 592, in check_action_maintenance_release
    if not self.repository_check(repository_pairs, state_hash, True):
  File "/home/jberry/openSUSE-release-tools/osclib/memoize.py", line 188, in _fn
    value = fn(*args, **kwargs)
  File "./repo_checker.py", line 417, in repository_check
    directories.append(self.mirror(pair_project, pair_repository, arch))
  File "/home/jberry/openSUSE-release-tools/osclib/memoize.py", line 188, in _fn
    value = fn(*args, **kwargs)
  File "./repo_checker.py", line 134, in mirror
    raise Exception('failed to mirror {}'.format(path))
Exception: failed to mirror SUSE:SLE-15:GA/SLE-Module-Basesystem/x86_64
```

With the change:

```
$ ./repo_checker.py --debug --dry --skip-cycle id 630974
[I] checking 630974
[D] skipping review of action targeting openSUSE:Backports:SLE-15:Update
[I] checking openSUSE:Maintenance:8649/openSUSE_Leap_15.0_Update@cc3e710[3]
[I] mirroring openSUSE:Maintenance:8649/openSUSE_Leap_15.0_Update/x86_64
[I] mirroring openSUSE:Leap:15.0:Update/standard/x86_64
[I] mirroring openSUSE:Leap:15.0/standard/x86_64
[W] no project_only run from which to extract existing problems
[I] cycle check: skip due to --skip-cycle or comment command
[I] install check: start (ignore:True, whitelist:0, parse:False, no_filter:False)
[I] install check: passed
[D] broadening search to include any state on openSUSE:Maintenance:8649
[D] no previous comment to replace on openSUSE:Maintenance:8649
[I] checking openSUSE:Maintenance:8649/openSUSE_Leap_42.3_Update@28e7733[3]
[I] mirroring openSUSE:Maintenance:8649/openSUSE_Leap_42.3_Update/x86_64
[I] mirroring openSUSE:Leap:42.3:Update/standard/x86_64
[I] mirroring openSUSE:Leap:42.3/standard/x86_64
[W] no project_only run from which to extract existing problems
[I] cycle check: skip due to --skip-cycle or comment command
[I] install check: start (ignore:True, whitelist:0, parse:False, no_filter:False)
[I] install check: passed
[D] broadening search to include any state on openSUSE:Maintenance:8649
[D] no previous comment to replace on openSUSE:Maintenance:8649
[D] skipping review of action targeting openSUSE:Backports:SLE-15:Update
[I] 630974 accepted: cycle and install check passed
[D] 630974 review not changed
```