### PR TITLE
repo_checker: include repository as bot name suffix for staging and direct package comments.

### DIFF
--- a/repo_checker.py
+++ b/repo_checker.py
@@ -66,7 +66,7 @@ class RepoChecker(ReviewBot.ReviewBot):
         state_hash = self.repository_state(repository_pairs)
         self.repository_check(repository_pairs, state_hash, False, bool(post_comments))
 
-    def package_comments(self, project):
+    def package_comments(self, project, repository):
         self.logger.info('{} package comments'.format(len(self.package_results)))
 
         for package, sections in self.package_results.items():
@@ -81,10 +81,11 @@ class RepoChecker(ReviewBot.ReviewBot):
                     'has installation issues and may not be installable:'.format(
                         project=project, package=package)
             else:
-                bot_name_suffix = None
+                bot_name_suffix = repository
                 comment_project = project
                 comment_package = package
-                message = 'This package has installation issues and may not be installable:'
+                message = 'This package has installation issues and may not be installable from the `{}` ' \
+                    'repository:'.format(repository)
 
             # Sort sections by text to group binaries together.
             sections = sorted(sections, key=lambda s: s.text)
@@ -465,7 +466,7 @@ class RepoChecker(ReviewBot.ReviewBot):
                 print(text)
 
             if post_comments:
-                self.package_comments(project)
+                self.package_comments(project, repository)
 
         if result and not published:
             # Wait for the complete stack to build before positive result.

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -359,7 +359,7 @@ class RepoChecker(ReviewBot.ReviewBot):
                 return content.splitlines()[0]
         else:
             comments = self.comment_api.get_comments(project_name=project)
-            _, info = self.comment_api.comment_find(comments, self.bot_name)
+            _, info = self.comment_api.comment_find(comments, '::'.join([self.bot_name, repository]))
             if info:
                 return info.get('build')
 
@@ -447,13 +447,14 @@ class RepoChecker(ReviewBot.ReviewBot):
                 # target project build phase. Once published update regardless.
                 self.comment_write(state='seen', result='failed', project=project,
                                    message='\n'.join(comment).strip(), identical=True,
-                                   info_extra=info_extra, info_extra_identical=published)
+                                   info_extra=info_extra, info_extra_identical=published,
+                                   bot_name_suffix=repository)
             else:
                 # Post passed comment only if previous failed comment.
                 text = 'Previously reported problems have been resolved.'
                 self.comment_write(state='done', result='passed', project=project,
                                    message=text, identical=True, only_replace=True,
-                                   info_extra=info_extra)
+                                   info_extra=info_extra, bot_name_suffix=repository)
         else:
             text = '\n'.join(comment).strip()
             if not self.dryrun:


### PR DESCRIPTION
- 108e0a2bf47f4b35e706a25265844554cf23f429:
    repo_checker: include repository as bot name suffix in direct package comment.
    
    This allows for multiple project_only runs with a different main-repo set.
    It is very unlikely this feature will be used, but will handle it properly
    to be consistent with pseudometa file name.

- da507a414730bda00fe90be6f782dbcc1fdd8446:
    repo_checker: include repository as bot name suffix for staging comments.
    
    This becomes necessary for multi-action requests like those seen in
    maintenance where there may be multiple repositories reviewed for a single
    request. The result is multiple comments made on the staging project which
    would override each other. This treats them separately just as devel
    project comments do with target project.

The review result is correct without this, but obviously if multiple repositories have problems only the comments would be visible.