### PR TITLE
leaper: comment_handler_lines_deduplicate() call as no longer applicable.

### DIFF
--- a/leaper.py
+++ b/leaper.py
@@ -527,9 +527,7 @@ class Leaper(ReviewBot.ReviewBot):
             else:
                 state = 'done'
                 result = 'declined'
-            # Since leaper calls other bots (like maintbot) comments may
-            # sometimes contain identical lines (like for unhandled requests).
-            self.comment_handler_lines_deduplicate()
+
             self.comment_write(state, result)
 
         add_review_groups = []


### PR DESCRIPTION
In factory for multi-action requests, like maintenance, this ends up hiding useful lines that should be repeated for actions with the same origin.

Noticed in #1662.