### PR TITLE
metrics: provide initial telegraf setup for ingesting historical snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,9 @@ install:
 	cp -R config/* $(DESTDIR)$(sysconfdir)/$(package_name)
 	for dir in dashboards datasources ; do ln -s $(pkgdatadir)/metrics/grafana/provisioning/$$dir.yaml \
 	  $(DESTDIR)$(grafana_provisioning_dir)/$$dir/$(package_name).yaml ; done
-	sed -i "s|OSRT_DATA_DIR|$(pkgdatadir)|" $(DESTDIR)$(pkgdatadir)/metrics/grafana/provisioning/dashboards.yaml
+	sed -i "s|OSRT_DATA_DIR|$(pkgdatadir)|" \
+	  $(DESTDIR)$(pkgdatadir)/metrics/grafana/provisioning/dashboards.yaml \
+	  $(DESTDIR)$(unitdir)/osrt-metrics-telegraf.service
 
 check: test
 

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -161,6 +161,7 @@ Requires(pre):  shadow
 Recommends:     python-influxdb
 Suggests:       grafana
 Suggests:       influxdb
+Suggests:       telegraf
 
 %description metrics
 Ingest relevant OBS and annotation data to generate insightful metrics.
@@ -506,6 +507,7 @@ fi
 %{_unitdir}/osrt-metrics@.timer
 %{_unitdir}/osrt-metrics-release@.service
 %{_unitdir}/osrt-metrics-release@.timer
+%{_unitdir}/osrt-metrics-telegraf.service
 
 %files metrics-access
 %defattr(-,root,root,-)

--- a/metrics/grafana/history.json
+++ b/metrics/grafana/history.json
@@ -1,0 +1,325 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_OSRT_TELEGRAF",
+      "label": "osrt_telegraf",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "5.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "osrt_telegraf",
+      "description": "The combined usage of all historical snapshots.",
+      "fill": 1,
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "count",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$col",
+          "groupBy": [],
+          "measurement": "history_bytes",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "size"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "$col",
+          "groupBy": [],
+          "measurement": "history_files",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Storage Consumption",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "osrt_telegraf",
+      "description": "The number of historical snapshots.",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$col",
+          "groupBy": [],
+          "measurement": "history_snapshots",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "snapshots"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "OSRT: History",
+  "uid": "osrt_history",
+  "version": 1
+}

--- a/metrics/grafana/provisioning/datasources.yaml
+++ b/metrics/grafana/provisioning/datasources.yaml
@@ -42,3 +42,9 @@ datasources:
   url: http://localhost:8086
   access: proxy
   database: osrt_access
+
+- name: osrt_telegraf
+  type: influxdb
+  url: http://localhost:8086
+  access: proxy
+  database: osrt_telegraf

--- a/metrics/telegraf/agent.conf
+++ b/metrics/telegraf/agent.conf
@@ -1,0 +1,6 @@
+[agent]
+  omit_hostname = true
+
+[[outputs.influxdb]]
+ urls = ["http://localhost:8086"]
+ database = "osrt_telegraf"

--- a/metrics/telegraf/history.conf
+++ b/metrics/telegraf/history.conf
@@ -1,0 +1,32 @@
+[[inputs.exec]]
+  commands = [
+    "/bin/bash -c 'curl --silent http://download.opensuse.org/history/list | wc -l'",
+  ]
+
+  interval = "24h"
+  name_override = "history_snapshots"
+
+  data_format = "value"
+  data_type = "integer"
+
+[[inputs.exec]]
+  commands = [
+    "/bin/bash -c 'curl --silent http://download.opensuse.org/history/disk | head -n 1 | grep -oP \"\\d+\"'",
+  ]
+
+  interval = "24h"
+  name_override = "history_bytes"
+
+  data_format = "value"
+  data_type = "integer"
+
+[[inputs.exec]]
+  commands = [
+    "/bin/bash -c 'curl --silent http://download.opensuse.org/history/disk | tail -n 1'",
+  ]
+
+  interval = "24h"
+  name_override = "history_files"
+
+  data_format = "value"
+  data_type = "integer"

--- a/systemd/osrt-metrics-telegraf.service
+++ b/systemd/osrt-metrics-telegraf.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=openSUSE Release Tools: metrics telegraf
+
+[Service]
+User=osrt-metrics
+SyslogIdentifier=osrt-metrics
+ExecStart=/usr/bin/telegraf \
+  --config OSRT_DATA_DIR/metrics/telegraf/agent.conf \
+  --config-directory OSRT_DATA_DIR/metrics/telegraf
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
After deployment of [poo#36766](https://progress.opensuse.org/issues/36766) the pretty storage consumption graph reading from AWS Cloudwatch will no longer be relevant (long-term). The re-creates essentially the same thing, plus snapshot count, but using download.o.o as a source.