### PR TITLE
dist/spec: include as requirement of check-source sub package.

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -122,6 +122,8 @@ Group:          Development/Tools/Other
 BuildArch:      noarch
 # TODO Update requirements.
 Requires:       osclib = %{version}
+# check_source.pl
+Requires:       perl-Text-Diff
 Requires(pre):  shadow
 
 %description check-source


### PR DESCRIPTION
Discovered missing while building container from scratch.