### PR TITLE
travis: increment targetted versions to openSUSE Leap 15.0 and SLE 15.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
         - docker build -f dist/ci/Dockerfile -t spec .
       script:
         - ./dist/ci/docker-run obs-build-target "$TARGET_REPO"
-    - env: TEST_SUITE=distribution TARGET_REPO=openSUSE_42.3
+    - env: TEST_SUITE=distribution TARGET_REPO=openSUSE_15.0
       sudo: required
       services:
         - docker
@@ -32,7 +32,7 @@ matrix:
         - docker build -f dist/ci/Dockerfile -t spec .
       script:
         - ./dist/ci/docker-run obs-build-target "$TARGET_REPO"
-    - env: TEST_SUITE=distribution TARGET_REPO=SLE_12_SP3
+    - env: TEST_SUITE=distribution TARGET_REPO=SLE_15
       sudo: required
       services:
         - docker


### PR DESCRIPTION
Although we still have `42.3` deployments this seems reasonable.Only potential problem is introducing new dependencies that are not available on `42.3` will not cause travis failure.