### PR TITLE
metrics: remove workaround for OBS xpath bug during request search.

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -59,7 +59,7 @@ def search_capture(apiurl, queries=None, **kwargs):
 # Provides a osc.core.search() implementation for use with get_request_list()
 # that paginates in sets of 1000 and yields each request.
 def search_paginated_generator(apiurl, queries=None, **kwargs):
-    if "submit/target/@project='openSUSE:Factory'" in kwargs['request']:
+    if "action/target/@project='openSUSE:Factory'" in kwargs['request']:
         kwargs['request'] = osc.core.xpath_join(kwargs['request'], '@id>250000', op='and')
 
     request_count = 0

--- a/metrics.py
+++ b/metrics.py
@@ -39,6 +39,7 @@ def get_request_list(*args, **kwargs):
     osc.core.search = search_capture
     osc.core._ET = osc.core.ET
     osc.core.ET = ET
+    osc.conf.config['include_request_from_project'] = False
 
     osc.core.get_request_list(*args, **kwargs)
 
@@ -93,7 +94,6 @@ def timestamp(datetime):
 def ingest_requests(api, project):
     requests = get_request_list(api.apiurl, project,
                                 req_state=('accepted', 'revoked', 'superseded'),
-                                exclude_target_projects=[project],
                                 withfullhistory=True)
     for request in requests:
         if request.find('action').get('type') not in ('submit', 'delete'):


### PR DESCRIPTION
- d7d3d555786c17f119adca1fa0912ff7c8f18f90:
    metrics: check for action/target instead of submit/target since removed.
    
    In the wake of openSUSE/osc@f1c3156 removing the deprecated submit/target,
    the special condition to limit Factory to "staging era" requests should be
    updated to look for action/target.

- 0b342a5856050e816a17f183b95c366bd9f3873e:
    metrics: remove workaround for OBS xpath bug during request search.
    
    Now that the bug related to openSUSE/open-build-service#5571 has been fixed
    the inverted behavior of exclude_target_projects no longer works. As such
    the argument should be removed and only way to get the desired behavior
    is to override include_request_from_project which includes request sourced
    from specific project. For the purposes of metrics only interested in
    requests targeting a specific project.

The whole behavior of `get_request_list()` was always awkward, but this finally brings it into line with the OBS fix. The finally sane query is produced:

```
/search/request?withfullhistory=1&limit=1000&match=(state/@name='accepted' or state/@name='revoked' or state/@name='superseded') and (action/target/@project='openSUSE:Factory')&offset=1000
```

The `action/target` change does not effect metrics since it has older `osc` related to _Leap_, but will eventually. The other fix I applied as hotfix since the last ingest run was screwed up because of OBS change.