### PR TITLE
metrics: add image totals by product to access dashboard.

### DIFF
--- a/metrics/access/aggregate.php
+++ b/metrics/access/aggregate.php
@@ -248,20 +248,25 @@ function merge(&$data1, $data2)
     $data1['total_product'][$product] += $data2['total_product'][$product];
   }
 
-  foreach ($data2['unique_product'] as $product => $unqiue) {
-    if (empty($data1['unique_product'][$product]))
-      $data1['unique_product'][$product] = [];
-
-    foreach ($unqiue as $uuid => $count) {
-      if (empty($data1['unique_product'][$product][$uuid]))
-        $data1['unique_product'][$product][$uuid] = 0;
-
-      $data1['unique_product'][$product][$uuid] += $data2['unique_product'][$product][$uuid];
-    }
-  }
+  merge_product_plus_key($data1['unique_product'], $data2['unique_product']);
 
   $data1['total_invalid'] += $data2['total_invalid'];
   $data1['bytes'] += $data2['bytes'];
+}
+
+function merge_product_plus_key(&$data1, $data2)
+{
+  foreach ($data2 as $product => $pairs) {
+    if (empty($data1[$product]))
+      $data1[$product] = [];
+
+    foreach ($pairs as $key => $value) {
+      if (empty($data1[$product][$key]))
+        $data1[$product][$key] = 0;
+
+      $data1[$product][$key] += $data2[$product][$key];
+    }
+  }
 }
 
 function summarize($data)

--- a/metrics/access/aggregate.php
+++ b/metrics/access/aggregate.php
@@ -11,7 +11,7 @@ const LANGLEY = 'http://langley.suse.de/pub/pontifex%s-opensuse.suse.de';
 const VHOST = 'download.opensuse.org';
 const FILENAME = 'download.opensuse.org-%s-access_log.xz';
 const IPV6_PREFIX = 'ipv6.';
-const PRODUCT_PATTERN = '/^(10\.[2-3]|11\.[0-4]|12\.[1-3]|13\.[1-2]|42\.[1-3]|15\.[0]|tumbleweed)$/';
+const PRODUCT_PATTERN = '/^(10\.[2-3]|11\.[0-4]|12\.[1-3]|13\.[1-2]|42\.[1-3]|15\.[0-1]|tumbleweed)$/';
 
 $begin = new DateTime();
 // Skip the current day since the logs are incomplete and not compressed yet.

--- a/metrics/access/ingest.php
+++ b/metrics/access/ingest.php
@@ -3,11 +3,13 @@
 
 const REGEX_LINE = '/\S+ \S+ \S+ \[([^:]+:\d+:\d+:\d+ [^\]]+)\] "(\S+)(?: (\S+) \S+)?" (\S+) (\S+) "[^"]*" "[^"]*" .* size:(\S+) \S+(?: +"?(\S+-\S+-\S+-\S+-[^\s"]+|-)"? "?(dvd|ftp|-)"?)?/';
 const REGEX_PRODUCT = '#/(?:(tumbleweed)|distribution/(?:leap/)?(\d+\.\d+)|openSUSE(?:_|:/)(?:leap(?:_|:/))?(factory|tumbleweed|\d+\.\d+))#i';
+const REGEX_IMAGE = '#(?:/(?:iso|live)/[^/]+-(DVD|NET|GNOME-Live|KDE-Live|Rescue-CD|Kubic-DVD)-[^/]+\.iso(?:\.torrent)?|/jeos/[^/]+-(JeOS)\.[^/]+\.(?:qcow2|vhdx|vmdk|vmx)$)#';
 
 $total = 0;
 $total_invalid = 0;
 $total_product = [];
 $unique_product = [];
+$total_image_product = [];
 
 $file = $argc == 2 ? $argv[1] : 'php://stdin';
 $handle = fopen($file, 'r');
@@ -40,6 +42,15 @@ while (($line = fgets($handle)) !== false) {
     if (!isset($unique_product[$product][$uuid])) $unique_product[$product][$uuid] = 0;
     $unique_product[$product][$uuid] += 1;
   }
+
+  if (preg_match(REGEX_IMAGE, $match[3], $match_image)) {
+    // Remove empty match groups and select non-all match.
+    $values = array_filter($match_image);
+    $image = next($values);
+    if (!isset($total_image_product[$product])) $total_image_product[$product] = [];
+    if (!isset($total_image_product[$product][$image])) $total_image_product[$product][$image] = 0;
+    $total_image_product[$product][$image] += 1;
+  }
 }
 $position = ftell($handle);
 fclose($handle);
@@ -54,6 +65,7 @@ echo json_encode([
   'total' => $total,
   'total_product' => $total_product,
   'unique_product' => $unique_product,
+  'total_image_product' => $total_image_product,
   'total_invalid' => $total_invalid,
   'bytes' => $position,
 ]) . "\n"; // JSON_PRETTY_PRINT for debugging.

--- a/metrics/grafana/access.json
+++ b/metrics/grafana/access.json
@@ -1893,6 +1893,453 @@
       ],
       "title": "Tool Feedback",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 43,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "osrt_access",
+          "fill": 1,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 40,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_key",
+              "groupBy": [
+                {
+                  "params": [
+                    "key"
+                  ],
+                  "type": "tag"
+                }
+              ],
+              "hide": false,
+              "measurement": "/^image_$frequency$/",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "slimit": "",
+              "tags": [
+                {
+                  "key": "product",
+                  "operator": "=~",
+                  "value": "/^$product$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total by Image (stacked)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "osrt_access",
+          "fill": 1,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 19
+          },
+          "id": 45,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_key",
+              "groupBy": [
+                {
+                  "params": [
+                    "key"
+                  ],
+                  "type": "tag"
+                }
+              ],
+              "hide": false,
+              "measurement": "/^image_$frequency$/",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "slimit": "",
+              "tags": [
+                {
+                  "key": "product",
+                  "operator": "=~",
+                  "value": "/^$product$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total by Image",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "osrt_access",
+          "fill": 1,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 29
+          },
+          "id": 44,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": true,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_key",
+              "groupBy": [
+                {
+                  "params": [
+                    "key"
+                  ],
+                  "type": "tag"
+                }
+              ],
+              "hide": false,
+              "measurement": "/^image_$frequency$/",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "slimit": "",
+              "tags": [
+                {
+                  "key": "product",
+                  "operator": "=~",
+                  "value": "/^$product$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total by Image (percentage)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": "100",
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "osrt_access",
+          "fill": 1,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 39
+          },
+          "id": 46,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": true,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_key",
+              "groupBy": [
+                {
+                  "params": [
+                    "key"
+                  ],
+                  "type": "tag"
+                }
+              ],
+              "hide": false,
+              "measurement": "/^image_$frequency$/",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "slimit": "",
+              "tags": [
+                {
+                  "key": "product",
+                  "operator": "=~",
+                  "value": "/^$product$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total by Image (percentage - zoomed)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": "100",
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "title": "Image Media - $product",
+      "type": "row"
     }
   ],
   "refresh": false,
@@ -1932,6 +2379,26 @@
         ],
         "query": "day, week, month",
         "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "osrt_access",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Product",
+        "multi": false,
+        "name": "product",
+        "options": [],
+        "query": "show tag values from image_month with key = \"product\"",
+        "refresh": 1,
+        "regex": "",
+        "sort": 2,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },

--- a/metrics/grafana/access.json
+++ b/metrics/grafana/access.json
@@ -201,8 +201,6 @@
           "measurement": "/^access_$frequency$/",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"unique\" FROM /^access_$frequency$/ WHERE $timeFilter AND product =~ /^(10\\.[2-3]|11\\.[0-4]|12\\.[1-3]|13\\.[1-2]|42\\.[1-3]|15\\.[0]|tumbleweed)$/ GROUP BY \"product\"",
-          "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -311,8 +309,6 @@
           "measurement": "/^access_$frequency$/",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"unique\" FROM /^access_$frequency$/ WHERE $timeFilter AND product =~ /^(11\\.[1-4]|12\\.[1-3]|13\\.[1-2]|42\\.[1-3]|15\\.[0]|tumbleweed)$/ GROUP BY \"product\"",
-          "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -421,8 +417,6 @@
           "measurement": "/^access_$frequency$/",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"unique\" FROM /^access_$frequency$/ WHERE $timeFilter AND product =~ /^(10\\.[2-3]|11\\.[0-4]|12\\.[1-3]|13\\.[1-2]|42\\.[1-3]|15\\.[0]|tumbleweed)$/ GROUP BY \"product\"",
-          "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -535,8 +529,6 @@
           "measurement": "/^access_$frequency$/",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT mean(\"value\") FROM \"measurement\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
           "refId": "A",
           "resultFormat": "table",
           "select": [
@@ -617,8 +609,6 @@
           "measurement": "/^access_$frequency$/",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT MAX(\"unique\") FROM /^access_$frequency$/ WHERE $timeFilter AND product =~ /^(10\\.[2-3]|11\\.[0-4]|12\\.[1-3]|13\\.[1-2]|42\\.[1-3]|15\\.[0]|tumbleweed)$/ group by product",
-          "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
           "select": [


### PR DESCRIPTION
- 5c410b7c76aa85b5a0eb6b0859717f1e0aefe9c4:
    metrics/grafana/access: add new row and graphs for image totals by product.
    
    Includes a new variable for switching which product is displayed.
    Unfortunately, there is no way to hide the variable within a row and it
    seems like over-kill to create a separate dashboard.

- 7492b109e5f370988a2e95b9c22eded81e6d734b:
    metrics/access/aggregate: process and summarize image totals by product.
    
    Accessible in new measurement prefixed by 'image'.

- c84add0bf7081ce839f3c95a5e4d66f26b5cf28a:
    metrics/access/aggregate: extract merge_product_plus_key() from merge().

- dc9afe2adf16e1375001eca9bc73c2211f73e27c:
    metrics/access/ingest: detect product image paths and included in dump.

- 6203b52a420c66bb8c6f3b6ee0d4a4bf36803d50:
    metrics/grafana/access: remove left-over raw queries.
    
    For some reason Grafana does not remove these from data structure even
    though they no longer represent current state.

- f80d3ff03fe0ed4e4e9444b250bf4303105fc8f4:
    metrics/access/aggregate: include Leap 15.1 in published metrics.

Rough data from last week or so only parsing first million log entries:

![image](https://user-images.githubusercontent.com/22943929/45574773-b76e3d00-b836-11e8-96d0-54b7f37e52e5.png)

I plan to reparse everything available from pontifex as that is trivial (just takes CPU). As such that is back to `2017-12-04` although that is 3 days before the _black hole_ so might as well just start at `2018-03-08`. Can re-parse langley if desired, but that requires copying data across networks (or super slow over VPN to my machine and back up).