### PR TITLE
check_source: decline all delete project requests and ReviewBot sub-delete check types.

### DIFF
--- a/check_maintenance_incidents.py
+++ b/check_maintenance_incidents.py
@@ -129,7 +129,7 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
 
         return True
 
-    def check_action_delete(self, req, a):
+    def check_action_delete_package(self, req, a):
         self._check_maintainer_review_needed(req, a)
 
         return True

--- a/check_source.py
+++ b/check_source.py
@@ -254,16 +254,6 @@ class CheckSource(ReviewBot.ReviewBot):
     def check_action_delete(self, request, action):
         self.target_project_config(action.tgt_project)
 
-        if action.tgt_repository is not None:
-            if action.tgt_project.startswith('openSUSE:'):
-                self.review_messages['declined'] = 'The repositories in the openSUSE:* namespace ' \
-                    'are managed by the Release Managers. For suggesting changes, send a mail ' \
-                    'to opensuse-releaseteam@opensuse.org with an explanation of why the change ' \
-                    'makes sense.'
-                return False
-            else:
-                self.review_messages['accepted'] = 'unhandled: removing repository'
-                return True
         try:
             result = osc.core.show_project_sourceinfo(self.apiurl, action.tgt_project, True, (action.tgt_package))
             root = ET.fromstring(result)
@@ -301,6 +291,17 @@ class CheckSource(ReviewBot.ReviewBot):
         # overridden, but seems like no valid case for allowing this (see #1696).
         self.review_messages['declined'] = 'Deleting the {} project is not allowed.'.format(action.tgt_project)
         return False
+
+    def check_action_delete_repository(self, request, action):
+        if action.tgt_project.startswith('openSUSE:'):
+            self.review_messages['declined'] = 'The repositories in the openSUSE:* namespace ' \
+                'are managed by the Release Managers. For suggesting changes, send a mail ' \
+                'to opensuse-releaseteam@opensuse.org with an explanation of why the change ' \
+                'makes sense.'
+            return False
+
+        self.review_messages['accepted'] = 'unhandled: removing repository'
+        return True
 
 class CommandLineInterface(ReviewBot.CommandLineInterface):
 

--- a/check_source.py
+++ b/check_source.py
@@ -251,7 +251,7 @@ class CheckSource(ReviewBot.ReviewBot):
         self.review_messages['declined'] = message
         return False
 
-    def check_action_delete(self, request, action):
+    def check_action_delete_package(self, request, action):
         self.target_project_config(action.tgt_project)
 
         try:

--- a/check_source.py
+++ b/check_source.py
@@ -296,6 +296,12 @@ class CheckSource(ReviewBot.ReviewBot):
             self.review_messages['declined'] = "This is an incorrect request, it's a linked package to %s/%s" % (linked_project, linked_package)
             return False
 
+    def check_action_delete_project(self, request, action):
+        # Presumably if the request is valid the bot should be disabled or
+        # overridden, but seems like no valid case for allowing this (see #1696).
+        self.review_messages['declined'] = 'Deleting the {} project is not allowed.'.format(action.tgt_project)
+        return False
+
 class CommandLineInterface(ReviewBot.CommandLineInterface):
 
     def __init__(self, *args, **kwargs):

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -546,7 +546,7 @@ class RepoChecker(ReviewBot.ReviewBot):
         self.review_messages['accepted'] = 'cycle and install check passed'
         return True
 
-    def check_action_delete(self, request, action):
+    def check_action_delete_package(self, request, action):
         # TODO Ignore tgt_project packages that depend on this that are part of
         # ignore list as and instead look at output from staging for those.
 


### PR DESCRIPTION
- 406fc41a851a594f3cbcfa11b7afe9d793de3203:
    ReviewBots: utilize delete_package check where it was already assumed.

- 658137b9e973b3fab66b0060d98acf44d71d9105:
    check_source: split out delete repository check to new sub action check.

- ecbc806b2d480ee1d92b64fb1b20b733a10e51e4:
    check_source: decline all delete project requests.

- d1b630b5dab3132f6dfaaf6febd825e59a190f8c:
    ReviewBot: break down sub-types of delete requests.
    
    Their is very little overlap in the types of reviews one typically wants
    to perform on delete requests. Already all of the existing code will crash
    if a delete project request is reviewed.

Fixes #1696, by producing:

```
$ ./check_source.py --debug --dry id 635926
[I] checking 635926
[I] 635926 declined: Deleting the openSUSE:Factory project is not allowed.
[D] 635926 review not changed
```