### PR TITLE
Do no longer CC submitters in request comments

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1555,7 +1555,7 @@ class StagingAPI(object):
             requests = meta['requests']
 
         for req in requests:
-            lines.append('  * {}request#{} for package {} submitted by @{}'.format(
+            lines.append('  * {}request#{} for package {} submitted by {}'.format(
                 req.get('prefix', ''), req['id'], req['package'], req.get('author')))
         msg = '\n'.join(lines)
         msg = comment_api.add_marker(msg, bot, info)

--- a/tests/select_tests.py
+++ b/tests/select_tests.py
@@ -37,7 +37,7 @@ class TestSelect(unittest.TestCase):
         # Only one comment is added
         self.assertEqual(len(first_select_comments), len(comments) + 1)
         # With the right content
-        self.assertTrue('request#123 for package gcc submitted by @Admin' in first_select_comment['comment'])
+        self.assertTrue('request#123 for package gcc submitted by Admin' in first_select_comment['comment'])
 
         # Second select
         self.assertEqual(True, SelectCommand(self.api, staging_b).perform(['puppet']))
@@ -48,8 +48,8 @@ class TestSelect(unittest.TestCase):
         self.assertEqual(len(second_select_comments) - 1, len(first_select_comments))
         self.assertNotEqual(second_select_comment['comment'], first_select_comment['comment'])
         # The new comments contains new, but not old
-        self.assertFalse('request#123 for package gcc submitted by @Admin' in second_select_comment['comment'])
-        self.assertTrue('added request#321 for package puppet submitted by @Admin' in second_select_comment['comment'])
+        self.assertFalse('request#123 for package gcc submitted by Admin' in second_select_comment['comment'])
+        self.assertTrue('added request#321 for package puppet submitted by Admin' in second_select_comment['comment'])
 
     def test_no_matches(self):
         # search for requests


### PR DESCRIPTION
Submitters complain more and more about the spam they're getting from
staging projects - and we rather leave that weapon for actual feedback.

One especially annoying case is if a package is added to one staging project
and then later moved to another, the submitter will receive notifications
of all kind of bots and actions for both staging projects.