### PR TITLE
check_maintenance_incidents: skip action if the action is for patchinfo

### DIFF
--- a/check_maintenance_incidents.py
+++ b/check_maintenance_incidents.py
@@ -33,6 +33,8 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
     def add_devel_project_review(self, req, package):
         """ add devel project/package as reviewer """
         a = req.actions[0]
+        if self._is_patchinfo(a.src_package):
+            a = req.actions[1]
         project = a.tgt_releaseproject if a.type == 'maintenance_incident' else req.actions[0].tgt_project
         root = owner_fallback(self.apiurl, project, package)
 


### PR DESCRIPTION
Action of patchinfo does not have a releaseproject attribute, with bad luck it might be lists as the first action of an maintenance incident, we should skip it and try next action.

We got this error on maintbot with https://build.opensuse.org/request/show/641770 , this incident have patchinfo as the first action, then maintbot crashes with

`
Oct 15 09:53:06 packagelists osrt-maintenance[15562]:     if not entry or project.startswith(entry.get('project')):
Oct 15 09:53:06 packagelists osrt-maintenance[15562]: AttributeError: 'NoneType' object has no attribute 'startswith'
`

Note: I already hot-patched this change on packagelists VM so maintbot can working again.