### PR TITLE
leaper: disable maintainer review addition for incidents.

### DIFF
--- a/leaper.py
+++ b/leaper.py
@@ -241,7 +241,9 @@ class Leaper(ReviewBot.ReviewBot):
                 self.logger.info('found pending submission against origin ({})'.format(origin))
                 return good
 
-            self.do_check_maintainer_review = True
+            # TODO #1662: Uncomment once maintbot has been superseded and leaper
+            # is no longer run in comment-only mode.
+            #self.do_check_maintainer_review = True
 
             return None
         elif self.action.type == 'maintenance_incident':


### PR DESCRIPTION
This was disabled manually in production to effectively run leaper in
"comment-only mode" for maintenance with the expectation that this would
not remain for long. Since it seems it will it makes sense to merge the
state expected to be deployed.

Fixes #1729.