### PR TITLE
CI: resolve build-time tar service failure

### DIFF
--- a/dist/ci/obs-build-target
+++ b/dist/ci/obs-build-target
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -ex
 
 SOURCE_DIR="${SOURCE_DIR:-/usr/src/target}"
 

--- a/dist/ci/obs-build-target
+++ b/dist/ci/obs-build-target
@@ -16,6 +16,8 @@ sed -i "s|$(cd "$SOURCE_DIR" && git remote get-url origin)|$SOURCE_DIR|" _servic
 sed -i "s|<param name=\"scm\">git</param>|<param name=\"scm\">git</param><param name=\"revision\">$(cd "$SOURCE_DIR" && git describe --all --always)</param>|" _service
 
 rm *.obscpio
+# ugly, but upstream not interested in making this process clean
+export TAR_SCM_TESTMODE=1
 osc service disabledrun
 
 # skip interactive


### PR DESCRIPTION
- ae01d143c91f48b67d5109e464bc28f92aca9cc3:
    dist/ci/obs-build-target: utilize TAR_SCM_TESTMODE to avoid URL check.
    
    See #1732 for details, but summarized the CI uses a local path which
    differs from the normal remote URL which causes tar_scm service to
    complain and no re-create the obscpio. See
    openSUSE/obs-service-tar_scm@44b3bee for the relevant change.

- 26c6dba22d826407fabeef81c6e4a52d6d592a1b:
    dist/ci/obs-build-target: stop at first error.

Fixes #1732.