### PR TITLE
osclib/conf: include NonFree subproject in openSUSE patterns.

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -19,7 +19,7 @@ from osclib.memoize import memoize
 #   the project.
 
 DEFAULT = {
-    r'openSUSE:(?P<project>Factory)$': {
+    r'openSUSE:(?P<project>Factory)(?::NonFree)?$': {
         'staging': 'openSUSE:%(project)s:Staging',
         'staging-group': 'factory-staging',
         'staging-archs': 'i586 x86_64',
@@ -50,7 +50,7 @@ DEFAULT = {
         'mail-noreply': 'noreply@opensuse.org',
         'mail-release-list': 'opensuse-releaseteam@opensuse.org',
     },
-    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+))$': {
+    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+))(?::NonFree)?$': {
         'staging': 'openSUSE:%(project)s:Staging',
         'staging-group': 'factory-staging',
         'staging-archs': 'i586 x86_64',
@@ -99,7 +99,7 @@ DEFAULT = {
         'mail-noreply': 'noreply@opensuse.org',
         'mail-release-list': 'opensuse-releaseteam@opensuse.org',
     },
-    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+):Update)$': {
+    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+)(?::NonFree)?:Update)$': {
         'main-repo': 'standard',
         'leaper-override-group': 'leap-reviewers',
         'repo_checker-arch-whitelist': 'x86_64',

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -19,7 +19,7 @@ from osclib.memoize import memoize
 #   the project.
 
 DEFAULT = {
-    r'openSUSE:(?P<project>Factory(?::Ports)?)$': {
+    r'openSUSE:(?P<project>Factory)$': {
         'staging': 'openSUSE:%(project)s:Staging',
         'staging-group': 'factory-staging',
         'staging-archs': 'i586 x86_64',
@@ -50,7 +50,7 @@ DEFAULT = {
         'mail-noreply': 'noreply@opensuse.org',
         'mail-release-list': 'opensuse-releaseteam@opensuse.org',
     },
-    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+)(?::Ports)?)$': {
+    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+))$': {
         'staging': 'openSUSE:%(project)s:Staging',
         'staging-group': 'factory-staging',
         'staging-archs': 'i586 x86_64',


### PR DESCRIPTION
- 35594e5f05d5fc061fb700c48cac29fe799457bd:
    osclib/conf: include NonFree subproject in openSUSE patterns.
    
    Intentionally left outside of <project> group so that the NonFree
    subproject still uses the main Staging subproject.

- 8ec1e1777b57985c8862ec91a0f471055015ce72:
    osclib/conf: remove Ports subprojects as they no longer exist.

Fixes #1735.