### PR TITLE
repo_checker: utilize 'staging' config option for instantiating StagingAPI (and related)

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -124,6 +124,12 @@ class ReviewBot(object):
             self.config = self._load_config()
 
     def staging_api(self, project):
+        # Allow for the Staging subproject to be passed directly from config
+        # which should be stripped before initializing StagingAPI. This allows
+        # for NonFree subproject to utilize StagingAPI for main project.
+        if project.endswith(':Staging'):
+            project = project[:-8]
+
         if project not in self.staging_apis:
             Config.get(self.apiurl, project)
             self.staging_apis[project] = StagingAPI(self.apiurl, project)

--- a/osclib/cycle.py
+++ b/osclib/cycle.py
@@ -129,8 +129,8 @@ class Package(object):
 class CycleDetector(object):
     """Class to detect cycles in an OBS project."""
 
-    def __init__(self, api):
-        self.api = api
+    def __init__(self, apiurl):
+        self.apiurl = apiurl
         # Store packages prevoiusly ignored. Don't pollute the screen.
         self._ignore_packages = set()
 
@@ -138,7 +138,7 @@ class CycleDetector(object):
         root = None
         try:
             # print('Generating _builddepinfo for (%s, %s, %s)' % (project, repository, arch))
-            url = makeurl(self.api.apiurl, ['build/%s/%s/%s/_builddepinfo' % (project, repository, arch)])
+            url = makeurl(self.apiurl, ['build/%s/%s/%s/_builddepinfo' % (project, repository, arch)])
             root = http_GET(url).read()
         except urllib2.HTTPError as e:
             print('ERROR in URL %s [%s]' % (url, e))

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -169,8 +169,9 @@ class RepoChecker(ReviewBot.ReviewBot):
     def binary_whitelist(self, override_pair, overridden_pair, arch):
         whitelist = self.binary_list_existing_problem(overridden_pair[0], overridden_pair[1])
 
-        if Config.get(self.apiurl, overridden_pair[0]).get('staging'):
-            additions = self.staging_api(overridden_pair[0]).get_prj_pseudometa(
+        staging = Config.get(self.apiurl, overridden_pair[0]).get('staging')
+        if staging:
+            additions = self.staging_api(staging).get_prj_pseudometa(
                 override_pair[0]).get('config', {})
             prefix = 'repo_checker-binary-whitelist'
             for key in [prefix, '-'.join([prefix, arch])]:
@@ -525,8 +526,9 @@ class RepoChecker(ReviewBot.ReviewBot):
 
         repository_pairs = []
         # Assumes maintenance_release target project has staging disabled.
-        if Config.get(self.apiurl, action.tgt_project).get('staging'):
-            api = self.staging_api(action.tgt_project)
+        staging = Config.get(self.apiurl, action.tgt_project).get('staging')
+        if staging:
+            api = self.staging_api(staging)
             stage_info = api.packages_staged.get(action.tgt_package)
             if not stage_info or str(stage_info['rq_id']) != str(request.reqid):
                 self.logger.info('{} not staged'.format(request.reqid))

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -297,7 +297,7 @@ class RepoChecker(ReviewBot.ReviewBot):
         self.logger.info('cycle check: start')
         comment = []
         first = True
-        cycle_detector = CycleDetector(self.staging_api(overridden_pair[0]))
+        cycle_detector = CycleDetector(self.apiurl)
         for index, (cycle, new_edges, new_packages) in enumerate(
             cycle_detector.cycles(override_pair, overridden_pair, arch), start=1):
 


### PR DESCRIPTION
- 616281e75fcdb42a0a2dc9dfe6beeac9680e10d0:
    repo_checker: utilize 'staging' config option for instantiating StagingAPI.

- c74e40ba70d5b30519a389da9d7ef9f6dc27abc5:
    osclib/cycle: remove need for StagingApi instance in favor of apiurl.

- 2a50b8cf72a79de1ebe10813cddd44c54e6871ac:
    ReviewBot: staging_api(): allow for Staging subproject to be used.

Fixes #1384.
Fixes #1247.