### PR TITLE
metrics/grafana/openqa: set minimum interval of 10s to avoid gaps.

### DIFF
--- a/metrics/grafana/openqa.json
+++ b/metrics/grafana/openqa.json
@@ -62,6 +62,7 @@
         "y": 0
       },
       "id": 2,
+      "interval": "10s",
       "legend": {
         "avg": false,
         "current": false,
@@ -253,6 +254,7 @@
         "y": 0
       },
       "id": 6,
+      "interval": "10s",
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -379,6 +381,7 @@
         "y": 9
       },
       "id": 4,
+      "interval": "10s",
       "legend": {
         "avg": false,
         "current": false,
@@ -502,6 +505,7 @@
         "y": 9
       },
       "id": 8,
+      "interval": "10s",
       "legend": {
         "avg": false,
         "current": false,


### PR DESCRIPTION
Since data is collected at the same interval it avoids grouping at smaller
intervals when zoomed in which reveals gaps between the data points.

@coolo Resolves the small issue noted in #1731.

Goes from:

![image](https://user-images.githubusercontent.com/22943929/47225839-a27c5080-d384-11e8-910f-26f91f130bce.png)

to:

![image](https://user-images.githubusercontent.com/22943929/47225843-a5774100-d384-11e8-930f-779a99d0f943.png)

like magic.

I have used this in other dashboards, just had to remember.