### PR TITLE
Fix deployment problems on rabbit-openqa

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -222,7 +222,7 @@ Group:          Development/Tools/Other
 BuildArch:      noarch
 # TODO Update requirements.
 Requires:       osclib = %{version}
-Requires:       python-openqa_client
+Requires:       python2-openqa_client
 Requires:       python2-pika
 
 %description totest-manager
@@ -298,6 +298,8 @@ Summary:        Sync openQA Status Into OBS
 Group:          Development/Tools/Other
 BuildArch:      noarch
 Requires:       osc >= 0.159.0
+Requires:       python2-openqa_client
+Requires:       python2-pika
 
 %description rabbit-openqa
 Bot listening to AMQP bus and syncs openQA job status into OBS for
@@ -399,8 +401,8 @@ fi
 %systemd_postun
 
 %pre rabbit-openqa
-getent passwd osrt-rabit-openqa > /dev/null || \
-  useradd -r -m -s /sbin/nologin -c "user for openSUSE-release-tools-rabbit-openqa" osrt-rabit-openqa
+getent passwd osrt-rabbit-openqa > /dev/null || \
+  useradd -r -m -s /sbin/nologin -c "user for openSUSE-release-tools-rabbit-openqa" osrt-rabbit-openqa
 exit 0
 
 %postun rabbit-openqa

--- a/rabbit-openqa.py
+++ b/rabbit-openqa.py
@@ -227,7 +227,7 @@ class Listener(PubSubConsumer):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Bot to sync openQA status to OBS')
-    parser.add_argument("--apiurl", '-A', type=str, default='https://api.opensuse.org', help='API URL of OBS')
+    parser.add_argument("--apiurl", '-A', type=str, help='API URL of OBS')
     parser.add_argument('-s', '--staging', type=str, default=None,
                         help='staging project letter')
     parser.add_argument('-f', '--force', action='store_true', default=False,
@@ -239,10 +239,10 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    osc.conf.get_config()
+    osc.conf.get_config(override_apiurl = args.apiurl)
     osc.conf.config['debug'] = args.debug
 
-    apiurl = args.apiurl
+    apiurl = osc.conf.config['apiurl']
 
     if apiurl.endswith('suse.de'):
         amqp_prefix = 'suse'


### PR DESCRIPTION
- 2 python modules required
- apiurl shouldn't take the default from config not from getopt
- fix typo in user name