### PR TITLE
[WIP] Add auth for influx to telegraf config

### DIFF
--- a/metrics/telegraf/agent.conf
+++ b/metrics/telegraf/agent.conf
@@ -4,3 +4,5 @@
 [[outputs.influxdb]]
  urls = ["http://localhost:8086"]
  database = "osrt_telegraf"
+ username = "influx"
+ password = "nottherealpassword"


### PR DESCRIPTION
We need to open directly connect to the influxdb from OBS, therefore we need to enable authentication. @jberry-suse not sure how you want to store / handle the PW, this is just a starting point for a discussion. We probably also need to add the auth to the metrics.py scripts, however, I didn't look into detail into it so I would need some pointers from your side. 

As said, this should just be a starting point for a discussion.

cc @hennevogel 