### PR TITLE
repo_checker: filter repository state and published checks by relevant architectures.

### DIFF
--- a/osclib/core.py
+++ b/osclib/core.py
@@ -392,31 +392,34 @@ def repository_arch_state(apiurl, project, repository, arch):
     from osclib.util import sha1_short
     return sha1_short(http_GET(url).read())
 
-def repository_state(apiurl, project, repository):
+def repository_state(apiurl, project, repository, archs=[]):
+    if not len(archs):
+        archs = target_archs(apiurl, project, repository)
+
     # Unfortunately, the state hash reflects the published state and not the
     # binaries published in repository. As such request binary list and hash.
     combined_state = []
-    for arch in target_archs(apiurl, project, repository):
+    for arch in archs:
         combined_state.append(repository_arch_state(apiurl, project, repository, arch))
     from osclib.util import sha1_short
     return sha1_short(combined_state)
 
-def repositories_states(apiurl, repository_pairs):
+def repositories_states(apiurl, repository_pairs, archs=[]):
     states = []
 
     for project, repository in repository_pairs:
-        states.append(repository_state(apiurl, project, repository))
+        states.append(repository_state(apiurl, project, repository, archs))
 
     return states
 
-def repository_published(apiurl, project, repository):
+def repository_published(apiurl, project, repository, archs=[]):
     root = ETL.fromstringlist(show_results_meta(
-        apiurl, project, multibuild=True, repository=[repository]))
+        apiurl, project, multibuild=True, repository=[repository], arch=archs))
     return not len(root.xpath('result[@state!="published" and @state!="unpublished"]'))
 
-def repositories_published(apiurl, repository_pairs):
+def repositories_published(apiurl, repository_pairs, archs=[]):
     for project, repository in repository_pairs:
-        if not repository_published(apiurl, project, repository):
+        if not repository_published(apiurl, project, repository, archs):
             return (project, repository)
 
     return True

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -388,7 +388,7 @@ class RepoChecker(ReviewBot.ReviewBot):
             project, repository, state_hash, len(repository_pairs)))
 
         archs = self.target_archs_from_prairs(repository_pairs, simulate_merge)
-        published = repositories_published(self.apiurl, repository_pairs)
+        published = repositories_published(self.apiurl, repository_pairs, archs)
 
         if not self.force:
             if state_hash == self.repository_state_last(project, repository, simulate_merge):

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -64,7 +64,7 @@ class RepoChecker(ReviewBot.ReviewBot):
             return
 
         repository_pairs = repository_path_expand(self.apiurl, project, repository)
-        state_hash = self.repository_state(repository_pairs)
+        state_hash = self.repository_state(repository_pairs, False)
         self.repository_check(repository_pairs, state_hash, False, bool(post_comments))
 
     def package_comments(self, project, repository):
@@ -356,8 +356,9 @@ class RepoChecker(ReviewBot.ReviewBot):
         return filename
 
     @memoize(ttl=60, session=True)
-    def repository_state(self, repository_pairs):
-        states = repositories_states(self.apiurl, repository_pairs)
+    def repository_state(self, repository_pairs, simulate_merge):
+        archs = self.target_archs_from_prairs(repository_pairs, simulate_merge)
+        states = repositories_states(self.apiurl, repository_pairs, archs)
         states.append(str(project_meta_revision(self.apiurl, repository_pairs[0][0])))
 
         return sha1_short(states)
@@ -566,7 +567,7 @@ class RepoChecker(ReviewBot.ReviewBot):
         if not isinstance(repository_pairs, list):
             return repository_pairs
 
-        state_hash = self.repository_state(repository_pairs)
+        state_hash = self.repository_state(repository_pairs, True)
         if not self.repository_check(repository_pairs, state_hash, True):
             return None
 
@@ -608,7 +609,7 @@ class RepoChecker(ReviewBot.ReviewBot):
         if not isinstance(repository_pairs, list):
             return repository_pairs
 
-        state_hash = self.repository_state(repository_pairs)
+        state_hash = self.repository_state(repository_pairs, True)
         if not self.repository_check(repository_pairs, state_hash, True):
             return None
 
@@ -623,7 +624,7 @@ class RepoChecker(ReviewBot.ReviewBot):
         if not isinstance(repository_pairs, list):
             return repository_pairs
 
-        state_hash = self.repository_state(repository_pairs)
+        state_hash = self.repository_state(repository_pairs, True)
         if not self.repository_check(repository_pairs, state_hash, True):
             return None
 

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -359,7 +359,9 @@ class RepoChecker(ReviewBot.ReviewBot):
     def repository_state(self, repository_pairs, simulate_merge):
         archs = self.target_archs_from_prairs(repository_pairs, simulate_merge)
         states = repositories_states(self.apiurl, repository_pairs, archs)
-        states.append(str(project_meta_revision(self.apiurl, repository_pairs[0][0])))
+
+        if simulate_merge:
+            states.append(str(project_meta_revision(self.apiurl, repository_pairs[0][0])))
 
         return sha1_short(states)
 


### PR DESCRIPTION
- 1e34a8f47e9e05c649e22d1d64960caf9f337a02:
    repo_checker: filter repository published check by arch.

- 30a42af6ca72192b72f3a6b61a557b9d37e0de44:
    repo_checker: repository_state_last(): switch to simulate_merge as arg.
    
    For the sake of consistency now that repository_state() also requires it.

- 12c9819614c1ecfa531754c69904f4e3a846335e:
    repo_checker: repository_state(): limit meta revision to simulate merge.
    
    Only staging projects are allowed to have psuedometa that makes it relevant
    to include the project meta revision.

- ff722f03b898cb4dae5a48ccedbe51afa53970ff:
    repo_checker: repository_state(): filter by relevant archs.

- dc91518b0a9657e1d38dc4a8033340f9cc3c60f6:
    repo_checker: extract arch determination as target_archs_from_prairs().

- 83688cf0ed2fe56d55b8d5121fd98123e3b949bd:
    osclib/core: provide archs filter for repository state and published queries.

Reduces total query count and no longer considers non-relevant archs in published or state check.

I have run a few tests on SLE-15-SP1 and Factory which has 1 vs 2 archs and the queries seem correct, but also have not witnessed all state types remotely on OBS end.