### PR TITLE
[ARM] Skip build number comparison

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -812,7 +812,7 @@ class ToTest151(ToTestBaseNew):
         return self.iso_build_version(self.project + ':ToTest', self.main_products[0])
 
 
-class ToTest151ARM(ToTestBaseNew):
+class ToTest151ARM(ToTest151):
     main_products = [
         '000product:openSUSE-cd-mini-aarch64',
         '000product:openSUSE-dvd5-dvd-aarch64',
@@ -827,18 +827,14 @@ class ToTest151ARM(ToTestBaseNew):
 
     # Leap 15.1 ARM still need to update snapshot
     set_snapshot_number = True
-
-    # product_repo openqa_group jobs_num values are specific to aarch64
-    # TODO: How to handle the other entries of main_products ?
+    # JeOS doesn't follow build numbers of main isos
+    need_same_build_number = False
 
     def openqa_group(self):
         return 'openSUSE Leap 15 AArch64'
 
     def jobs_num(self):
         return 10
-
-    def get_current_snapshot(self):
-        return self.iso_build_version(self.project + ':ToTest', self.main_products[0])
 
 
 class ToTest150Ports(ToTestBaseNew):


### PR DESCRIPTION
The LiveCD products (JeOS) for ARM will never follow
the same iso build numbers (and don't produce iso's to begin with)
than the main project. In lack of a "ignore mismatch for livecd
products only" option we just skip the syncing globally. that should
be fine as hopefully the main products always produce the same build.