### PR TITLE
osclib/core: repository_published() make x86_64 dependent on i586.

### DIFF
--- a/osclib/core.py
+++ b/osclib/core.py
@@ -413,6 +413,19 @@ def repositories_states(apiurl, repository_pairs, archs=[]):
     return states
 
 def repository_published(apiurl, project, repository, archs=[]):
+    # In a perfect world this would check for the existence of imports from i586
+    # into x86_64, but in an even more perfect world OBS would show archs that
+    # depend on another arch for imports as not completed until the dependent
+    # arch completes. This is a simplified check that ensures x86_64 repos are
+    # not indicated as published when i586 has not finished which is primarily
+    # useful for repo_checker when only checking x86_64. The API treats archs as
+    # a filter on what to return and thus non-existent archs do not cause an
+    # issue nor alter the result.
+    if 'x86_64' in archs and 'i586' not in archs:
+        # Create a copy to avoid altering caller's list.
+        archs = list(archs)
+        archs.append('i586')
+
     root = ETL.fromstringlist(show_results_meta(
         apiurl, project, multibuild=True, repository=[repository], arch=archs))
     return not len(root.xpath('result[@state!="published" and @state!="unpublished"]'))


### PR DESCRIPTION
Without this if `x86_64` completes before `i586` and the imported `*-32bit` binaries cause an issue repo-checker may have accepted the reviews before it sees that. This is only possible recently after #1748 and I have not observed a case of this, but remembered this rather broken OBS behavior and confirmed in home project.