### PR TITLE
osclib/request_splitter: provide stageable option and make default True.

### DIFF
--- a/osclib/list_command.py
+++ b/osclib/list_command.py
@@ -29,7 +29,6 @@ class ListCommand:
         if not len(requests): return
 
         splitter = RequestSplitter(self.api, requests, in_ring=True)
-        splitter.filter_add('./action[@type="submit" or @type="delete"]')
         splitter.group_by('./action/target/@devel_project')
         splitter.split()
 
@@ -68,6 +67,7 @@ class ListCommand:
             print 'Not in a ring:', ' '.join(sorted(non_ring_packages))
 
         # Print requests not handled by staging process to highlight them.
+        splitter.stageable = False
         for request_type in ('change_devel', 'set_bugowner'):
             splitter.reset()
             splitter.filter_add('./action[@type="{}"]'.format(request_type))


### PR DESCRIPTION
Without this, the relative rarer types of requests seen in projects with
staging and handled by list command will be included in staging proposal.
However, since they are not stageable the select operation will fail. This
change ensures that a filter is always present when stageable is True to
exclude non-stableable requests. The list command sets stageable to false
in order to list out the non-stageable requests of interest.

Without this change the following occurs until non-stageable requests are handled.

```
0#devel@YaST:Head:
  bootstrap_required: false
  group: YaST:Head
  requests:
    176229: yast2-storage-ng
    176234: libstorage-ng
  staging: E
  strategy:
    name: devel
1#none@all:
  bootstrap_required: false
  group: all
  requests:
    176055: llvm7
    176057: vpp
    176158: live-langset-data
    176235: oprofile
  staging: F
  strategy:
    name: none

Accept proposal? [y/n] (y): y
Staging 0#devel@YaST:Head in E
(1/2) "176234 (libstorage-ng) supersedes 175944
Staging 1#none@all in F
(1/4) Adding request "176057" to project "SUSE:SLE-15-SP1:GA:Staging:F"
Request 176057 is not a submit or delete request
```

with the change

```
0#devel@YaST:Head:
  bootstrap_required: false
  group: YaST:Head
  requests:
    176229: yast2-storage-ng
    176234: libstorage-ng
  staging: E
  strategy:
    name: devel
1#none@all:
  bootstrap_required: false
  group: all
  requests:
    176235: oprofile
  staging: F
  strategy:
    name: none

Accept proposal? [y/n] (y):
```

Which is a valid proposal. The non-stageabe requests for SLE are typically `set_bugowner` and `change_devel` for openSUSE, but any non-stageable request can cause the issue.