### PR TITLE
devel-projects: remove workaround for OBS xpath bug during request search.

### DIFF
--- a/devel-project.py
+++ b/devel-project.py
@@ -146,12 +146,12 @@ def requests(args):
     apiurl = osc.conf.config['apiurl']
     devel_projects = devel_projects_load(args)
 
+    # Disable including source project in get_request_list() query.
+    osc.conf.config['include_request_from_project'] = False
     for devel_project in devel_projects:
         requests = get_request_list(apiurl, devel_project,
                                     req_state=('new', 'review'),
                                     req_type='submit',
-                                    # Seems to work backwards, as it includes only.
-                                    exclude_target_projects=[devel_project],
                                     withfullhistory=True)
         for request in requests:
             action = request.actions[0]


### PR DESCRIPTION
Now that the bug related to openSUSE/open-build-service#5571 has been fixed
the inverted behavior of exclude_target_projects no longer works. As such
the argument should be removed and only way to get the desired behavior
is to override include_request_from_project which includes request sourced
from specific project. For the purposes of `devel-projects requests` only
interested in requests targeting a specific project.

See also commit 0b342a5.

Observed the odd reminder comments on requests like: [644831](https://build.opensuse.org/request/show/644831). This is due to the fact that the request is not expected to be returned via the query.