### PR TITLE
Fail rabbit-openqa and have systemd restart it

### DIFF
--- a/rabbit-openqa.py
+++ b/rabbit-openqa.py
@@ -32,6 +32,7 @@ class Project(object):
         self.api = StagingAPI(apiurl, name)
         self.staging_projects = dict()
         self.listener = None
+        self.logger = logging.getLogger(__name__)
         self.replace_string = self.api.attribute_value_load('OpenQAMapping')
 
     def init(self):
@@ -104,7 +105,7 @@ class Project(object):
             taken_names[name] = id
 
         for info in openqa_infos.values():
-            xml = self.openqa_check_xml(info['url'], info['state'], info['name'])
+            xml = self.openqa_check_xml(info['url'], info['state'], 'openqa:' + info['name'])
             try:
                 http_POST(url, data=xml)
             except HTTPError:
@@ -262,11 +263,8 @@ if __name__ == '__main__':
     for entry in root.findall('project'):
         l.add(Project(entry.get('name')))
 
-    while True:
-        try:
-            l.run()
-        except KeyboardInterrupt:
-            l.stop()
-        except (HTTPError, URLError, ConnectionError, SSLError):
-            # OBS/openQA hickup
-            sleep(10)
+    try:
+        l.run()
+    except KeyboardInterrupt:
+        l.stop()
+

--- a/systemd/osrt-rabbit-openqa.service
+++ b/systemd/osrt-rabbit-openqa.service
@@ -4,6 +4,7 @@ Description=openSUSE Release Tools: Sync openQA status
 [Service]
 User=osrt-rabbit-openqa
 ExecStart=/usr/bin/osrt-rabbit-openqa
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There were still exceptions not caught - and I have the suspicion
that the memory leaks we see in production are caused by the reconnects
(if you google for python memory leaks you end up with pika and lxml
examples - both we use here, so a restart every couple of hours can't
hurt)