### PR TITLE
[ttm] remove ppc64 (BE) for TW tempo bypass boo#1112920

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -724,9 +724,7 @@ class ToTestFactory(ToTestBase):
 
 
 class ToTestFactoryPowerPC(ToTestBase):
-    main_products = ['000product:openSUSE-dvd5-dvd-ppc64',
-                     '000product:openSUSE-dvd5-dvd-ppc64le',
-                     '000product:openSUSE-cd-mini-ppc64',
+    main_products = ['000product:openSUSE-dvd5-dvd-ppc64le',
                      '000product:openSUSE-cd-mini-ppc64le']
 
     ftp_products = ['000product:openSUSE-ftp-ftp-ppc64_ppc64le']


### PR DESCRIPTION
exemple of output after change:
```
$./totest-manager.py --dry  --debug run Factory:PowerPC 2>&1
2018-11-05 09:59:23,874 - totest-manager:299 INFO job
opensuse-Tumbleweed-DVD-ppc64-Build-RAID5@ppc64 failed, but was ignored
2018-11-05 09:59:24,069 - totest-manager:299 INFO job
opensuse-Tumbleweed-DVD-ppc64-Build-RAID10@ppc64 failed, but was ignored
2018-11-05 09:59:24,259 - totest-manager:299 INFO job
opensuse-Tumbleweed-DVD-ppc64le-Build-extra_tests_in_textmode@ppc64le
failed, but was ignored
2018-11-05 09:59:24,480 - totest-manager:299 INFO job
opensuse-Tumbleweed-DVD-ppc64le-Build-gnome@ppc64le failed, but was
ignored
2018-11-05 09:59:24,679 - totest-manager:311 INFO job
opensuse-Tumbleweed-DVD-ppc64le-Build-extra_tests_on_gnome@ppc64le
failed, see https://openqa.opensuse.org/tests/781048
2018-11-05 09:59:25,104 - totest-manager:524 INFO current_snapshot
20181022: failed
2018-11-05 09:59:25,104 - totest-manager:525 DEBUG new_snapshot 20181101
2018-11-05 09:59:25,104 - totest-manager:526 DEBUG current_qa_version
20181022
2018-11-05 09:59:28,686 - totest-manager:529 DEBUG snapshotable: True
2018-11-05 09:59:28,927 - totest-manager:580 DEBUG No ttm_amqp_url
configured in oscrc - skipping amqp event emission
2018-11-05 09:59:29,210 - totest-manager:549 DEBUG totest already
publishing
2018-11-05 09:59:29,210 - totest-manager:482 INFO Updating snapshot
20181101
2018-11-05 09:59:29,210 - totest-manager:465 INFO release
openSUSE:Factory:PowerPC/000product:openSUSE-ftp-ftp-ppc64_ppc64le
(None)
2018-11-05 09:59:29,210 - totest-manager:465 INFO release
openSUSE:Factory:PowerPC/000product:openSUSE-dvd5-dvd-ppc64le
(Snapshot20181101)
2018-11-05 09:59:29,210 - totest-manager:465 INFO release
openSUSE:Factory:PowerPC/000product:openSUSE-cd-mini-ppc64le
(Snapshot20181101)
```

TODO: is is sufficient to have ppc64 (BE) iso build failure
to be ignored by OBS as per bug 1112920
https://bugzilla.suse.com/show_bug.cgi?id=1112920
and continue to submit ppc64le isos to be submitted to openQA and
released independently from ppc64 ?

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>