### PR TITLE
obs_operator: provide initial version of server and update userscript/staging-move-drag-n-drop

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -199,6 +199,17 @@ Requires:       build
 Requires:       perl-XML-Simple
 Requires(pre):  shadow
 
+%package obs-operator
+Summary:        Server used to perform staging operations
+Group:          Development/Tools/Other
+BuildArch:      noarch
+Requires:       osc-plugin-staging = %{version}
+Requires(pre):  shadow
+
+%description obs-operator
+Server used to perform staging operations as a service instead of requiring
+the osc staging plugin to be utilized directly.
+
 %description repo-checker
 Repository checker service that inspects built RPMs from stagings.
 
@@ -365,6 +376,17 @@ exit 0
 # If grafana-server.service is enabled then restart it to load new dashboards.
 if [ -x /usr/bin/systemctl ] && /usr/bin/systemctl is-enabled grafana-server ; then
   /usr/bin/systemctl try-restart --no-block grafana-server
+fi
+
+%pre obs-operator
+getent passwd osrt-obs-operator > /dev/null || \
+  useradd -r -m -s /sbin/nologin -c "user for openSUSE-release-tools-obs-operator" osrt-obs-operator
+exit 0
+
+%postun obs-operator
+%systemd_postun
+if [ -x /usr/bin/systemctl ] && /usr/bin/systemctl is-enabled osrt-obs-operator ; then
+  /usr/bin/systemctl try-restart --no-block osrt-obs-operator
 fi
 
 %pre repo-checker
@@ -543,6 +565,10 @@ exit 0
 %{_datadir}/%{source_dir}/metrics/grafana/access.json
 %{_unitdir}/osrt-metrics-access.service
 %{_unitdir}/osrt-metrics-access.timer
+
+%files obs-operator
+%{_bindir}/osrt-obs_operator
+%{_unitdir}/osrt-obs-operator.service
 
 %files repo-checker
 %defattr(-,root,root,-)

--- a/obs_operator.py
+++ b/obs_operator.py
@@ -1,0 +1,194 @@
+#!/usr/bin/python3
+
+import argparse
+from http.cookies import SimpleCookie
+from http.cookiejar import Cookie, LWPCookieJar
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
+import json
+import tempfile
+import os
+from osclib import common
+import subprocess
+import sys
+import time
+from urllib.parse import urlparse
+
+# Available in python 3.7.
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    pass
+
+class RequestHandler(BaseHTTPRequestHandler):
+    COOKIE_NAME = 'openSUSE_session' # Both OBS and IBS.
+    POST_ACTIONS = ['select']
+
+    def do_GET(self):
+        if self.path != '/':
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain')
+        self.end_headers()
+
+        self.write_string('namespace: {}\n'.format(common.NAME))
+        self.write_string('name: {}\n'.format('OBS Operator'))
+        self.write_string('version: {}\n'.format(common.VERSION))
+
+    def do_POST(self):
+        action = self.path.lstrip('/')
+        if action not in self.POST_ACTIONS:
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        data = self.data_parse()
+        user = data.get('user')
+        apiurl = self.apiurl_get()
+        if not data or not user or not apiurl:
+            self.send_response(400)
+            self.end_headers()
+            return
+        if self.debug:
+            print('data: {}'.format(data))
+            print('apiurl: {}'.format(apiurl))
+
+        session = self.session_get()
+        if not session:
+            self.send_response(401)
+            self.end_headers()
+            return
+        if self.debug:
+            print('session: {}'.format(session))
+
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain')
+        self.send_header('Access-Control-Allow-Credentials', 'true')
+        self.send_header('Access-Control-Allow-Origin', self.headers.get('Origin'))
+        self.end_headers()
+
+        with tempfile.NamedTemporaryFile() as cookiejar_file:
+            with tempfile.NamedTemporaryFile() as oscrc_file:
+                self.oscrc_create(oscrc_file, apiurl, cookiejar_file, user)
+                self.cookiejar_create(cookiejar_file, session)
+
+                func = getattr(self, 'handle_{}'.format(action))
+                commands = func(data)
+                for command in commands:
+                    self.write_string('$ {}\n'.format(' '.join(command)))
+                    if not self.execute(oscrc_file, command):
+                        self.write_string('failed')
+                        break
+
+    def data_parse(self):
+        data = self.rfile.read(int(self.headers['Content-Length']))
+        return json.loads(data.decode('utf-8'))
+
+    def apiurl_get(self):
+        if self.apiurl:
+            return self.apiurl
+
+        origin = self.headers.get('Origin')
+        if not origin:
+            return None
+
+        # Strip port if present.
+        domain = urlparse(origin).netloc.split(':', 2)[0]
+        if '.' not in domain:
+            return None
+
+        # Remove first subdomain and replace with api subdomain.
+        domain_parent = '.'.join(domain.split('.')[1:])
+        return 'https://api.{}'.format(domain_parent)
+
+    def session_get(self):
+        if self.session:
+            return self.session
+        else:
+            cookie = self.headers.get('Cookie')
+            if cookie:
+                cookie = SimpleCookie(cookie)
+                if self.COOKIE_NAME in cookie:
+                    return cookie[self.COOKIE_NAME].value
+
+        return None
+
+    def oscrc_create(self, oscrc_file, apiurl, cookiejar_file, user):
+        oscrc_file.write('\n'.join([
+            '[general]',
+            'apiurl = {}'.format(apiurl),
+            'cookiejar = {}'.format(cookiejar_file.name),
+            'staging.color = 0',
+            '[{}]'.format(apiurl),
+            'user = {}'.format(user),
+            'pass = invalid',
+            '',
+        ]).encode('utf-8'))
+        oscrc_file.flush()
+
+        # In order to avoid osc clearing the cookie file the modified time of
+        # the oscrc file must be set further into the past.
+        # if int(round(config_mtime)) > int(os.stat(cookie_file).st_mtime):
+        recent_past = time.time() - 3600
+        os.utime(oscrc_file.name, (recent_past, recent_past))
+
+    def cookiejar_create(self, cookiejar_file, session):
+        cookie_jar = LWPCookieJar(cookiejar_file.name)
+        cookie_jar.set_cookie(Cookie(0, self.COOKIE_NAME, session,
+            None, False,
+            '', False, True,
+            '/', True,
+            True,
+            None, None, None, None, {}))
+        cookie_jar.save()
+        cookiejar_file.flush()
+
+    def execute(self, oscrc_file, command):
+        env = os.environ
+        env['OSC_CONFIG'] = oscrc_file.name
+
+        # Would be preferrable to stream incremental output, but python http
+        # server does not seem to support this easily.
+        result = subprocess.run(command, env=env, stdout=self.wfile, stderr=self.wfile)
+        return result.returncode == 0
+
+    def write_string(self, string):
+        self.wfile.write(string.encode('utf-8'))
+
+    def staging_command(self, project, subcommand):
+        return ['osc', 'staging', '-p', project, subcommand]
+
+    def handle_select(self, data):
+        for staging, requests in data['selection'].items():
+            command = self.staging_command(data['project'], 'select')
+            if 'move' in data and data['move']:
+                command.append('--move')
+            command.append(staging)
+            command.extend(requests)
+            yield command
+
+def main(args):
+    RequestHandler.apiurl = args.apiurl
+    RequestHandler.session = args.session
+    RequestHandler.debug = args.debug
+
+    with ThreadedHTTPServer((args.host, args.port), RequestHandler) as httpd:
+        print('listening on {}:{}'.format(args.host, args.port))
+        httpd.serve_forever()
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='OBS Operator server used to perform staging operations.')
+    parser.set_defaults(func=main)
+
+    parser.add_argument('--host', default='', help='host name to which to bind')
+    parser.add_argument('--port', type=int, default=8080, help='port number to which to bind')
+    parser.add_argument('-A', '--apiurl',
+        help='OBS instance API URL to use instead of basing from request origin')
+    parser.add_argument('--session',
+        help='session cookie value to use instead of any passed cookie')
+    parser.add_argument('-d', '--debug', action='store_true',
+        help='print debugging information')
+
+    args = parser.parse_args()
+    sys.exit(args.func(args))

--- a/systemd/osrt-obs-operator.service
+++ b/systemd/osrt-obs-operator.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=openSUSE Release Tools: OBS Operator
+
+[Service]
+User=osrt-obs-operator
+ExecStart=/usr/bin/osrt-obs_operator --debug
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/userscript/staging-move-drag-n-drop.user.js
+++ b/userscript/staging-move-drag-n-drop.user.js
@@ -16,6 +16,11 @@
 
 (function()
 {
+    // Exclude not usable browsers.
+    if (!document.querySelectorAll || !('draggable' in document.createElement('span'))) {
+        return;
+    }
+
     // Add explanation of trigger shortcut to legend box.
     var explanation = document.createElement('div');
     explanation.id = 'osrt-explanation';
@@ -92,18 +97,6 @@
 })();
 
 var initMoveInterface = function(){
-    //exclude older browsers by the features we need them to support
-    //and legacy opera explicitly so we don't waste time on a dead browser
-    if
-    (
-        !document.querySelectorAll
-        ||
-        !('draggable' in document.createElement('span'))
-        ||
-        window.opera
-    )
-    { return; }
-
     // Update explanation text and add new legend entries.
     function addLegend(type)
     {

--- a/userscript/staging-move-drag-n-drop.user.js
+++ b/userscript/staging-move-drag-n-drop.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OSRT Staging Move Drag-n-Drop
 // @namespace    openSUSE/openSUSE-release-tools
-// @version      0.1.0
+// @version      0.2.0
 // @description  Provide staging request moving interface on staging dashboard.
 // @author       Jimmy Berry
 // @match        */project/staging_projects/*
@@ -18,6 +18,11 @@
 {
     // Exclude not usable browsers.
     if (!document.querySelectorAll || !('draggable' in document.createElement('span'))) {
+        return;
+    }
+
+    // Ensure user is logged in.
+    if (!document.querySelector('#link-to-user-home')) {
         return;
     }
 
@@ -59,13 +64,55 @@
     z-index: 10000;
     bottom: 0;
     left: 0;
-    width: 95%;
-    height: 100px;
-    padding: 10px;
-    background-color: black;
-    color: #18f018;
-    white-space: pre;
-    overflow: scroll;
+    width: 100%%;
+    height: 2em;
+    padding-top: 0.7em;
+    text-align: center;
+    background-color: white;
+}
+
+#osrt-summary button
+{
+    margin-left: 10px;
+}
+
+#osrt-summary progress
+{
+    display: none;
+}
+
+#osrt-summary.osrt-progress progress
+{
+    display: inline;
+}
+
+#osrt-summary.osrt-progress span,
+#osrt-summary.osrt-progress button,
+#osrt-summary.osrt-success button
+{
+    display: none;
+}
+
+#osrt-summary.osrt-failed
+{
+    background-color: red;
+    color: white;
+}
+
+#osrt-summary.osrt-failed span
+{
+    display: inline;
+}
+
+#osrt-summary.osrt-failed progress
+{
+    display: none;
+}
+
+#osrt-summary.osrt-success
+{
+    background-color: green;
+    color: white;
 }
 
 /* drop target state */
@@ -107,7 +154,7 @@
 
 })();
 
-var initMoveInterface = function(){
+var initMoveInterface = function() {
     // Update explanation text and add new legend entries.
     function addLegend(type)
     {
@@ -150,7 +197,7 @@ var initMoveInterface = function(){
             e.osrtContinue = (e.target.getAttribute('data-draggable') != 'item' &&
                               e.target.tagName != 'A' &&
                               e.target.tagName != 'LABEL' &&
-                              e.target.id != 'osrt-summary');
+                              !e.target.id.startsWith('osrt-'));
         },
         // Abuse key option by setting the value in start callback whic is run
         // first and the value determines if drag selection is started.
@@ -178,38 +225,96 @@ var initMoveInterface = function(){
         return parent.querySelector('div.letter a').innerText;
     }
 
+    var summary = {};
     function updateSummary()
     {
         var summaryElement = document.querySelector('div#osrt-summary');
         if (!summaryElement) {
             summaryElement = document.createElement('div');
             summaryElement.id = 'osrt-summary';
+            summaryElement.appendChild(document.createElement('span'))
+
+            var button = document.createElement('button');
+            button.innerText = 'Apply';
+            button.onclick = applyChanges;
+            summaryElement.appendChild(button);
+
+            summaryElement.appendChild(document.createElement('progress'))
             document.body.appendChild(summaryElement);
         }
 
         var elements = document.querySelectorAll('.osrt-moved');
-        var summary = {};
+        summary = {};
         var staging;
         for (var i = 0; i < elements.length; i++) {
             staging = getStaging(elements[i]);
+            if (!isNaN(staging)) {
+                staging = 'adi:' + staging;
+            }
             if (!(staging in summary)) {
                 summary[staging] = [];
             }
             summary[staging].push(elements[i].children[0].innerText.trim());
         }
 
-        var summaryText = '';
+        summaryElement.children[0].innerText = elements.length + ' request(s) to move affecting ' + Object.keys(summary).length + ' stagings(s)';
+        summaryElement.children[2].setAttribute('max', elements.length);
+    }
+
+    function applyChanges()
+    {
+        var summaryElement = document.querySelector('div#osrt-summary');
+        summaryElement.classList.add('osrt-progress');
+
+        var user = document.querySelector('#link-to-user-home').innerText.trim();
         var pathParts = window.location.pathname.split('/');
         var project = pathParts[pathParts.length - 1];
-        for (var key in summary) {
-            staging = key;
-            if (!isNaN(key)) {
-                staging = 'adi:' + key;
-            }
-            summaryText += 'osc staging -p ' + project + ' select --move ' + staging + ' ' + summary[key].join(' ') + "\n";
+
+        var data = JSON.stringify({'user': user, 'project': project, 'move': true, 'selection': summary});
+        var domain_parent = window.location.hostname.split('.').splice(1).join('.');
+        var subdomain = domain_parent.endsWith('suse.de') ? 'tortuga' : 'operator';
+        var url = 'https://' + subdomain + '.' + domain_parent + '/select';
+        $.post({url: url, data: data, crossDomain: true, xhrFields: {withCredentials: true},
+                success: applyChangesSuccess}).fail(applyChangesFailed);
+    }
+
+    function applyChangesSuccess(data)
+    {
+        // Could provide link to this in UI.
+        console.log(data);
+
+        var summaryElement = document.querySelector('div#osrt-summary');
+        summaryElement.classList.add('osrt-complete');
+        if (data.trim().endsWith('failed')) {
+            applyChangesFailed();
+            return;
         }
 
-        summaryElement.innerText = summaryText;
+        var expected = summaryElement.children[2].getAttribute('max');
+        if ((data.match(/\(\d+\/\d+\)/g) || []).length == expected) {
+            summaryElement.children[0].innerText = 'Moved ' + expected + ' request(s).';
+            summaryElement.children[2].setAttribute('value', expected);
+            summaryElement.classList.add('osrt-success');
+            summaryElement.classList.remove('osrt-progress');
+
+            // Could reset UI in a more elegant way.
+            reloadShortly();
+            return;
+        }
+
+        applyChangesFailed();
+    }
+
+    function applyChangesFailed()
+    {
+        var summaryElement = document.querySelector('div#osrt-summary');
+        summaryElement.children[0].innerText = 'Failed to move requests.';
+        summaryElement.classList.add('osrt-failed');
+    }
+
+    function reloadShortly()
+    {
+        setTimeout(function() { window.location.reload(); }, 3000);
     }
 
     //get the collection of draggable targets and add their draggable attribute

--- a/userscript/staging-move-drag-n-drop.user.js
+++ b/userscript/staging-move-drag-n-drop.user.js
@@ -24,7 +24,12 @@
     // Add explanation of trigger shortcut to legend box.
     var explanation = document.createElement('div');
     explanation.id = 'osrt-explanation';
-    explanation.innerText = 'press ctrl+m to move requests';
+    explanation.innerText = 'enter move mode';
+    explanation.setAttribute('title', 'ctrl + m');
+    explanation.onclick = function() {
+        initMoveInterface();
+        this.onclick = null;
+    };
     document.querySelector('#legends').appendChild(explanation);
 
     window.onkeyup = function(e) {
@@ -40,6 +45,12 @@
     padding: 10px;
     background-color: #d9b200;
     color: white;
+    cursor: pointer;
+}
+
+#osrt-explanation.osrt-active
+{
+    cursor: default;
 }
 
 #osrt-summary
@@ -111,7 +122,10 @@ var initMoveInterface = function(){
     addLegend('Moved');
     addLegend('Selected');
 
-    document.querySelector('#osrt-explanation').innerText = 'move mode activated: drag box around requests or ctrl/shift+click requests to select and drag a request to another staging.';
+    var explanation = document.querySelector('#osrt-explanation');
+    explanation.innerText = 'drag box around requests or ctrl/shift + click requests to select and drag a request to another staging.';
+    explanation.setAttribute('title', 'move mode activated');
+    explanation.classList.add('osrt-active');
 
     // @resource will not work since served without proper MIME type.
     $.get('https://raw.githubusercontent.com/p34eu/selectables/master/selectables.css', function(data, status) {


### PR DESCRIPTION
- 408f8fb031091147d399f1daa064d7e506b54304:
    dist/spec: provide obs-operator subpackage.

- 24d56d8eed79f044b13967d48e3e1a94496920b7:
    userscript/staging-move-drag-n-drop: rework to utilize OBS Operator server.

- 3d0832f97d5bb2ae349d4b9a53272645ab846797:
    obs_operator: provide initial version of server.

- 880bd1b638fb931448485d2b87d32bcdf91d0e20:
    userscript/staging-move-drag-n-drop: provide option to click to start.

- d1e776379112c18164d83f1e94add038911499a2:
    userscript/staging-move-drag-n-drop: move browser compatability check to init

I verified this by moving adi requests in both Leap and Factory that needed moving using the browser interface to trigger the OBS Operator server to make the selection changes (ie. drag-n-drop and press apply in browser).

![image](https://user-images.githubusercontent.com/22943929/48209312-6d876c00-e33a-11e8-9044-7712a1114808.png)

![image](https://user-images.githubusercontent.com/22943929/48209316-6fe9c600-e33a-11e8-8589-780f2d699470.png)
