### PR TITLE
travis: configure notification e-mail to internal list.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,3 +94,8 @@ cache:
 before_cache:
   - sudo rm -rf .docker-tmp/build-root
   - sudo chmod -R o+rw .docker-tmp
+
+notifications:
+  email:
+    recipients:
+      - opensuse-releaseteam@suse.de


### PR DESCRIPTION
I setup this internal list a few weeks ago, but haven't used it for anything yet. The idea being for more spamming topics really only relevant to us in addition to potentially using for third-party account e-mail address so everyone on team has access instead of bus factor 1.

Related #1770.