### PR TITLE
ReviewBot: accept patchinfo action reviews instead of ignore.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -393,7 +393,7 @@ class ReviewBot(object):
     def check_action_maintenance_incident(self, req, a):
         if self._is_patchinfo(a.src_package):
             self.logger.debug('ignoring patchinfo action')
-            return None
+            return True
 
         # Duplicate src_package as tgt_package since prior to assignment to a
         # specific incident project there is no target package (odd API). After
@@ -416,7 +416,8 @@ class ReviewBot(object):
         pkgname = a.src_package
         if self._is_patchinfo(pkgname):
             self.logger.debug('ignoring patchinfo action')
-            return None
+            return True
+
         linkpkg = self._get_linktarget_self(a.src_project, pkgname)
         if linkpkg is not None:
             pkgname = linkpkg

--- a/check_maintenance_incidents.py
+++ b/check_maintenance_incidents.py
@@ -116,7 +116,7 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
     def check_action_maintenance_incident(self, req, a):
 
         if a.src_package == 'patchinfo':
-            return None
+            return True
 
         self._check_maintainer_review_needed(req, a)
 


### PR DESCRIPTION
Ignore is used to wait for a change to occur while patchinfo should never
affect the result. Since all actions must be accepted for the request to
be accepted setting patchinfo to accept is the correct way to ignore it.

Fixes #1730.