### PR TITLE
dist/kubernetes: provide OBS Operator component (and related changes)

### DIFF
--- a/dist/kiwi/osrt-worker-obs.kiwi
+++ b/dist/kiwi/osrt-worker-obs.kiwi
@@ -21,6 +21,7 @@
   <packages type="image">
     <package name="openSUSE-release-tools-check-source"/>
     <package name="openSUSE-release-tools-leaper"/>
+    <package name="openSUSE-release-tools-obs-operator"/>
     <package name="openSUSE-release-tools-pkglistgen"/>
     <package name="openSUSE-release-tools-repo-checker"/>
     <package name="openSUSE-release-tools-staging-bot"/>

--- a/dist/kubernetes/app.yaml
+++ b/dist/kubernetes/app.yaml
@@ -7,9 +7,9 @@ environments:
     k8sVersion: v1.8.0
     path: heroes
     targets:
-    - check-source
+    #- check-source
     - obs-operator
-    - repo-checker
+    #- repo-checker
 kind: ksonnet.io/app
 name: openSUSE-release-tools
 version: 0.0.1

--- a/dist/kubernetes/app.yaml
+++ b/dist/kubernetes/app.yaml
@@ -8,6 +8,7 @@ environments:
     path: heroes
     targets:
     - check-source
+    - obs-operator
     - repo-checker
 kind: ksonnet.io/app
 name: openSUSE-release-tools

--- a/dist/kubernetes/components/obs-operator/params.libsonnet
+++ b/dist/kubernetes/components/obs-operator/params.libsonnet
@@ -1,0 +1,14 @@
+{
+  global: {
+    cpu: "100m",
+    memory: "128Mi",
+    image: null,
+    prefix: "obs-operator",
+  },
+  components: {
+    service: {
+      externalIPs: null,
+      externalPort: null,
+    },
+  },
+}

--- a/dist/kubernetes/components/obs-operator/service.jsonnet
+++ b/dist/kubernetes/components/obs-operator/service.jsonnet
@@ -1,0 +1,13 @@
+local params = std.extVar("__ksonnet/params").components.service;
+local service = import '../service.libsonnet';
+
+[
+  service.parts.deployment.base(
+    params.prefix, "deployment",
+    params.cpu, params.memory, params.image,
+     "osrt-obs_operator --debug"),
+
+  service.parts.service.base(
+    params.prefix, "service", 8080, params.externalIPs, params.externalPort,
+  ),
+]

--- a/dist/kubernetes/components/service.libsonnet
+++ b/dist/kubernetes/components/service.libsonnet
@@ -1,0 +1,84 @@
+{
+  parts:: {
+    deployment:: {
+      base(prefix, name, cpu, memory, image, command):: {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: {
+          name: prefix + "-" + name,
+          labels: {
+            app: prefix,
+          },
+        },
+        spec: {
+          replicas: 1,
+          selector: {
+            matchLabels: {
+              app: prefix,
+            },
+          },
+          template: {
+            metadata: {
+              labels: {
+                app: prefix,
+              },
+            },
+            spec: {
+              containers: [{
+                name: "service",
+                image: image,
+                args: [
+                  "/bin/bash", "-c",
+                  "cp /secret/.oscrc /root && osc staging --version && " + command
+                ],
+                volumeMounts: [
+                  {
+                    name: "oscrc",
+                    mountPath: "/secret",
+                    readOnly: true,
+                  },
+                ],
+                resources: {
+                  requests: {
+                    cpu: cpu,
+                    memory: memory,
+                  }
+                }
+              }],
+              volumes: [
+                {
+                  name: "oscrc",
+                  secret: {
+                    secretName: prefix + "-oscrc",
+                  }
+                },
+              ],
+            }
+          }
+        }
+      }
+    },
+
+    service:: {
+      base(prefix, name, internalPort, externalIPs, externalPort):: {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          name: prefix + "-" + name,
+        },
+        spec: {
+          type: "NodePort",
+          selector: {
+            app: prefix,
+          },
+          ports: [{
+            protocol: "TCP",
+            port: internalPort,
+            nodePort: externalPort,
+          }],
+          externalIPs: externalIPs,
+        }
+      }
+    },
+  }
+}

--- a/dist/kubernetes/environments/heroes/globals.libsonnet
+++ b/dist/kubernetes/environments/heroes/globals.libsonnet
@@ -1,4 +1,4 @@
-local image = "registry.opensuse.org/home/jberry/container/container/osrt/worker-obs";
+local image = "registry.opensuse.org/opensuse/tools/images/images/osrt/worker-obs";
 local image_version = "latest";
 local image_full = image + ':' + image_version;
 

--- a/dist/kubernetes/environments/heroes/params.libsonnet
+++ b/dist/kubernetes/environments/heroes/params.libsonnet
@@ -2,6 +2,14 @@ local params = std.extVar("__ksonnet/params");
 local globals = import "globals.libsonnet";
 local envParams = params + {
   components+: {
+    "obs-operator.service"+: {
+      externalIPs: [
+        "192.168.47.44",
+        "192.168.47.45",
+        "192.168.47.46",
+      ],
+      externalPort: 31452,
+    },
     "repo-checker.project_only"+: {
       projects: [
         "openSUSE:Factory",

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -27,6 +27,7 @@ License:        GPL-2.0-or-later AND MIT
 Group:          Development/Tools/Other
 Url:            https://github.com/openSUSE/openSUSE-release-tools
 Source:         %{name}-%{version}.tar.xz
+Source99:       osrt-worker-obs.kiwi
 BuildArch:      noarch
 # Requires sr#512849 which provides osc_plugin_dir.
 BuildRequires:  osc >= 0.159.0

--- a/obs_operator.py
+++ b/obs_operator.py
@@ -1,4 +1,6 @@
-#!/usr/bin/python3
+#!/usr/bin/python3 -u
+# Without the -u option for unbuffered output nothing shows up in journal or
+# kubernetes logs.
 
 import argparse
 from http.cookies import SimpleCookie


### PR DESCRIPTION
- 6b02225c75b7c26c2e7d900ce6430d474f7ebdb5:
    dist/kubernetes: utilize new image home in openSUSE:Tools:Images.

- 2e50be7557f80c3c0f60d3efe9b53d1199e73878:
    dist/package: include worker kiwi to allow extraction via _service.
    
    Since the kiwi file will reside in the source package, it needs to be
    referenced in order to appease Factory rpmlint.

- a75f4fbabbaff83ad047973bb7eb1ce0343a7bf1:
    dist/kiwi/worker: include obs-operator subpackage.

- 6b1003fb062aabc542103ee3b91103d18f85d9e4:
    obs_operator: use unbuffered output to work properly in systemd.

- 3ac0086154c85807a56c5be9914ef4caba87bf82:
    dist/kubernetes: provide OBS Operator component.

Should accept [OBS request 649089](https://build.opensuse.org/request/show/649089) after merged to allow for kiwi file to be updated. Created [temporary branched package](https://build.opensuse.org/package/show/openSUSE:Tools:Images/openSUSE-release-tools) in openSUSE:Tools:Images to verify everything works. The package should be re-branched from openSUSE:Tools once merged.

WIP until verify k8s approach with @tampakrap.