### PR TITLE
fetch string value 'none' of data

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -698,7 +698,7 @@ class StagingAPI(object):
     def load_prj_pseudometa(self, description_text):
         try:
             data = yaml.load(description_text)
-            if data is None:
+            if isinstance(data, str) or data is None:
                 data = {}
         except (TypeError, AttributeError):
             data = {}


### PR DESCRIPTION
In some cases yaml.load(description_text) can return a string value 'none'. 

This will be fetched with isinstance(data, str)