### PR TITLE
Checked with aplanas: using stringio is preferred

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -240,8 +240,8 @@ class Config(object):
         config = attribute_value_load(apiurl, self.project, 'Config')
         if config:
             cp = OscConfigParser.OscConfigParser()
-            config = '[remote]\n' + config
-            cp.readfp(io.BytesIO(config))
+            config = u'[remote]\n' + config
+            cp.readfp(io.StringIO(config))
             return dict(cp.items('remote'))
 
         return None


### PR DESCRIPTION
@aplanas and me checked - and the config still works with StringIO. As unicode and string have the same hash value for all keys we pass