### PR TITLE
 staging-report: ignore projects not in a final state.

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1036,6 +1036,10 @@ class StagingAPI(object):
 
         return requests
 
+    def project_status_final(self, status):
+        """Determine if staging project is both active and no longer pending."""
+        return status['overall_state'] in ['acceptable', 'review', 'failed']
+
     def days_since_last_freeze(self, project):
         """
         Checks the last update for the frozen links


### PR DESCRIPTION
I received the following notification email:

```
Staging Bot wrote in project openSUSE:Factory:Staging:K:

<!-- StagingReport -->

Checks:

- pending
  - [openqa:rescue_system](https://openqa.opensuse.org/tests/799404)
  - [openqa:RAID0](https://openqa.opensuse.org/tests/799406)
  - [openqa:cryptlvm](https://openqa.opensuse.org/tests/799407)
  - [openqa:gnome](https://openqa.opensuse.org/tests/799408)
  - [openqa:kde@64bit](https://openqa.opensuse.org/tests/799409)
  - [openqa:kde@USBboot_64](https://openqa.opensuse.org/tests/799410)
  - and 5 more...
```

This can only occur with new status report API and the new state "pending". The checks do not show as pending on a fresh staging, but do after it has been reset. It would be more consistent to show them in `missing_checks` as the openqa _placeholder_ is on fresh staging. Either way this will cause an extra comment on re-testing that is likely undesirable.

While investigated it seemed clear that the report should wait until a staging is in a _final_ state anyway rather than posting intermediate results. Such intermediate results can be viewed via dashboard anyway.

One caveat to _final_ state is that once a single test fails the staging is marked as _failed_ even though it is not in a final state. If I remember correctly this is a deviation in behavior whereas previous a staging was marked _testing_ until done testing even if test failures or build failures where presented as well. I think the old behavior should be reinstated.

Either way this seems like net improvement.