### PR TITLE
stagingapi: No longer build disable to sub packages

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1213,9 +1213,7 @@ class StagingAPI(object):
             # Skip inner-project links for letter staging
             if not self.is_adi_project(project) and sub_prj == project:
                 continue
-            if self._supersede:
-                disable_build = self._package_disabled.get('/'.join([sub_prj, sub_pkg]), False)
-            self.create_package_container(sub_prj, sub_pkg, disable_build=disable_build)
+            self.create_package_container(sub_prj, sub_pkg)
 
             root = ET.Element('link', package=tar_pkg, project=project)
             url = self.makeurl(['source', sub_prj, sub_pkg, '_link'])


### PR DESCRIPTION
Follow up with https://github.com/openSUSE/openSUSE-release-tools/pull/1774/commits/7a3b86fed17566f0680ee4eb8ad64238a70b77b9 , a regression happens, fixes UnboundLocalError: local variable 'disable_build' referenced before assignment error.

Hot-patched on packagelists.