### PR TITLE
If we can't resolve the package name, it's no reason to decline

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -430,8 +430,8 @@ class ReviewBot(object):
         # to find the real package name
         (linkprj, linkpkg) = self._get_linktarget(a.src_project, pkgname)
         if linkpkg is None or linkprj is None or linkprj != a.tgt_project:
-            self.logger.error("%s/%s is not a link to %s"%(a.src_project, pkgname, a.tgt_project))
-            return False
+            self.logger.warning("%s/%s is not a link to %s"%(a.src_project, pkgname, a.tgt_project))
+            return self.check_source_submission(a.src_project, a.src_package, a.src_rev, a.tgt_project, a.tgt_package)
         else:
             pkgname = linkpkg
         return self.check_source_submission(a.src_project, a.src_package, None, a.tgt_project, pkgname)


### PR DESCRIPTION
Sometimes maintenance adds specific containers to build in the
incident

ibs#177934 was declined by legal-auto because of some maintenance hackery. But legal-auto is not supposed to judge maintenace hackeries, but legal status. And that was actually fine.

returning False without setting a message is problematic anyway - as the legal-auto review was declined as 'ok'