### PR TITLE
pkglistgen: for nonefree repo handling should update to tool's repos rather than commandline's repos

### DIFF
--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1324,11 +1324,11 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
             repos_ = self.repos
             opts_nonfree = copy.deepcopy(opts)
             opts_nonfree.project = nonfree
-            self.repos = self.tool.expand_repos(nonfree, main_repo)
+            self.tool.repos = self.tool.expand_repos(nonfree, main_repo)
             self.tool.update_repos(opts_nonfree)
 
             # Switch repo back to main target project.
-            self.repos = repos_
+            self.tool.repos = repos_
 
             print('-> update_merge')
             self.update_merge(nonfree if drop_list else False)


### PR DESCRIPTION
Fix a bug that NonFree repo solv data has not get updated.