### PR TITLE
Revert extracted kiwi again

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -27,7 +27,6 @@ License:        GPL-2.0-or-later AND MIT
 Group:          Development/Tools/Other
 Url:            https://github.com/openSUSE/openSUSE-release-tools
 Source:         %{name}-%{version}.tar.xz
-Source99:       osrt-worker-obs.kiwi
 BuildArch:      noarch
 # Requires sr#512849 which provides osc_plugin_dir.
 BuildRequires:  osc >= 0.159.0


### PR DESCRIPTION
This kiwi file is built in all places where this package ends, including
openSUSE:Factory, where it creates a problem as there is no tumbleweed#current

And we really don't want to build it again there, we only want it in
openSUSE:Tools(:Images)