### PR TITLE
check_duplicate_binaries: set arch key to string instead of the list

### DIFF
--- a/osclib/check_duplicate_binaries_command.py
+++ b/osclib/check_duplicate_binaries_command.py
@@ -21,7 +21,7 @@ class CheckDuplicateBinariesCommand(object):
                 binaries.setdefault(arch, {})
 
                 if pb.name in binaries[arch]:
-                    duplicates.setdefault(arch, {})
+                    duplicates.setdefault(str(arch), {})
                     duplicates[arch].setdefault(pb.name, set())
                     duplicates[arch][pb.name].add(pb.package)
                     duplicates[arch][pb.name].add(binaries[arch][pb.name])


### PR DESCRIPTION
See https://github.com/openSUSE/openSUSE-release-tools/issues/1820

```
# osc staging -p openSUSE:Leap:15.1 check_duplicate_binaries
i586:
  python3-clang:
  - llvm5
  - llvm7
x86_64:
  gnome-themes-accessibility:
  - gnome-themes-extra
  - gnome-themes-standard
  gnome-themes-accessibility-gtk2:
  - gnome-themes-extra
  - gnome-themes-standard
  gtk2-metatheme-adwaita:
  - gnome-themes-extra
  - gnome-themes-standard
  gtk2-theming-engine-adwaita:
  - gnome-themes-extra
  - gnome-themes-standard
  gtk3-metatheme-adwaita:
  - gnome-themes-extra
  - gnome-themes-standard
  libc++-devel:
  - llvm5
  - llvm7
  libc++1:
  - llvm5
  - llvm7
  libc++abi-devel:
  - llvm5
  - llvm7
  libc++abi1:
  - llvm5
  - llvm7
  metatheme-adwaita-common:
  - gnome-themes-extra
  - gnome-themes-standard
  python2-astroid:
  - python-astroid
  - python2-astroid
  python2-cmd2:
  - python-cmd2
  - python2-cmd2
  python2-matplotlib:
  - python-matplotlib
  - python2-matplotlib
  python2-matplotlib-cairo:
  - python-matplotlib
  - python2-matplotlib
  python2-matplotlib-gtk3:
  - python-matplotlib
  - python2-matplotlib
  python2-matplotlib-latex:
  - python-matplotlib
  - python2-matplotlib
  python2-matplotlib-qt-shared:
  - python-matplotlib
  - python2-matplotlib
  python2-matplotlib-qt4:
  - python-matplotlib
  - python2-matplotlib
  python2-matplotlib-qt5:
  - python-matplotlib
  - python2-matplotlib
  python2-matplotlib-tk:
  - python-matplotlib
  - python2-matplotlib
  python2-matplotlib-web:
  - python-matplotlib
  - python2-matplotlib
  python2-matplotlib-wx:
  - python-matplotlib
  - python2-matplotlib
  python3-clang:
  - llvm5
  - llvm7
```