### PR TITLE
ttm: Follow Tumbleweed move to new pkglistgen pkg layout

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -167,7 +167,7 @@ class ToTestBase(object):
 
     def release_version(self):
         url = self.api.makeurl(['build', self.project, 'standard', self.arch(),
-                                '000product:%s-release' % self.project_base])
+                                '000release-packages:%s-release' % self.project_base])
         f = self.api.retried_GET(url)
         root = ET.parse(f).getroot()
         for binary in root.findall('binary'):


### PR DESCRIPTION
The new pkglist generator no longer has the openSUSE-release inside the 000product container, but moved it to 000package-groups. Follow this (with TW being the last one to move, this should be safe)

in a later step, we should probably be able to simplify ttm again - the variation between BaseTest and BaseTestNew might be minimized again)