### PR TITLE
osc cycle: correctly handle comma-separated arg list

### DIFF
--- a/osc-cycle.py
+++ b/osc-cycle.py
@@ -16,9 +16,8 @@ def do_cycle(self, subcmd, opts, *args):
     apiurl = self.get_api_url()
 
     print ("digraph depgraph {")
+    args = [pkg.strip() for pkglist in args for pkg in pkglist.split(',') if pkg.strip()]
     for pkgname in args:
-        pkgname = pkgname.strip(',')
-        if len(pkgname) == 0: continue
         try:
             deps = ET.fromstring(get_dependson(apiurl, "openSUSE:Factory", "standard", "x86_64", [pkgname]))
 


### PR DESCRIPTION
Most of the time I copy/paste a comma-separated package list from the obs WEBUI to the command line. With this, I don't have to worry about the commas in the list and we just strip them away. A few minutes won whenever this is used.