### PR TITLE
pkglistgen: Reset the tool between projects

### DIFF
--- a/pkglistgen/cli.py
+++ b/pkglistgen/cli.py
@@ -106,6 +106,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
 
         def solve_project(project, scope):
             try:
+                self.tool.reset()
                 if self.tool.update_and_solve_target(api, target_project, target_config, main_repo,
                                 project=project, scope=scope, force=opts.force,
                                 no_checkout=opts.no_checkout,

--- a/pkglistgen/tool.py
+++ b/pkglistgen/tool.py
@@ -44,6 +44,10 @@ class PkgListGen(ToolBase.ToolBase):
 
     def __init__(self):
         ToolBase.ToolBase.__init__(self)
+        self.logger = logging.getLogger(__name__)
+        self.reset()
+
+    def reset(self):
         # package -> supportatus
         self.packages = dict()
         self.groups = dict()
@@ -56,7 +60,6 @@ class PkgListGen(ToolBase.ToolBase):
         self.output = None
         self.locales = set()
         self.did_update = False
-        self.logger = logging.getLogger(__name__)
         self.filtered_architectures = None
         self.dry_run = False
         self.all_architectures = None


### PR DESCRIPTION
So far I only cared for single projects, but never tested all staging projects in a loop while developing, so I didn't notice the problem