### PR TITLE
Remove openSUSE-images from rebuildpacs - long gone

### DIFF
--- a/rebuildpacs.pl
+++ b/rebuildpacs.pl
@@ -82,7 +82,7 @@ my %parents = (
           xfce4-branding-openSUSE
           kdebase4-openSUSE kde-branding-openSUSE
           bundle-lang-kde bundle-lang-common
-          openSUSE-images installation-images-openSUSE)
+          installation-images-openSUSE)
     ],
     "kdebase4-openSUSE" => [qw(bundle-lang-kde)],
     "kernel-source"     => [qw(perf)],


### PR DESCRIPTION
(and this causes a 404 on rebuildpac, which might stop the rest)