### PR TITLE
osclib/list_command: 24ae4ba broke formatting.

### DIFF
--- a/osclib/list_command.py
+++ b/osclib/list_command.py
@@ -59,7 +59,7 @@ class ListCommand:
                 if message:
                     line += '\n' + Fore.WHITE + message + Fore.RESET
 
-                print(' ' + line)
+                print(' ', line)
 
         if len(splitter.other):
             non_ring_packages = []


### PR DESCRIPTION
- 01d9504d90a403b8dddc44bf1f1208bb312f5f24:
    osclib/list_command: 24ae4ba81 broke formatting.
    
    ```
    The author was attempting to port for python3, but changed the meaning:
    
    - print ' ', line
    + print(' ' + line)
    
    The first prints "  $line", while the second:
                     " $line".
    
    This changes console output from:
    
    science
     666254 libArcus-lulzbot               -> delete       (delete request)
             3 more users
    
    back to:
    
    science
      666254 libArcus-lulzbot               -> delete       (delete request)
             3 more users
    
    (ignore lines up and standard double space indent used)
    ```