### PR TITLE
Fix project/status route

### DIFF
--- a/build-fail-reminder.py
+++ b/build-fail-reminder.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 Charset.add_charset('utf-8', Charset.QP, Charset.QP, 'utf-8')
 
 # FIXME: compute from apiurl
-URL="https://build.opensuse.org/project/status?&project=%s&ignore_pending=true&limit_to_fails=true&include_versions=false&format=json"
+URL="https://build.opensuse.org/project/status/%s?ignore_pending=true&limit_to_fails=true&include_versions=false&format=json"
 # for maintainer search
 FACTORY='openSUSE:Factory'
 


### PR DESCRIPTION
Following a change in OBS, the project parameter is always required in the project/status route.

The commit:
openSUSE/open-build-service@f795712#diff-61c12a5866566c0d732134f0c447d788

Thank you to @lnussel for reporting this on IRC.