### PR TITLE
 dist/kubernetes: add origin-manager component.

### DIFF
--- a/dist/kiwi/osrt-worker-obs.kiwi
+++ b/dist/kiwi/osrt-worker-obs.kiwi
@@ -22,6 +22,7 @@
     <package name="openSUSE-release-tools-check-source"/>
     <package name="openSUSE-release-tools-leaper"/>
     <package name="openSUSE-release-tools-obs-operator"/>
+    <package name="openSUSE-release-tools-origin-manager"/>
     <package name="openSUSE-release-tools-pkglistgen"/>
     <package name="openSUSE-release-tools-repo-checker"/>
     <package name="openSUSE-release-tools-staging-bot"/>

--- a/dist/kubernetes/app.yaml
+++ b/dist/kubernetes/app.yaml
@@ -9,7 +9,7 @@ environments:
     targets:
     #- check-source
     - obs-operator
-    - origin-manager
+    #- origin-manager
     #- repo-checker
 kind: ksonnet.io/app
 name: openSUSE-release-tools

--- a/dist/kubernetes/app.yaml
+++ b/dist/kubernetes/app.yaml
@@ -9,6 +9,7 @@ environments:
     targets:
     #- check-source
     - obs-operator
+    - origin-manager
     #- repo-checker
 kind: ksonnet.io/app
 name: openSUSE-release-tools

--- a/dist/kubernetes/components/origin-manager/params.libsonnet
+++ b/dist/kubernetes/components/origin-manager/params.libsonnet
@@ -1,0 +1,13 @@
+{
+  global: {
+    cpu: "100m",
+    memory: "128Mi",
+    cache: "100Mi",
+    image: null,
+    prefix: "origin-manager",
+  },
+  components: {
+    review: {
+    },
+  },
+}

--- a/dist/kubernetes/components/origin-manager/review.jsonnet
+++ b/dist/kubernetes/components/origin-manager/review.jsonnet
@@ -1,0 +1,12 @@
+local params = std.extVar("__ksonnet/params").components.review;
+local review_bot = import '../review_bot.libsonnet';
+
+[
+  review_bot.parts.cache.base(
+    params.prefix, params.cache),
+
+  review_bot.parts.cron.base(
+    params.prefix, "review",
+    "*/5 * * * *", params.cpu, params.memory, params.image,
+     "osrt-origin-manager --debug review"),
+]

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -594,6 +594,7 @@ exit 0
 
 %files origin-manager
 %{_bindir}/osrt-origin-manager
+%{_datadir}/%{source_dir}/origin-manager.py
 %{_unitdir}/osrt-origin-manager.service
 %{_unitdir}/osrt-origin-manager.timer
 


### PR DESCRIPTION
For posterity since lacking proper authentication setup on k8s cluster to allow other release managers access.