### PR TITLE
origin-manager: osc plugin (origin) and report service

### DIFF
--- a/devel-project.py
+++ b/devel-project.py
@@ -117,7 +117,6 @@ def notify(args):
                 maintainer_map.setdefault(userid, set())
                 maintainer_map[userid].add(devel_package_identifier)
 
-    Config(apiurl, args.project) # Ensure mail-* options are loaded for mail_send().
     subject = 'Packages you maintain are present in {}'.format(args.project)
     for userid, package_identifiers in maintainer_map.items():
         email = entity_email(apiurl, userid)
@@ -139,7 +138,7 @@ in charge of the following packages:
 - {}""".format(
             args.project, '\n- '.join(sorted(package_identifiers)))
 
-        mail_send(args.project, email, subject, message, dry=args.dry)
+        mail_send(apiurl, args.project, email, subject, message, dry=args.dry)
         print('notified {} of {} packages'.format(userid, len(package_identifiers)))
 
 def requests(args):

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -296,6 +296,15 @@ Requires:       osc >= 0.159.0
 %description -n osc-plugin-cycle
 OSC plugin for cycle visualization, see `osc cycle --help`.
 
+%package -n osc-plugin-origin
+Summary:        OSC plugin for origin management
+Group:          Development/Tools/Other
+BuildArch:      noarch
+Requires:       osc >= 0.159.0
+
+%description -n osc-plugin-origin
+OSC plugin for for working with origin information, see `osc origin --help`.
+
 %package -n osc-plugin-staging
 Summary:        OSC plugin for the staging workflow
 Group:          Development/Tools/Other
@@ -497,6 +506,7 @@ exit 0
 %exclude %{_datadir}/%{source_dir}/osclib
 %exclude %{_datadir}/%{source_dir}/osc-check_dups.py
 %exclude %{_datadir}/%{source_dir}/osc-cycle.py
+%exclude %{_datadir}/%{source_dir}/osc-origin.py
 %exclude %{_datadir}/%{source_dir}/osc-staging.py
 %exclude %{_datadir}/%{source_dir}/osc-vdelreq.py
 %exclude %{_datadir}/%{source_dir}/update_crawler.py
@@ -667,6 +677,11 @@ exit 0
 %defattr(-,root,root,-)
 %{_datadir}/%{source_dir}/osc-cycle.py
 %{osc_plugin_dir}/osc-cycle.py
+
+%files -n osc-plugin-origin
+%defattr(-,root,root,-)
+%{_datadir}/%{source_dir}/osc-origin.py
+%{osc_plugin_dir}/osc-origin.py
 
 %files -n osc-plugin-staging
 %defattr(-,root,root,-)

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -193,6 +193,7 @@ Summary:        Package origin management tools
 Group:          Development/Tools/Other
 BuildArch:      noarch
 Requires:       osclib = %{version}
+Requires:       osc-plugin-origin = %{version}
 Requires(pre):  shadow
 
 %description origin-manager
@@ -607,6 +608,8 @@ exit 0
 %{_datadir}/%{source_dir}/origin-manager.py
 %{_unitdir}/osrt-origin-manager.service
 %{_unitdir}/osrt-origin-manager.timer
+%{_unitdir}/osrt-origin-manager-report@.service
+%{_unitdir}/osrt-origin-manager-report@.timer
 
 %files repo-checker
 %defattr(-,root,root,-)

--- a/osc-origin.py
+++ b/osc-origin.py
@@ -1,0 +1,203 @@
+import logging
+import os
+import os.path
+from osc import cmdln
+from osc import core
+from osc import oscerr
+from osclib.cache import Cache
+from osclib.cache_manager import CacheManager
+from osclib.core import package_list_without_links
+from osclib.origin import config_load
+from osclib.origin import origin_find
+from osclib.origin import config_origin_list
+from osclib.util import mail_send
+from shutil import copyfile
+import time
+import yaml
+
+OSRT_ORIGIN_LOOKUP_TTL = 60 * 60 * 24 * 7
+
+@cmdln.option('--debug', action='store_true', help='output debug information')
+@cmdln.option('--diff', action='store_true', help='diff against previous report')
+@cmdln.option('--dry', action='store_true', help='perform a dry-run where applicable')
+@cmdln.option('--force-refresh', action='store_true', help='force refresh of data')
+@cmdln.option('--mail', action='store_true', help='mail report to <confg:mail-release-list>')
+@cmdln.option('--origins-only', action='store_true', help='list origins instead of expanded config')
+@cmdln.option('-p', '--project', help='project on which to operate (default is openSUSE:Factory)')
+def do_origin(self, subcmd, opts, *args):
+    """${cmd_name}: tools for working with origin information
+
+    ${cmd_option_list}
+
+    config: print expanded OSRT:OriginConfig
+    list: print all packages and their origin
+    package: print the origin of package
+    report: print origin summary report
+
+    Usage:
+        osc origin config [--origins-only]
+        osc origin list [--force-refresh]
+        osc origin package [--debug] PACKAGE
+        osc origin report [--diff] [--force-refresh] [--mail]
+    """
+
+    if len(args) == 0:
+        raise oscerr.WrongArgs('A command must be indicated.')
+    command = args[0]
+    if command not in ['config', 'list', 'package', 'report']:
+        raise oscerr.WrongArgs('Unknown command: {}'.format(command))
+    if command == 'package' and len(args) < 2:
+        raise oscerr.WrongArgs('A package must be indicated.')
+
+    level = logging.DEBUG if opts.debug else None
+    logging.basicConfig(level=level, format='[%(levelname).1s] %(message)s')
+
+    # Allow for determining project from osc store.
+    if not opts.project:
+        if core.is_project_dir('.'):
+            opts.project = core.store_read_project('.')
+        else:
+            opts.project = 'openSUSE:Factory'
+
+    Cache.init()
+    apiurl = self.get_api_url()
+    config = config_load(apiurl, opts.project)
+    if not config:
+        raise oscerr.WrongArgs('OSRT:OriginConfig attribute missing from {}'.format(opts.project))
+
+    function = 'osrt_origin_{}'.format(command)
+    globals()[function](apiurl, opts, *args[1:])
+
+def osrt_origin_config(apiurl, opts, *args):
+    config = config_load(apiurl, opts.project)
+
+    if opts.origins_only:
+        print('\n'.join(config_origin_list(config)))
+    else:
+        yaml.Dumper.ignore_aliases = lambda *args : True
+        print(yaml.dump(config))
+
+def osrt_origin_lookup_file(previous=False):
+    lookup_name = 'lookup.yaml' if not previous else 'lookup.previous.yaml'
+    cache_dir = CacheManager.directory('origin-manager')
+    return os.path.join(cache_dir, lookup_name)
+
+def osrt_origin_lookup(apiurl, project, force_refresh=False, previous=False):
+    lookup_path = osrt_origin_lookup_file(previous)
+    if not force_refresh and os.path.exists(lookup_path):
+        if not previous and time.time() - os.stat(lookup_path).st_mtime > OSRT_ORIGIN_LOOKUP_TTL:
+            return osrt_origin_lookup(apiurl, project, True)
+
+        with open(lookup_path, 'r') as lookup_stream:
+            lookup = yaml.safe_load(lookup_stream)
+    else:
+        if previous:
+            return None
+
+        packages = package_list_without_links(apiurl, project)
+        logging.debug('{} packages found in {}'.format(len(packages), project))
+
+        lookup = {}
+        for package in packages:
+            lookup[str(package)] = str(origin_find(apiurl, project, package))
+
+        if os.path.exists(lookup_path):
+            lookup_path_previous = osrt_origin_lookup_file(True)
+            copyfile(lookup_path, lookup_path_previous)
+
+        with open(lookup_path, 'w+') as lookup_stream:
+            yaml.dump(lookup, lookup_stream, default_flow_style=False)
+
+    return lookup
+
+def osrt_origin_max_key(dictionary, minimum):
+    return max(len(max(dictionary.keys(), key=len)), minimum)
+
+def osrt_origin_list(apiurl, opts, *args):
+    lookup = osrt_origin_lookup(apiurl, opts.project, opts.force_refresh)
+
+    line_format = '{:<' + str(osrt_origin_max_key(lookup, 7)) + '}  {}'
+    print(line_format.format('package', 'origin'))
+
+    for package, origin in lookup.items():
+        print(line_format.format(package, origin))
+
+def osrt_origin_package(apiurl, opts, *packages):
+    origin_info = origin_find(apiurl, opts.project, packages[0])
+    print(origin_info)
+
+def osrt_origin_report_count(lookup):
+    origin_count = {}
+    for package, origin in lookup.items():
+        origin_count.setdefault(origin, 0)
+        origin_count[origin] += 1
+
+    return origin_count
+
+def osrt_origin_report_count_diff(origin_count, origin_count_previous):
+    origin_count_change = {}
+    for origin, count in origin_count.items():
+        delta = count - origin_count_previous.get(origin, 0)
+        delta = '+' + str(delta) if delta > 0 else str(delta)
+        origin_count_change[origin] = delta
+
+    return origin_count_change
+
+def osrt_origin_report_diff(lookup, lookup_previous):
+    diff = {}
+    for package, origin in lookup.items():
+        origin_previous = lookup_previous.get(package)
+        if origin != origin_previous:
+            diff[package] = (origin, origin_previous)
+
+    return diff
+
+def osrt_origin_report(apiurl, opts, *args):
+    lookup = osrt_origin_lookup(apiurl, opts.project, opts.force_refresh)
+    origin_count = osrt_origin_report_count(lookup)
+
+    columns = ['origin', 'count', 'percent']
+    column_formats = [
+        '{:<' + str(osrt_origin_max_key(origin_count, 6)) + '}',
+        '{:>5}',
+        '{:>7}',
+    ]
+
+    if opts.diff:
+        columns.insert(2, 'change')
+        column_formats.insert(2, '{:>6}')
+
+        lookup_previous = osrt_origin_lookup(apiurl, opts.project, previous=True)
+        if lookup_previous is not None:
+            origin_count_previous = osrt_origin_report_count(lookup_previous)
+            origin_count_change = osrt_origin_report_count_diff(origin_count, origin_count_previous)
+            package_diff = osrt_origin_report_diff(lookup, lookup_previous)
+        else:
+            origin_count_change = {}
+            package_diff = []
+
+    line_format = '  '.join(column_formats)
+    report = [line_format.format(*columns)]
+
+    total = len(lookup)
+    for origin, count in sorted(origin_count.items(), key=lambda x : x[1], reverse=True):
+        values = [origin, count, round(float(count) / total * 100, 2)]
+        if opts.diff:
+            values.insert(2, origin_count_change.get(origin, 0))
+        report.append(line_format.format(*values))
+
+    if opts.diff and len(package_diff):
+        line_format = '{:<' + str(osrt_origin_max_key(package_diff, 7)) + '}  ' + \
+            '  '.join([column_formats[0]] * 2)
+        report.append('')
+        report.append(line_format.format('package', 'origin', 'origin previous'))
+        for package, origins in sorted(package_diff.items()):
+            report.append(line_format.format(package, *origins))
+
+
+    body = '\n'.join(report)
+    print(body)
+
+    if opts.mail:
+        mail_send(apiurl, opts.project, 'release-list', '{} origin report'.format(opts.project),
+                  body, None, dry=opts.dry)

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -309,7 +309,9 @@ def package_list_without_links(apiurl, project):
     url = makeurl(apiurl, ['source', project], query)
     root = ETL.parse(http_GET(url)).getroot()
     return root.xpath(
-        '//sourceinfo[not(./linked[@project="{}"]) and not(contains(@package, ":"))]/@package'.format(project))
+        '//sourceinfo[not(./linked[@project="{}"]) and '
+        'not(contains(@package, ":"))'
+        'and not(starts-with(@package, "00"))]/@package'.format(project))
 
 def attribute_value_load(apiurl, project, name, namespace='OSRT'):
     url = makeurl(apiurl, ['source', project, '_attribute', namespace + ':' + name])

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -43,6 +43,10 @@ OriginInfo = namedtuple('OriginInfo', ['project', 'pending'])
 PendingRequestInfo = namedtuple('PendingRequestInfo', ['identifier', 'reviews_remaining'])
 PolicyResult = namedtuple('PolicyResult', ['wait', 'accept', 'reviews', 'comments'])
 
+def origin_info_str(self):
+    return self.project + ('+' if self.pending else '')
+OriginInfo.__str__ = origin_info_str
+
 @memoize(session=True)
 def config_load(apiurl, project):
     config = attribute_value_load(apiurl, project, 'OriginConfig')

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -164,7 +164,7 @@ def config_resolve_create_workarounds(config, values_workaround, origins_skip):
 def config_resolve_create_family(apiurl, project, config, position, origin, values):
     projects = project_list_family_prior_pattern(apiurl, origin, project)
     for origin_expanded in reversed(projects):
-        config['origins'].insert(position, { origin_expanded: values })
+        config['origins'].insert(position, { str(origin_expanded): values })
 
 def config_resolve_apply(config, values_apply, key=None, workaround=False, until=None):
     for origin, values in config_origin_generator(config['origins']):

--- a/osclib/util.py
+++ b/osclib/util.py
@@ -131,6 +131,8 @@ def mail_send(project, to, subject, body, from_key='maintainer', followup_to_key
     msg['Message-ID'] = email.utils.make_msgid()
     msg['Date'] = email.utils.formatdate(localtime=1)
     msg['From'] = config['mail-{}'.format(from_key)]
+    if '@' not in to:
+        to = config['mail-{}'.format(to)]
     msg['To'] = to
     followup_to = config.get('mail-{}'.format(followup_to_key))
     if followup_to:

--- a/osclib/util.py
+++ b/osclib/util.py
@@ -1,5 +1,6 @@
 from osc import conf
 from osclib.conf import Config
+from osclib.core import entity_email
 from osclib.core import project_list_prefix
 from osclib.memoize import memoize
 
@@ -132,7 +133,10 @@ def mail_send(apiurl, project, to, subject, body, from_key='maintainer',
     msg = MIMEText(body)
     msg['Message-ID'] = email.utils.make_msgid()
     msg['Date'] = email.utils.formatdate(localtime=1)
-    msg['From'] = config['mail-{}'.format(from_key)]
+    if from_key is None:
+        msg['From'] = entity_email(apiurl, conf.get_apiurl_usr(apiurl), include_name=True)
+    else:
+        msg['From'] = config['mail-{}'.format(from_key)]
     if '@' not in to:
         to = config['mail-{}'.format(to)]
     msg['To'] = to

--- a/osclib/util.py
+++ b/osclib/util.py
@@ -1,4 +1,5 @@
 from osc import conf
+from osclib.conf import Config
 from osclib.core import project_list_prefix
 from osclib.memoize import memoize
 
@@ -121,12 +122,13 @@ def project_version(project):
 
     return 0
 
-def mail_send(project, to, subject, body, from_key='maintainer', followup_to_key='release-list', dry=False):
+def mail_send(apiurl, project, to, subject, body, from_key='maintainer',
+              followup_to_key='release-list', dry=False):
     from email.mime.text import MIMEText
     import email.utils
     import smtplib
 
-    config = conf.config[project]
+    config = Config.get(apiurl, project)
     msg = MIMEText(body)
     msg['Message-ID'] = email.utils.make_msgid()
     msg['Date'] = email.utils.formatdate(localtime=1)

--- a/systemd/osrt-origin-manager-report@.service
+++ b/systemd/osrt-origin-manager-report@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=openSUSE Release Tools: origin-manager report for %i
+
+[Service]
+User=osrt-origin-manager
+SyslogIdentifier=osrt-origin-manager
+ExecStart=/usr/bin/osc origin -p "%i" report --diff --force-refresh --mail
+RuntimeMaxSec=12 hour
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/osrt-origin-manager-report@.timer
+++ b/systemd/osrt-origin-manager-report@.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=openSUSE Release Tools: origin-manager report for %i
+
+[Timer]
+OnCalendar=weekly
+Unit=osrt-origin-manager-report@%i.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
- 3a8e54c4b82f2761d2a6d26176d5e8ae81944b6e:
    dist: provide origin-manager report service and timer.

- 6ce6fd46796aa76f58e4a082fed19ec40a1a2894:
    dist/package: provide osc-plugin-origin package.

- 04e9b29f2090765d6f26def572dfa2ff5cb50a01:
    osc-origin: provide initial origin osc subcommand.

- ecb00c7c4c10ed40166eb533401fea0f6f96f6a5:
    osclib/core: package_list_without_links(): ignore meta packages (00 prefix).

- eb1cd60d063d10e7b4b4118494bd17c1ee2e08ad:
    osclib/origin: provide __str__ method that indicates pending.

- 98dc37f56088b7e30b94313a4348061694dceaa3:
    osclib/origin: config_resolve_create_family(): force origin_expanded to string.
    
    Drops the lxml string element reference which is cumbersome when printing.

- 99675253d8035d53b35bcbbef3f4e99bc3ff784c:
    osclib/util: mail_send(): allow a from_key of None to indicate osc user.

- e5bb203ea401a9cedac6efb59bd50038f2433a25:
    osclib/util: mail_send() utilize Config.get() pattern.

- 6fc571dcf39818543549b0d66e3632f6d31d937d:
    osclib/util: mail_send(): use to as config key if no at sign.