### PR TITLE
dist/ci/Dockerfile: change from Tumbleweed to Leap for build host.

### DIFF
--- a/dist/ci/Dockerfile
+++ b/dist/ci/Dockerfile
@@ -1,7 +1,7 @@
 # https://docs.docker.com/engine/reference/builder/
 # Used for TEST_SUITE=distribution and deployment to OBS.
 
-FROM opensuse/tumbleweed
+FROM opensuse/leap
 MAINTAINER Jimmy Berry <jberry@suse.com>
 
 # https://github.com/openSUSE/obs-service-set_version/issues/44 python-packaging


### PR DESCRIPTION
There is no need for Tumbleweed base as only the latest stable osc tools
and openSUSE:Tools packages should be needed. Unlike run-time for
repo-checker which is limited by latest solver stack the distribution
test suite has no need.

Currently, there is a zypper related segfault, #1887, that breaks the
test suite and demonstrates an advantage to switching to Leap.

Fixes #1887.