### PR TITLE
[openqa-maintenance] Add openSUSE Leap 15.1 configuration

### DIFF
--- a/data/apimap.json
+++ b/data/apimap.json
@@ -138,5 +138,10 @@
     "version": "15.0",
     "flavor": "DVD-Incidents",
     "distri": "opensuse"
+  },
+  "openSUSE:Leap:15.1:Update" : {
+    "version": "15.1",
+    "flavor": "DVD-Incidents",
+    "distri": "opensuse"
   }
 }

--- a/data/incidents.json
+++ b/data/incidents.json
@@ -151,5 +151,11 @@
      "FLAVOR": "DVD-Incidents",
      "VERSION": "15.0",
      "ARCH": "x86_64"
+  },
+  "openSUSE:Leap:15.1:Update": {
+     "DISTRI": "opensuse",
+     "FLAVOR": "DVD-Incidents",
+     "VERSION": "15.1",
+     "ARCH": "x86_64"
   }
 }

--- a/data/repos.json
+++ b/data/repos.json
@@ -27,6 +27,20 @@
             "http://download.opensuse.org/update/leap/15.0/oss/",
             "http://download.opensuse.org/update/leap/15.0/non-oss/"
          ]
+      },
+      "openSUSE:Leap:15.1:Update" : {
+         "settings" : {
+            "OS_TEST_ISSUES" : "",
+            "FLAVOR" : "DVD-Updates",
+            "DISTRI" : "opensuse",
+            "VERSION" : "15.1",
+            "ARCH" : "x86_64"
+         },
+         "test" : "kde",
+         "repos" : [
+            "http://download.opensuse.org/update/leap/15.1/oss/",
+            "http://download.opensuse.org/update/leap/15.1/non-oss/"
+         ]
       }
    },
    "https://openqa.suse.de" : {


### PR DESCRIPTION
Tested with

```
./openqa-maintenance.py --dry --debug --review=accept-onpass --group qam-openqa --openqa=https://openqa.opensuse.org review |& grep '\(15.1\|684360\)'
```

which yields

```
DEBUG: openSUSE:Leap:15.1:Update -- product in apimap
DEBUG: Pmap: {'distri': 'opensuse', 'flavor': 'DVD-Incidents', 'version': '15.1'} Posts: []
…
```

but not the test request https://build.opensuse.org/request/show/684360 I have created