### PR TITLE
Replace deprecated (and not advised) yaml.load() with yaml.safe_load().

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -698,7 +698,7 @@ class StagingAPI(object):
 
     def load_prj_pseudometa(self, description_text):
         try:
-            data = yaml.load(description_text)
+            data = yaml.safe_load(description_text)
             if isinstance(data, str) or data is None:
                 data = {}
         except (TypeError, AttributeError):

--- a/totest-manager.py
+++ b/totest-manager.py
@@ -94,7 +94,7 @@ class ToTestBase(object):
     def load_issues_to_ignore(self):
         text = self.api.attribute_value_load('IgnoredIssues')
         if text:
-            root = yaml.load(text)
+            root = yaml.safe_load(text)
             self.issues_to_ignore = root.get('last_seen')
         else:
             self.issues_to_ignore = dict()


### PR DESCRIPTION
The following warning is output:

```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```