### PR TITLE
origin-manager: include origin annotation in comment when waiting.

### DIFF
--- a/origin-manager.py
+++ b/origin-manager.py
@@ -51,6 +51,11 @@ class OriginManager(ReviewBot.ReviewBot):
         if len(result.reviews):
             self.policy_result_reviews_add(project, package, result.reviews)
 
+        if result.wait:
+            # Since the review will not be accepted with the annotation
+            # containing origin context dump it the comment.
+            result.comments.insert(0, origin_annotation_dump(origin_info_new, origin_info_old))
+
         self.policy_result_comment_add(project, package, result.comments)
 
         if result.wait:


### PR DESCRIPTION
A stop-gap to aid in human review until UI exists.

Fixes #1881.