### PR TITLE
origin-manager: miscellaneous improvements.

### DIFF
--- a/osc-origin.py
+++ b/osc-origin.py
@@ -119,7 +119,7 @@ def osrt_origin_list(apiurl, opts, *args):
     line_format = '{:<' + str(osrt_origin_max_key(lookup, 7)) + '}  {}'
     print(line_format.format('package', 'origin'))
 
-    for package, origin in lookup.items():
+    for package, origin in sorted(lookup.items()):
         print(line_format.format(package, origin))
 
 def osrt_origin_package(apiurl, opts, *packages):

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -526,7 +526,8 @@ def package_source_hash(apiurl, project, package, revision=None):
         url = makeurl(apiurl, ['source', project, package], query)
         root = ETL.parse(http_GET(url)).getroot()
     except HTTPError as e:
-        if e.code == 404:
+        if e.code == 400 or e.code == 404:
+            # 400: revision not found, 404: package not found.
             return None
 
         raise e

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -417,7 +417,7 @@ def policy_input_evaluate(policy, inputs):
 
     if inputs['new_package']:
         if policy['maintainer_review_initial']:
-            result.reviews['maintainer'] = 'Need package maintainer approval for inital submission.'
+            result.reviews['maintainer'] = 'Need package maintainer approval for initial submission.'
 
         if not inputs['from_highest_priority']:
             result.reviews['fallback'] = 'Not from the highest priority origin which provides the package.'

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -459,7 +459,8 @@ def policy_input_evaluate(policy, inputs):
         result.reviews['maintainer'] = 'Need package maintainer approval.'
 
     for additional_review in policy['additional_reviews']:
-        result.reviews[additional_review] = 'Additional review required based on origin.'
+        if additional_review not in result.reviews:
+            result.reviews[additional_review] = 'Additional review required based on origin.'
 
     return result
 


### PR DESCRIPTION
- 42cca7a134e1445177df3c620f16444931ecab51:
    osclib/origin: policy_input_calculate(): s/inital/initial/.

- 613227c7013a3726940fec78c7029092e2e250ab:
    origin-manager: policy_result_handle(): denote annotation dump as preformatted.

- 8cdc99c1beef4865ccf63013598b322b1549de87:
    osc-origin: list: sort by package name.

- b6866e6456fc54459402660576ed619074e154e6:
    osclib/origin: policy_input_evaluate(): only add additional review if not already set.
    
    This allows for more cleanly adding additional_reviews to include fallback
    review where it may already be added for a more specific reason.

- 07ecf7b2504a87f6c6b9fdc78bee34a0f0296fe5:
    osclib/core: package_source_hash(): handle non-existant revision.