### PR TITLE
origin-manager: expose osc-plugin-origin commands via operator and provide initial supplementary interface.

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -214,6 +214,7 @@ Requires(pre):  shadow
 Summary:        Server used to perform staging operations
 Group:          Development/Tools/Other
 BuildArch:      noarch
+Requires:       osc-plugin-origin = %{version}
 Requires:       osc-plugin-staging = %{version}
 Requires(pre):  shadow
 

--- a/osc-origin.py
+++ b/osc-origin.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from datetime import timedelta
 import logging
 import os
 import os.path
@@ -12,6 +14,7 @@ from osclib.origin import origin_find
 from osclib.origin import config_origin_list
 from osclib.util import mail_send
 from shutil import copyfile
+import sys
 import time
 import yaml
 
@@ -110,6 +113,10 @@ def osrt_origin_lookup(apiurl, project, force_refresh=False, previous=False):
 
         with open(lookup_path, 'w+') as lookup_stream:
             yaml.dump(lookup, lookup_stream, default_flow_style=False)
+
+    if not previous:
+        dt = timedelta(seconds=time.time() - os.stat(lookup_path).st_mtime)
+        print('# generated {} ago'.format(dt), file=sys.stderr)
 
     return lookup
 

--- a/osc-origin.py
+++ b/osc-origin.py
@@ -77,13 +77,16 @@ def osrt_origin_config(apiurl, opts, *args):
         yaml.Dumper.ignore_aliases = lambda *args : True
         print(yaml.dump(config))
 
-def osrt_origin_lookup_file(previous=False):
-    lookup_name = 'lookup.yaml' if not previous else 'lookup.previous.yaml'
+def osrt_origin_lookup_file(project, previous=False):
+    parts = [project, 'yaml']
+    if previous:
+        parts.insert(1, 'previous')
+    lookup_name = '.'.join(parts)
     cache_dir = CacheManager.directory('origin-manager')
     return os.path.join(cache_dir, lookup_name)
 
 def osrt_origin_lookup(apiurl, project, force_refresh=False, previous=False):
-    lookup_path = osrt_origin_lookup_file(previous)
+    lookup_path = osrt_origin_lookup_file(project, previous)
     if not force_refresh and os.path.exists(lookup_path):
         if not previous and time.time() - os.stat(lookup_path).st_mtime > OSRT_ORIGIN_LOOKUP_TTL:
             return osrt_origin_lookup(apiurl, project, True)
@@ -102,7 +105,7 @@ def osrt_origin_lookup(apiurl, project, force_refresh=False, previous=False):
             lookup[str(package)] = str(origin_find(apiurl, project, package))
 
         if os.path.exists(lookup_path):
-            lookup_path_previous = osrt_origin_lookup_file(True)
+            lookup_path_previous = osrt_origin_lookup_file(project, True)
             copyfile(lookup_path, lookup_path_previous)
 
         with open(lookup_path, 'w+') as lookup_stream:

--- a/userscript/README.md
+++ b/userscript/README.md
@@ -2,6 +2,10 @@
 
 The scripts may be installed in one's browser using the Tampermonkey extension to provide additional features using OBS via the web. After installing the extension simply click on the link for the desired script below to install it. Any scripts that provide an interface for making changes depend on the user being logged in to the OBS instance with a user with the appropriate permissions to complete the task.
 
+- [Origin](https://github.com/openSUSE/openSUSE-release-tools/raw/master/userscript/origin.js)
+
+  Supplement OBS interface with origin information. When viewing a package on OBS (`/package/show/$PACKAGE`) the origin information will be added to the links in the top right.
+
 - [Staging Move Drag-n-Drop](https://github.com/openSUSE/openSUSE-release-tools/raw/master/userscript/staging-move-drag-n-drop.user.js)
 
   Provides a drag-n-drop interface for moving requests between stagings using the staging dashboard. The staging dashboard can be found by visiting `/project/staging_projects/$PROJECT` on the relevant OBS instance where `$PROJECT` is the target project for the stagings (ex. `openSUSE:Factory` or `SUSE:SLE-15-SP1:GA`).

--- a/userscript/origin.js
+++ b/userscript/origin.js
@@ -1,0 +1,26 @@
+// ==UserScript==
+// @name         OSRT Origin
+// @namespace    openSUSE/openSUSE-release-tools
+// @version      0.1.0
+// @description  Supplement OBS interface with origin information.
+// @author       Jimmy Berry
+// @match        */package/show/*
+// @require      https://code.jquery.com/jquery-3.3.1.min.js
+// @grant        none
+// ==/UserScript==
+
+(function()
+{
+    var pathParts = window.location.pathname.split('/');
+    var project = pathParts[pathParts.length - 2];
+    var package = pathParts[pathParts.length - 1];
+
+    var domain_parent = window.location.hostname.split('.').splice(1).join('.');
+    var subdomain = domain_parent.endsWith('suse.de') ? 'tortuga' : 'operator';
+    var url = 'https://' + subdomain + '.' + domain_parent + '/origin/package/' + project + '/' + package;
+
+    $.get(url, function(origin) {
+        if (origin.endsWith('failed')) return;
+        $('ul.clean_list, ul.list-unstyled').append('<li>Origin: <a href="/package/show/' + origin + '/' + package + '">' + origin + '</a>');
+    })
+})();


### PR DESCRIPTION
- ca687d4089bcbc2f82e8a4c50f2719eb4a4ce72f:
    userscript/origin: provide initial supplementary interface.

- 0734bf756c55df56fe61e2c2c3b6544b2e217dbb:
    obs_operator: expose osc-plugin-origin commands via GET.

- 2c45688f2f2a6f6f0dc829ce913b7317a6a0fc06:
    obs_operator: extract osc environment setup as with object.

- 3293a24a894fdf4350d35a749fac8c79f13988d4:
    osc-origin: osrt_origin_lookup(): print time since generated.

- d5dff4d15c01513b67568be31f9664c3f84bdbf3:
    osc-origin: osrt_origin_lookup_file(): include project in cache file name.

No frills supplementary interface that makes use of operator server. Can expand OBS overlay JS to provide links to overall origin list and report, etc.

![image](https://user-images.githubusercontent.com/22943929/54727340-41c88e00-4b45-11e9-9399-647cc0da6d56.png)

![image](https://user-images.githubusercontent.com/22943929/54727363-67ee2e00-4b45-11e9-8c2c-f55fd5eaed38.png)

The "UI" as referred to will use the same basic format of querying the operator sever origin data paths, but will require additional information to be exposed.