### PR TITLE
userscript/origin: use cross-domain request with credentials.

### DIFF
--- a/userscript/origin.js
+++ b/userscript/origin.js
@@ -19,8 +19,8 @@
     var subdomain = domain_parent.endsWith('suse.de') ? 'tortuga' : 'operator';
     var url = 'https://' + subdomain + '.' + domain_parent + '/origin/package/' + project + '/' + package;
 
-    $.get(url, function(origin) {
+    $.get({url: url, crossDomain: true, xhrFields: {withCredentials: true}, success: function(origin) {
         if (origin.endsWith('failed')) return;
         $('ul.clean_list, ul.list-unstyled').append('<li>Origin: <a href="/package/show/' + origin + '/' + package + '">' + origin + '</a>');
-    })
+    }});
 })();


### PR DESCRIPTION
Otherwise, requests are denied with not running operator server in development mode. This is the same behavior used by drag-n-drop selects, just overlooked.