### PR TITLE
obs_operator: improve robustness

### DIFF
--- a/obs_operator.py
+++ b/obs_operator.py
@@ -98,12 +98,12 @@ class RequestHandler(BaseHTTPRequestHandler):
         if self.apiurl:
             return self.apiurl
 
-        origin = self.headers.get('Origin')
-        if not origin:
+        host = self.headers.get('Host')
+        if not host:
             return None
 
         # Strip port if present.
-        domain = urlparse(origin).netloc.split(':', 2)[0]
+        domain = host.split(':', 2)[0]
         if '.' not in domain:
             return None
 


### PR DESCRIPTION
- 2a3def39fd589be32652ba63b339d378a144e753:
    obs_operator: verify that origin root-domain matches host domain.
    
    Reduces the attack surface by limiting sites that can initiate a
    cross-domain request to sub-domains of the domain on which the operator
    server is running.

- d3ff38cbf8edd16b1b28cd72fbffd1998a99f643:
    obs_operator: raise exceptions when osc request environment cannot be aquired.

- cdb99a1f1a57c6de5d07c2be952253e2600f00a4:
    obs_operator: calculate apiurl from host instead of origin header.
    
    Debated originally, but was attempting to allow operator to run on
    different domain from request origin and handle multiple origins. This
    does not work in practice since openSUSE and SUSE https certs are not
    present on same machine. As such, host works better since it allows for
    non-cross-origin requests to work without having to specify an apiurl
    in startup arguments.