### PR TITLE
obs_operator: provide cache volume and origin-manager report cron.

### DIFF
--- a/dist/kubernetes/components/obs-operator/origin_manager_report.jsonnet
+++ b/dist/kubernetes/components/obs-operator/origin_manager_report.jsonnet
@@ -1,0 +1,10 @@
+local params = std.extVar("__ksonnet/params").components.origin_manager_report;
+local review_bot = import '../review_bot.libsonnet';
+
+[
+  review_bot.parts.cron.base(
+    params.prefix, "report-" + std.asciiLower(std.strReplace(project, ":", "-")),
+    "0 0 * * 0,2,4", params.cpu, params.memory, params.image,
+    "osc origin -p '" + project + "' report --force-refresh")
+  for project in params.projects
+]

--- a/dist/kubernetes/components/obs-operator/params.libsonnet
+++ b/dist/kubernetes/components/obs-operator/params.libsonnet
@@ -1,5 +1,6 @@
 {
   global: {
+    cache: "500Mi",
     cpu: "100m",
     memory: "128Mi",
     image: null,

--- a/dist/kubernetes/components/obs-operator/params.libsonnet
+++ b/dist/kubernetes/components/obs-operator/params.libsonnet
@@ -11,5 +11,8 @@
       externalIPs: null,
       externalPort: null,
     },
+    origin_manager_report: {
+      projects: [],
+    },
   },
 }

--- a/dist/kubernetes/components/obs-operator/service.jsonnet
+++ b/dist/kubernetes/components/obs-operator/service.jsonnet
@@ -8,7 +8,7 @@ local service = import '../service.libsonnet';
   service.parts.deployment.base(
     params.prefix, "deployment",
     params.cpu, params.memory, params.image,
-     "osrt-obs_operator --debug"),
+     "osrt-obs_operator"),
 
   service.parts.service.base(
     params.prefix, "service", 8080, params.externalIPs, params.externalPort,

--- a/dist/kubernetes/components/obs-operator/service.jsonnet
+++ b/dist/kubernetes/components/obs-operator/service.jsonnet
@@ -2,6 +2,9 @@ local params = std.extVar("__ksonnet/params").components.service;
 local service = import '../service.libsonnet';
 
 [
+  service.parts.cache.base(
+    params.prefix, params.cache),
+
   service.parts.deployment.base(
     params.prefix, "deployment",
     params.cpu, params.memory, params.image,

--- a/dist/kubernetes/components/service.libsonnet
+++ b/dist/kubernetes/components/service.libsonnet
@@ -1,5 +1,23 @@
 {
   parts:: {
+    cache:: {
+      base(prefix, capacity):: {
+        apiVersion: "v1",
+        kind: "PersistentVolumeClaim",
+        metadata: {
+          name: prefix + "-pvc",
+        },
+        spec: {
+          accessModes: ["ReadWriteMany"],
+          resources: {
+            requests: {
+              storage: capacity,
+            }
+          }
+        }
+      }
+    },
+
     deployment:: {
       base(prefix, name, cpu, memory, image, command):: {
         apiVersion: "apps/v1",
@@ -37,6 +55,10 @@
                     mountPath: "/secret",
                     readOnly: true,
                   },
+                  {
+                    name: "cache",
+                    mountPath: "/root/.cache",
+                  },
                 ],
                 resources: {
                   requests: {
@@ -50,6 +72,12 @@
                   name: "oscrc",
                   secret: {
                     secretName: prefix + "-oscrc",
+                  }
+                },
+                {
+                  name: "cache",
+                  persistentVolumeClaim: {
+                    claimName: prefix + "-pvc"
                   }
                 },
               ],

--- a/dist/kubernetes/environments/heroes/params.libsonnet
+++ b/dist/kubernetes/environments/heroes/params.libsonnet
@@ -10,6 +10,11 @@ local envParams = params + {
       ],
       externalPort: 31452,
     },
+    "obs-operator.origin_manager_report"+: {
+      projects: [
+        "openSUSE:Leap:15.1",
+      ],
+    },
     "repo-checker.project_only"+: {
       projects: [
         "openSUSE:Factory",


### PR DESCRIPTION
- 8f53d66594f35c7ee06d4321afec3066ba30458e:
    dist/k8s: drop --debug flag from obs_operator service.

- 9fbab1b87eaeb4632ff2e1a055f058dd32720977:
    dist/k8s: provide obs_operator origin-manager report sub component.
    
    Refreshes origin information 3 days a week for quick serving from cache.

- 9d1264390c7ceba52dc3820bc0629ce9cbe9efdb:
    dist/k8s: add service cache to obs_operator.

- 8912b660c5900ac1c6f750518b56d37882940cfb:
    dist/k8s: provide service level cache similar to reviewbot cache.