### PR TITLE
ReviewBot: handle any exception raised by check_one_request().

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -179,7 +179,13 @@ class ReviewBot(object):
             if override is not None:
                 good = override
             else:
-                good = self.check_one_request(req)
+                try:
+                    good = self.check_one_request(req)
+                except:
+                    good = None
+
+                    import traceback
+                    traceback.print_exc()
 
             if self.review_mode == 'no':
                 good = None


### PR DESCRIPTION
Prevents a single failure from stopping all reviews.

```diff
diff --git a/origin-manager.py b/origin-manager.py
index 952da66b..c44e68b8 100755
--- a/origin-manager.py
+++ b/origin-manager.py
@@ -18,6 +18,7 @@ class OriginManager(ReviewBot.ReviewBot):
         self.override_allow = False
 
     def check_source_submission(self, src_project, src_package, src_rev, tgt_project, tgt_package):
+        raise Exception('caboom')
         if not self.config_validate(tgt_project):
             return False
 
```

```
$ ./origin-manager.py --dry --debug id 688427
[I] checking 688427
Traceback (most recent call last):
  File "/home/jberry/openSUSE-release-tools/ReviewBot.py", line 183, in check_requests
    good = self.check_one_request(req)
  File "/home/jberry/openSUSE-release-tools/ReviewBot.py", line 375, in check_one_request
    ret = func(req, a)
  File "/home/jberry/openSUSE-release-tools/ReviewBot.py", line 456, in check_action_submit
    return self.check_source_submission(a.src_project, a.src_package, a.src_rev, a.tgt_project, a.tgt_package)
  File "./origin-manager.py", line 21, in check_source_submission
    raise Exception('caboom')
Exception: caboom
[I] 688427 ignored
```

Fixes #1934.
Fixes #1929.