### PR TITLE
osc-staging: exclude NonFree requests from staging proposals.

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -547,7 +547,7 @@ def do_staging(self, subcmd, opts, *args):
                     print('--move and --filter-from must be used with explicit staging and request list')
                     return
 
-                open_requests = api.get_open_requests({'withhistory': 1})
+                open_requests = api.get_open_requests({'withhistory': 1}, include_nonfree=False)
                 if len(open_requests) == 0:
                     print('No open requests to consider')
                     return

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -633,7 +633,7 @@ class StagingAPI(object):
         self.pseudometa_file_ensure('ignored_requests', ignore)
 
     @memoize(session=True, add_invalidate=True)
-    def get_open_requests(self, query_extra=None):
+    def get_open_requests(self, query_extra=None, include_nonfree=True):
         """
         Get all requests with open review for staging project
         that are not yet included in any staging project
@@ -645,7 +645,7 @@ class StagingAPI(object):
         # xpath query, using the -m, -r, -s options
         where = "@by_group='{}' and @state='new'".format(self.cstaging_group)
         projects = [format(self.project)]
-        if self.cnonfree:
+        if include_nonfree and self.cnonfree:
             projects.append(self.cnonfree)
         targets = ["target[@project='{}']".format(p) for p in projects]
 


### PR DESCRIPTION
- NonFree delete requests are never staged.
- NonFree submit requests are handled by adi command.

Fixes #1932.