### PR TITLE
Improve error msg that the project was not frozen

### DIFF
--- a/osclib/freeze_command.py
+++ b/osclib/freeze_command.py
@@ -5,6 +5,7 @@ import time
 import re
 from xml.etree import cElementTree as ET
 
+MAX_FROZEN_AGE = 6.5
 
 class FreezeCommand(object):
 

--- a/osclib/select_command.py
+++ b/osclib/select_command.py
@@ -6,6 +6,7 @@ from osc import oscerr
 from osc.core import http_GET
 
 from osclib.request_finder import RequestFinder
+from osclib.freeze_command import MAX_FROZEN_AGE
 # from osclib.freeze_command import FreezeCommand
 
 
@@ -122,7 +123,8 @@ class SelectCommand(object):
 
         # If the project is not frozen enough yet freeze it
         if not (no_freeze or self.api.prj_frozen_enough(self.target_project)):
-            print('Freeze the prj first')
+            print('Project needs to be frozen or there was no change for last %d days.' % MAX_FROZEN_AGE)
+            print('Please freeze the project or use an option to ignore the time from the last freee.')
             return False
             # FreezeCommand(self.api).perform(self.target_project)
 

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -56,6 +56,7 @@ from osclib.core import source_file_load
 from osclib.comments import CommentAPI
 from osclib.ignore_command import IgnoreCommand
 from osclib.memoize import memoize
+from osclib.freeze_command import MAX_FROZEN_AGE
 
 
 class StagingAPI(object):
@@ -1392,7 +1393,7 @@ class StagingAPI(object):
             return True  # already has content
 
         # young enough
-        if self.days_since_last_freeze(project) < 6.5:
+        if self.days_since_last_freeze(project) < MAX_FROZEN_AGE:
             return True
 
         return False


### PR DESCRIPTION
This change is trying to provide user more information
in case that he already froze project but date of last
freeze was not updated, since there were no changes for
last MAX_FROZEN_AGE days.

* Use osclib.freeze_command.MAX_FROZEN_AGE constant
* Avoid explicit proposal of --no-freeze bug suggest alternative