### PR TITLE
Add option to release image_products into a separate repo

### DIFF
--- a/ttm/publisher.py
+++ b/ttm/publisher.py
@@ -321,3 +321,8 @@ class ToTestPublisher(ToTestManager):
         self.api.switch_flag_in_prj(
             self.project.test_project, flag='publish', state='enable',
             repository=self.project.product_repo)
+
+        if self.project.totest_images_repo != self.project.product_repo:
+            self.logger.info('Publish test project content (image_products)')
+            self.api.switch_flag_in_prj(self.project.test_project, flag='publish', state='enable',
+            repository=self.project.totest_images_repo)

--- a/ttm/releaser.py
+++ b/ttm/releaser.py
@@ -220,7 +220,9 @@ class ToTestReleaser(ToTestManager):
 
         for image in self.project.image_products:
             self.release_package(self.project.name, image.package, set_release=set_release,
-                                  repository=self.project.product_repo)
+                                 repository=self.project.product_repo,
+                                 target_project=self.project.test_project,
+                                 target_repository=self.project.totest_images_repo)
 
     def update_totest(self, snapshot=None):
         # omit snapshot, we don't want to rename on release
@@ -231,5 +233,9 @@ class ToTestReleaser(ToTestManager):
         if not (self.dryrun or self.project.do_not_release):
             self.api.switch_flag_in_prj(self.project.test_project, flag='publish', state='disable',
                                         repository=self.project.product_repo)
+
+            if self.project.totest_images_repo != self.project.product_repo:
+                self.api.switch_flag_in_prj(self.project.test_project, flag='publish', state='disable',
+                repository=self.project.totest_images_repo)
 
         self._release(set_release=release)

--- a/ttm/totest.py
+++ b/ttm/totest.py
@@ -37,6 +37,8 @@ class ToTest(object):
         self.product_arch = 'local'
         self.livecd_repo = 'images'
         self.totest_container_repo = 'containers'
+        # Repo for image_products. If not set, uses product_repo.
+        self.totest_images_repo = None
 
         self.main_products = []
         self.ftp_products = []
@@ -58,6 +60,10 @@ class ToTest(object):
                 self.set_products(value)
             else:
                 setattr(self, key, value)
+
+        # Set default for totest_images_repo
+        if self.totest_images_repo is None:
+            self.totest_images_repo = self.product_repo
 
     def parse_images(self, products):
         parsed = []


### PR DESCRIPTION
totest_images_repo defaults to product_repo if unset.
That's not exactly the same behaviour as before (following the releasetarget),
but should cover all current projects.