### PR TITLE
Add small OBS instance without data

### DIFF
--- a/dist/ci/miniobs/BSConfig.pm.patch
+++ b/dist/ci/miniobs/BSConfig.pm.patch
@@ -1,0 +1,21 @@
+--- /usr/lib/obs/server/BSConfig.pm.back       2019-04-30 06:21:39.000000000 +0000
++++ /usr/lib/obs/server/BSConfig.pm    2019-04-30 06:32:04.000000000 +0000
+@@ -34,3 +34,3 @@
+ # If defined, restrict access to the backend servers (bs_repserver, bs_srcserver, bs_service)
+-our $ipaccess = {
++our $removed_ipaccess  = {
+    '^::1$' => 'rw',    # only the localhost can write to the backend
+@@ -48,5 +48,5 @@
+ # Change also the SLP reg files in /etc/slp.reg.d/ when you touch hostname or port
+-our $srcserver = "http://$hostname:5352";
+-our $reposerver = "http://$hostname:5252";
+-our $serviceserver = "http://$hostname:5152";
++our $srcserver = "http://srcserver:5352";
++our $reposerver = "http://repserver:5252";
++our $serviceserver = "http://serviceserver:5152";
+ our $clouduploadserver = "http://$hostname:5452"; 
+@@ -226,3 +226,3 @@
+ # enable service dispatcher
+-our $servicedispatch = 1;
++our $servicedispatch = 0;
+ # max of 4 parallel running services (default)

--- a/dist/ci/miniobs/Dockerfile
+++ b/dist/ci/miniobs/Dockerfile
@@ -1,0 +1,31 @@
+#!BuildTag: osrt_miniobs
+FROM opensuse-leap-15.0:current
+
+RUN zypper ar http://download.opensuse.org/repositories/OBS:/Server:/Unstable/openSUSE_15.0/ 'O:S:U'; \
+    zypper --gpg-auto-import-keys refresh
+
+RUN zypper install -y obs-api obs-worker obs-server \
+    ca-certificates patch vim vim-data psmisc timezone \
+    glibc-locale aaa_base aaa_base-extras netcat net-tools
+
+COPY database.yml.local /srv/www/obs/api/config/database.yml
+
+RUN /usr/lib/mysql/mysql-systemd-helper install ;\
+    sed -e 's,127.0.0.1,0.0.0.0,' -i /etc/my.cnf ;\
+    sed -e 's,server-id,skip-grant-tables,' -i /etc/my.cnf ;\
+    /usr/lib/mysql/mysql-systemd-helper start & \
+    /usr/lib/mysql/mysql-systemd-helper wait ;\
+    /usr/bin/mysql -u root -e "SELECT @@version; CREATE USER 'root'@'%' IDENTIFIED BY 'opensuse'; GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;" ;\
+    chroot --userspec=wwwrun / /bin/bash -c "cd /srv/www/obs/api && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 RAILS_ENV=production bundle exec rails db:create db:setup" ;\
+    mysqladmin shutdown
+
+COPY config.yml   /srv/www/obs/api/config/options.yml
+COPY database.yml /srv/www/obs/api/config/database.yml
+
+RUN sed -i -e 's,\(config.public_file_server.enabled\).*,\1 = true,; s,\(config.log_level\).*,\1 = :debug,' \
+    /srv/www/obs/api/config/environments/production.rb
+RUN rm -f /srv/www/obs/api/tmp/pids/server.pid
+
+COPY BSConfig.pm.patch /tmp
+RUN patch /usr/lib/obs/server/BSConfig.pm /tmp/BSConfig.pm.patch
+

--- a/dist/ci/miniobs/config.yml
+++ b/dist/ci/miniobs/config.yml
@@ -1,0 +1,5 @@
+production:
+  source_host: srcserver
+  source_port: 5352
+  memcached_host: cache
+

--- a/dist/ci/miniobs/database.yml
+++ b/dist/ci/miniobs/database.yml
@@ -1,0 +1,11 @@
+production:
+  adapter: mysql2
+  database: obs_production
+  username: root
+  host: db
+  password: opensuse
+  encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
+  timeout: 15
+  pool: 30
+

--- a/dist/ci/miniobs/database.yml.local
+++ b/dist/ci/miniobs/database.yml.local
@@ -1,0 +1,11 @@
+production:
+  adapter: mysql2
+  database: obs_production
+  host: localhost
+  username: root
+  password: opensuse
+  encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
+  timeout: 15
+  pool: 30
+

--- a/dist/ci/miniobs/docker-compose.yml
+++ b/dist/ci/miniobs/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.7"
+
+x-obs: &obs
+  image: registry.opensuse.org/opensuse/tools/images/containers/osrt_miniobs:latest
+  volumes:
+    - ".:/code"
+
+services:
+  db:
+    <<: *obs
+    command: /usr/lib/mysql/mysql-systemd-helper start
+  cache:
+    <<: *obs
+    command: /usr/sbin/memcached -u memcached
+  api:
+    <<: *obs
+    command: chroot --userspec=wwwrun / /bin/bash -c "cd /srv/www/obs/api && /usr/bin/bundle exec rails s -e production"
+    ports:
+      - "3737:3000"
+    depends_on:
+      - db
+      - cache
+      - srcserver
+      - repserver
+      - servicedispatch
+  srcserver:
+    <<: *obs
+    command: chroot --userspec=obsrun / /usr/lib/obs/server/bs_srcserver
+  repserver:
+    <<: *obs
+    command: chroot --userspec=obsrun / /usr/lib/obs/server/bs_repserver
+  servicedispatch:
+    <<: *obs
+    command: chroot --userspec=obsrun / /usr/lib/obs/server/bs_servicedispatch


### PR DESCRIPTION
The default user is Admin:opensuse and the docker compose opens only one port at 3737 running the api/webui

This can be used for CI on sources or to build against it with osc (if you add interconnect project), but it won't build packages

Cherry picked from #1963 to avoid the chick-egg problem, I already created the OBS project