### PR TITLE
origin-manager: provide web interface to aid in maintenance and decision making

### DIFF
--- a/dist/ci/flake-extra
+++ b/dist/ci/flake-extra
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Should never contain references to products.
-! grep -iP 'leap|factory|sle' origin-manager.py osclib/origin.py
+! grep -iP 'leap|factory|sle' origin-manager.py osc-origin.py osclib/origin.py

--- a/obs_operator.py
+++ b/obs_operator.py
@@ -293,7 +293,7 @@ class OSCRequestEnvironment(object):
     def __enter__(self):
         apiurl = self.handler.apiurl_get()
         origin_domain = self.handler.origin_domain_get()
-        if not apiurl or (origin_domain and not apiurl.endswith(origin_domain)):
+        if not apiurl or (not self.handler.apiurl and origin_domain and not apiurl.endswith(origin_domain)):
             self.handler.send_response(400)
             self.handler.end_headers()
             if not apiurl:

--- a/obs_operator.py
+++ b/obs_operator.py
@@ -34,6 +34,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         'package/diff',
     ]
     POST_PATHS = [
+        'request/submit',
         'staging/select',
     ]
 
@@ -261,6 +262,16 @@ class RequestHandler(BaseHTTPRequestHandler):
 
     def handle_package_diff(self, args, query):
         return ['osc', 'rdiff', args[0], args[1], args[2]]
+
+    def handle_request_submit(self, args, query, data):
+        command = ['osc', 'sr', args[0], args[1], args[2]]
+        command.append('-m')
+        if 'message' in query and query['message'][0]:
+            command.append(query['message'][0])
+        else:
+            command.append('created via operator')
+        command.append('--yes')
+        return [command]
 
     def staging_command(self, project, subcommand):
         return ['osc', 'staging', '-p', project, subcommand]

--- a/obs_operator.py
+++ b/obs_operator.py
@@ -197,6 +197,18 @@ class RequestHandler(BaseHTTPRequestHandler):
     def write_string(self, string):
         self.wfile.write(string.encode('utf-8'))
 
+    def command_format_add(self, command, query):
+        format = None
+        if self.headers.get('Accept'):
+            format = self.headers.get('Accept').split('/', 2)[1]
+            if format != 'json' and format != 'yaml':
+                format = None
+        if not format and 'format' in query:
+            format = query['format'][0]
+        if format:
+            command.append('--format')
+            command.append(format)
+
     def handle_origin_config(self, args, query):
         command = ['osc', 'origin', '-p', args[0], 'config']
         if 'origins-only' in query:
@@ -207,6 +219,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         command = ['osc', 'origin', '-p', args[0], 'list']
         if 'force-refresh' in query:
             command.append('--force-refresh')
+        self.command_format_add(command, query)
         return command
 
     def handle_origin_package(self, args, query):

--- a/obs_operator.py
+++ b/obs_operator.py
@@ -31,6 +31,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         'origin/potentials',
         'origin/projects',
         'origin/report',
+        'package/diff',
     ]
     POST_PATHS = [
         'staging/select',
@@ -257,6 +258,9 @@ class RequestHandler(BaseHTTPRequestHandler):
         if 'force-refresh' in query:
             command.append('--force-refresh')
         return command
+
+    def handle_package_diff(self, args, query):
+        return ['osc', 'rdiff', args[0], args[1], args[2]]
 
     def staging_command(self, project, subcommand):
         return ['osc', 'staging', '-p', project, subcommand]

--- a/obs_operator.py
+++ b/obs_operator.py
@@ -29,6 +29,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         'origin/list',
         'origin/package',
         'origin/potentials',
+        'origin/projects',
         'origin/report',
     ]
     POST_PATHS = [
@@ -244,6 +245,11 @@ class RequestHandler(BaseHTTPRequestHandler):
         self.command_format_add(command, query)
         if len(args) > 1:
             command.append(args[1])
+        return command
+
+    def handle_origin_projects(self, args, query):
+        command = ['osc', 'origin', 'projects']
+        self.command_format_add(command, query)
         return command
 
     def handle_origin_report(self, args, query):

--- a/obs_operator.py
+++ b/obs_operator.py
@@ -28,6 +28,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         'origin/history',
         'origin/list',
         'origin/package',
+        'origin/potentials',
         'origin/report',
     ]
     POST_PATHS = [
@@ -234,6 +235,13 @@ class RequestHandler(BaseHTTPRequestHandler):
         command = ['osc', 'origin', '-p', args[0], 'package']
         if 'debug' in query:
             command.append('--debug')
+        if len(args) > 1:
+            command.append(args[1])
+        return command
+
+    def handle_origin_potentials(self, args, query):
+        command = ['osc', 'origin', '-p', args[0], 'potentials']
+        self.command_format_add(command, query)
         if len(args) > 1:
             command.append(args[1])
         return command

--- a/obs_operator.py
+++ b/obs_operator.py
@@ -25,6 +25,7 @@ class RequestHandler(BaseHTTPRequestHandler):
     COOKIE_NAME = 'openSUSE_session' # Both OBS and IBS.
     GET_PATHS = [
         'origin/config',
+        'origin/history',
         'origin/list',
         'origin/package',
         'origin/report',
@@ -213,6 +214,13 @@ class RequestHandler(BaseHTTPRequestHandler):
         command = ['osc', 'origin', '-p', args[0], 'config']
         if 'origins-only' in query:
             command.append('--origins-only')
+        return command
+
+    def handle_origin_history(self, args, query):
+        command = ['osc', 'origin', '-p', args[0], 'history']
+        self.command_format_add(command, query)
+        if len(args) > 1:
+            command.append(args[1])
         return command
 
     def handle_origin_list(self, args, query):

--- a/obs_operator.py
+++ b/obs_operator.py
@@ -111,6 +111,8 @@ class RequestHandler(BaseHTTPRequestHandler):
             self.write_string(str(e))
 
     def data_parse(self):
+        if int(self.headers['Content-Length']) == 0:
+            return {}
         data = self.rfile.read(int(self.headers['Content-Length']))
         return json.loads(data.decode('utf-8'))
 

--- a/obs_operator.py
+++ b/obs_operator.py
@@ -33,6 +33,15 @@ class RequestHandler(BaseHTTPRequestHandler):
         'staging/select',
     ]
 
+    def do_OPTIONS(self):
+        try:
+            with OSCRequestEnvironment(self) as oscrc_file:
+                self.send_header('Access-Control-Allow-Methods', 'GET, POST')
+                self.send_header('Access-Control-Allow-Headers', 'Access-Control-Allow-Origin, Content-Type, X-Requested-With')
+        except OSCRequestEnvironmentException as e:
+            self.send_header('Allow', 'OPTIONS, GET, POST')
+        self.end_headers()
+
     def do_GET(self):
         url_parts = urlparse(self.path)
 

--- a/osc-origin.py
+++ b/osc-origin.py
@@ -33,7 +33,7 @@ OSRT_ORIGIN_LOOKUP_TTL = 60 * 60 * 24 * 7
 @cmdln.option('--format', default='plain', help='output format')
 @cmdln.option('--mail', action='store_true', help='mail report to <confg:mail-release-list>')
 @cmdln.option('--origins-only', action='store_true', help='list origins instead of expanded config')
-@cmdln.option('-p', '--project', help='project on which to operate (default is openSUSE:Factory)')
+@cmdln.option('-p', '--project', help='project on which to operate')
 def do_origin(self, subcmd, opts, *args):
     """${cmd_name}: tools for working with origin information
 
@@ -66,15 +66,14 @@ def do_origin(self, subcmd, opts, *args):
     logging.basicConfig(level=level, format='[%(levelname).1s] %(message)s')
 
     # Allow for determining project from osc store.
-    if not opts.project:
-        if core.is_project_dir('.'):
-            opts.project = core.store_read_project('.')
-        else:
-            opts.project = 'openSUSE:Factory'
+    if not opts.project and core.is_project_dir('.'):
+        opts.project = core.store_read_project('.')
 
     Cache.init()
     apiurl = self.get_api_url()
     if command != 'projects':
+        if not opts.project:
+            raise oscerr.WrongArgs('A project must be indicated.')
         config = config_load(apiurl, opts.project)
         if not config:
             raise oscerr.WrongArgs('OSRT:OriginConfig attribute missing from {}'.format(opts.project))

--- a/osc-origin.py
+++ b/osc-origin.py
@@ -15,6 +15,7 @@ from osclib.core import project_attribute_list
 from osclib.origin import config_load
 from osclib.origin import config_origin_list
 from osclib.origin import origin_find
+from osclib.origin import origin_potentials
 from osclib.origin import origin_revision_state
 from osclib.util import mail_send
 from shutil import copyfile
@@ -46,6 +47,7 @@ def do_origin(self, subcmd, opts, *args):
         osc origin config [--origins-only]
         osc origin list [--force-refresh] [--format json|yaml]
         osc origin package [--debug] PACKAGE
+        osc origin potentials [--format json|yaml] PACKAGE
         osc origin projects [--format json|yaml]
         osc origin report [--diff] [--force-refresh] [--mail]
     """
@@ -53,7 +55,7 @@ def do_origin(self, subcmd, opts, *args):
     if len(args) == 0:
         raise oscerr.WrongArgs('A command must be indicated.')
     command = args[0]
-    if command not in ['config', 'list', 'package', 'projects', 'report']:
+    if command not in ['config', 'list', 'package', 'potentials', 'projects', 'report']:
         raise oscerr.WrongArgs('Unknown command: {}'.format(command))
     if command == 'package' and len(args) < 2:
         raise oscerr.WrongArgs('A package must be indicated.')
@@ -185,6 +187,23 @@ def osrt_origin_list(apiurl, opts, *args):
 def osrt_origin_package(apiurl, opts, *packages):
     origin_info = origin_find(apiurl, opts.project, packages[0])
     print(origin_info)
+
+def osrt_origin_potentials(apiurl, opts, *packages):
+    potentials = origin_potentials(apiurl, opts.project, packages[0])
+
+    if opts.format != 'plain':
+        out = []
+        for origin, version in potentials.items():
+            out.append({'origin': origin, 'version': version})
+
+        osrt_origin_dump(opts.format, out)
+        return
+
+    line_format = '{:<50}  {}'
+    print(line_format.format('origin', 'version'))
+
+    for origin, version in potentials.items():
+        print(line_format.format(origin, version))
 
 def osrt_origin_projects(apiurl, opts, *args):
     projects = list(project_attribute_list(apiurl, 'OSRT:OriginConfig'))

--- a/osc-origin.py
+++ b/osc-origin.py
@@ -15,6 +15,7 @@ from osclib.core import project_attribute_list
 from osclib.origin import config_load
 from osclib.origin import config_origin_list
 from osclib.origin import origin_find
+from osclib.origin import origin_history
 from osclib.origin import origin_potentials
 from osclib.origin import origin_revision_state
 from osclib.util import mail_send
@@ -45,6 +46,7 @@ def do_origin(self, subcmd, opts, *args):
 
     Usage:
         osc origin config [--origins-only]
+        osc origin history [--format json|yaml] PACKAGE
         osc origin list [--force-refresh] [--format json|yaml]
         osc origin package [--debug] PACKAGE
         osc origin potentials [--format json|yaml] PACKAGE
@@ -55,7 +57,7 @@ def do_origin(self, subcmd, opts, *args):
     if len(args) == 0:
         raise oscerr.WrongArgs('A command must be indicated.')
     command = args[0]
-    if command not in ['config', 'list', 'package', 'potentials', 'projects', 'report']:
+    if command not in ['config', 'history', 'list', 'package', 'potentials', 'projects', 'report']:
         raise oscerr.WrongArgs('Unknown command: {}'.format(command))
     if command == 'package' and len(args) < 2:
         raise oscerr.WrongArgs('A package must be indicated.')
@@ -99,6 +101,19 @@ def osrt_origin_dump(format, data):
             print('unknown format: {}'.format(format), file=sys.stderr)
         return False
     return True
+
+def osrt_origin_history(apiurl, opts, *packages):
+    config = config_load(apiurl, opts.project)
+    history = origin_history(apiurl, opts.project, packages[0], config['review-user'])
+
+    if osrt_origin_dump(opts.format, history):
+        return
+
+    line_format = '{:<50}  {:<10}  {:>7}'
+    print(line_format.format('origin', 'state', 'request'))
+
+    for record in history:
+        print(line_format.format(record['origin'], record['state'], record['request']))
 
 def osrt_origin_lookup_file(project, previous=False):
     parts = [project, 'yaml']

--- a/osc-origin.py
+++ b/osc-origin.py
@@ -10,8 +10,8 @@ from osclib.cache import Cache
 from osclib.cache_manager import CacheManager
 from osclib.core import package_list_without_links
 from osclib.origin import config_load
-from osclib.origin import origin_find
 from osclib.origin import config_origin_list
+from osclib.origin import origin_find
 from osclib.util import mail_send
 from shutil import copyfile
 import sys

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -624,9 +624,9 @@ def project_remote_apiurl(apiurl, project):
 
     return apiurl, project
 
-def review_find_last(request, who):
+def review_find_last(request, user):
     for review in reversed(request.reviews):
-        if review.who == who:
+        if review.by_user == user:
             return review
 
     return None

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -582,6 +582,18 @@ def package_source_hash_history(apiurl, project, package, limit=5, include_proje
                 if limit_remaining == 0:
                     break
 
+def package_version(apiurl, project, package):
+    try:
+        url = makeurl(apiurl, ['source', project, package, '_history'], {'limit': 1})
+        root = ETL.parse(http_GET(url)).getroot()
+    except HTTPError as e:
+        if e.code == 404:
+            return False
+
+        raise e
+
+    return root.xpath('(//version)[last()]/text()')[0]
+
 @memoize(session=True)
 def project_remote_list(apiurl):
     remotes = {}

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -594,6 +594,15 @@ def package_version(apiurl, project, package):
 
     return root.xpath('(//version)[last()]/text()')[0]
 
+def project_attribute_list(apiurl, attribute, value=None):
+    xpath = 'attribute/@name="{}"'.format(attribute)
+    if value is not None:
+        xpath += '="{}"'.format(value)
+
+    root = search(apiurl, project=xpath)['project']
+    for project in root.findall('project'):
+        yield project.get('name')
+
 @memoize(session=True)
 def project_remote_list(apiurl):
     remotes = {}

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -521,3 +521,24 @@ def origin_potentials(apiurl, target_project, package):
             potentials[origin] = version
 
     return potentials
+
+def origin_history(apiurl, target_project, package, user):
+    history = []
+
+    requests = get_request_list(apiurl, target_project, package, None, ['all'], 'submit')
+    for request in sorted(requests, key=lambda r: r.reqid, reverse=True):
+        review = review_find_last(request, user)
+        if not review:
+            continue
+
+        annotation = origin_annotation_load(review.comment)
+        if not annotation:
+            continue
+
+        history.append({
+            'origin': annotation.get('origin', 'None'),
+            'request': request.reqid,
+            'state': request.state.name,
+        })
+
+    return history

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -8,6 +8,7 @@ from osclib.core import devel_project_get
 from osclib.core import entity_exists
 from osclib.core import package_source_hash
 from osclib.core import package_source_hash_history
+from osclib.core import package_version
 from osclib.core import project_remote_apiurl
 from osclib.core import review_find_last
 from osclib.core import reviews_remaining
@@ -508,3 +509,15 @@ def origin_revision_state(apiurl, target_project, package, origin_info=None, lim
 
     # To simplify usage which is left-right (oldest-newest) place oldest first.
     return list(reversed(revisions))
+
+def origin_potentials(apiurl, target_project, package):
+    potentials = {}
+
+    config = config_load(apiurl, target_project)
+    for origin, _ in config_origin_generator(config['origins'], apiurl, target_project, package, True):
+        version = package_version(apiurl, origin, package)
+        if version is not False:
+            # Package exists in origin, but may still have unknown version.
+            potentials[origin] = version
+
+    return potentials

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -480,3 +480,31 @@ def policy_input_evaluate_reviews_not_allowed(policy, inputs):
             reviews_not_allowed.append(review_remaining)
 
     return reviews_not_allowed
+
+def origin_revision_state(apiurl, target_project, package, origin_info=None, limit=10):
+    if not origin_info:
+        origin_info = origin_find(apiurl, target_project, package)
+
+    revisions = []
+
+    # Allow for origin project to contain revisions not present in target by
+    # considering double the limit of revisions. The goal is to know how many
+    # revisions behind the package in target project is and if it deviated from
+    # origin, not that it ended up with every revision found in origin project.
+    origin_project = origin_info.project.rstrip('~')
+    origin_hashes = list(package_source_hash_history(apiurl, origin_project, package, limit * 2, True))
+    target_hashes = list(package_source_hash_history(apiurl, target_project, package, limit))
+    for source_hash in origin_hashes:
+        if source_hash not in target_hashes:
+            revisions.append(-1)
+        else:
+            break
+
+    for source_hash in target_hashes:
+        if len(revisions) == limit:
+            break
+
+        revisions.append(int(source_hash in origin_hashes))
+
+    # To simplify usage which is left-right (oldest-newest) place oldest first.
+    return list(reversed(revisions))

--- a/userscript/staging-move-drag-n-drop.user.js
+++ b/userscript/staging-move-drag-n-drop.user.js
@@ -273,7 +273,7 @@ var initMoveInterface = function() {
         var data = JSON.stringify({'user': user, 'project': project, 'move': true, 'selection': summary});
         var domain_parent = window.location.hostname.split('.').splice(1).join('.');
         var subdomain = domain_parent.endsWith('suse.de') ? 'tortuga' : 'operator';
-        var url = 'https://' + subdomain + '.' + domain_parent + '/select';
+        var url = 'https://' + subdomain + '.' + domain_parent + '/staging/select';
         $.post({url: url, data: data, crossDomain: true, xhrFields: {withCredentials: true},
                 success: applyChangesSuccess}).fail(applyChangesFailed);
     }

--- a/web/origin-manager/index.html
+++ b/web/origin-manager/index.html
@@ -1,0 +1,41 @@
+<html>
+    <head>
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tabulator/4.2.3/css/bootstrap/tabulator_bootstrap.min.css">
+        <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.0/css/all.css" integrity="sha384-lZN37f5QGtY3VHgisS14W3ExzMWZxybE1SJSEsQp9S+oqd12jhcu+A56Ebc1zFSJ" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/diff2html/2.7.0/diff2html.css">
+        <link rel="stylesheet" href="main.css">
+
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-sparklines/2.1.2/jquery.sparkline.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/4.4.0/bootbox.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/tabulator/4.2.3/js/tabulator.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/diff2html/2.7.0/diff2html.js"></script>
+        <script src="util.js"></script>
+        <script src="main.js"></script>
+
+        <link rel="shortcut icon" href="https://www.gravatar.com/avatar/590fa7a9bbeceb2e07c820ec3bec5e44?s=20&d=wavatar">
+        <title>Origin Manager</title>
+    </head>
+    <body>
+        <main>
+            <section>
+                <div id="project-table"></div>
+            </section>
+            <aside>
+                <div id="potential-table"></div>
+                <div id="history-table"></div>
+            </aside>
+            <div id="details">
+            </div>
+        </main>
+        <script>
+        project_table_init('#project-table');
+        potential_table_init('#potential-table');
+        history_table_init('#history-table');
+        hash_init();
+        </script>
+    </body>
+</html>

--- a/web/origin-manager/main.css
+++ b/web/origin-manager/main.css
@@ -1,0 +1,35 @@
+main {
+  clear: both;
+}
+
+section, aside, #details {
+  float: left;
+}
+
+section {
+  min-width: 700px;
+  height: 100%;
+}
+
+section #project-table {
+  height: inherit;
+  margin-bottom: 0;
+}
+
+aside {
+  min-width: 400px;
+  max-width: 600px;
+  display: none;
+}
+
+#details {
+  display: none;
+  min-width: 600px;
+  max-width: 800px;
+  height: 100%;
+  overflow: auto;
+}
+
+#details p {
+  margin: 20px;
+}

--- a/web/origin-manager/main.js
+++ b/web/origin-manager/main.js
@@ -1,0 +1,464 @@
+var OBS_URL = obs_url();
+var FETCH_CONFIG = {
+    method: 'GET',
+    mode: 'cors',
+    credentials: 'include',
+};
+var FETCH_JSON_CONFIG = Object.assign({}, FETCH_CONFIG, {
+    headers: {
+        'Accept': 'application/json',
+    },
+});
+var POST_CONFIG = Object.assign({}, FETCH_CONFIG, {
+    method: 'POST',
+});
+
+function origin_project(origin) {
+    return origin.replace(/[+~]$/, '')
+}
+
+function param_lookup_package(cell) {
+    return {
+        urlPrefix: OBS_URL + '/package/show/' + project_get() + '/',
+        target: '_blank',
+    };
+}
+
+function param_lookup_origin(cell) {
+    var origin = cell.getValue();
+    if (origin == 'None') {
+        return { url: '#' };
+    }
+
+    var params = {
+        labelField: 'origin',
+        urlField: 'package',
+        urlPrefix: OBS_URL + '/package/show/' + origin_project(origin) + '/',
+        target: '_blank',
+    };
+    if (cell.getTable().package) {
+        params['url'] = params['urlPrefix'] + cell.getTable().package;
+        params['urlPrefix'] = null;
+    }
+
+    return params;
+}
+
+function param_lookup_request(cell) {
+    if (cell.getValue() == null) {
+        return { label: ' ', url: '#' }
+    }
+    return {
+        urlPrefix: OBS_URL + '/request/show/',
+        target: '_blank',
+    };
+}
+
+function formatter_tristate(cell, formatterParams, onRendered) {
+    onRendered(function() {
+        $(cell.getElement()).sparkline(cell.getValue(), {
+            type: 'tristate',
+            width: '100%',
+            barWidth: 14,
+            disableTooltips: true,
+        });
+    });
+}
+
+function sorter_tristate(a, b, aRow, bRow, column, dir, sorterParams) {
+    return sorter_tristate_distance(a) - sorter_tristate_distance(b);
+}
+
+function sorter_request(a, b, aRow, bRow, column, dir, sorterParams) {
+    if (a == b) return 0;
+    if (a == null) return (dir == 'asc' ?  1 : -1) * Number.MAX_SAFE_INTEGER;
+    if (b == null) return (dir == 'asc' ? -1 :  1) * Number.MAX_SAFE_INTEGER;
+    return a - b;
+}
+
+function sorter_tristate_distance(revisions) {
+    var distance = 0;
+    for (var i = revisions.length - 1; i >= 0; i--) {
+        if (revisions[i] === -1) distance += 10;
+        else if (revisions[i] === 0) distance += 1;
+        else break
+    }
+
+    return distance
+}
+
+function table_selection_get(table) {
+    if (table.getSelectedRows().length > 0) {
+        return table.getSelectedRows()[0].getIndex();
+    }
+    return null;
+}
+
+function table_selection_set(table, value) {
+    if (table.getSelectedRows().length > 0) {
+        if (table.getSelectedRows()[0].getIndex() != value) {
+            table.getSelectedRows()[0].deselect();
+            table.selectRow(value);
+        }
+    } else {
+        table.selectRow(value);
+    }
+}
+
+var project_table;
+function project_table_init(selector) {
+    project_table = new Tabulator(selector, {
+        columns: [
+            {
+                title: 'Package',
+                field: 'package',
+                headerFilter: 'input',
+                width: 200,
+                formatter: 'link',
+                formatterParams: param_lookup_package,
+            },
+            {
+                title: 'Origin',
+                field: 'origin',
+                headerFilter: 'input',
+                width: 200,
+                formatter: 'link',
+                formatterParams: param_lookup_origin,
+            },
+            {
+                title: 'Revisions',
+                field: 'revisions',
+                width: 170,
+                formatter: formatter_tristate,
+                sorter: sorter_tristate,
+            },
+            {
+                title: 'Request',
+                field: 'request',
+                headerFilter: 'input',
+                width: 100,
+                formatter: 'link',
+                formatterParams: param_lookup_request,
+                sorter: sorter_request,
+            },
+        ],
+        dataLoaded: package_select_set,
+        index: 'package',
+        initialSort: [
+            { column: 'package', dir: 'asc' },
+        ],
+        rowClick: package_select_hash,
+        selectable: 1,
+        tooltips: true,
+    });
+}
+
+var potential_table;
+function potential_table_init(selector) {
+    potential_table = new Tabulator(selector, {
+        columns: [
+            {
+                title: 'Origin',
+                field: 'origin',
+                headerFilter: 'input',
+                width: 200,
+                formatter: 'link',
+                formatterParams: param_lookup_origin,
+            },
+            {
+                title: 'Version',
+                field: 'version',
+                headerFilter: 'input',
+                width: 100,
+            },
+            {
+                title: '',
+                formatter: function(cell, formatterParams, onRendered) {
+                    return "<i class='fa fa-stream'></i>";
+                },
+                width: 20,
+                headerSort: false,
+                tooltip: 'diff',
+                cellClick: potential_external,
+            },
+            {
+                title: '',
+                formatter: function(cell, formatterParams, onRendered) {
+                    return "<i class='fa fa-share-square'></i>";
+                },
+                width: 20,
+                headerSort: false,
+                tooltip: 'submit',
+                cellClick: potential_submit_prompt,
+            },
+        ],
+        dataLoaded: potential_select_set,
+        index: 'origin',
+        initialSort: [
+            { column: 'origin', dir: 'asc' },
+        ],
+        rowClick: potential_select_hash,
+        selectable: 1,
+        tooltips: true,
+    });
+}
+
+var history_table;
+function history_table_init(selector) {
+    history_table = new Tabulator(selector, {
+        columns: [
+            {
+                title: 'Origin',
+                field: 'origin',
+                headerFilter: 'input',
+                width: 200,
+                formatter: 'link',
+                formatterParams: param_lookup_origin,
+            },
+            {
+                title: 'Request',
+                field: 'request',
+                headerFilter: 'input',
+                width: 100,
+                formatter: 'link',
+                formatterParams: param_lookup_request,
+                sorter: sorter_request,
+            },
+            {
+                title: 'State',
+                field: 'state',
+                headerFilter: 'input',
+                width: 100,
+            },
+        ],
+        initialSort: [
+            { column: 'request', dir: 'desc' },
+        ],
+        tooltips: true,
+    });
+}
+
+function project_prompt() {
+    const request = new Request(operator_url() + '/origin/projects/all', FETCH_JSON_CONFIG);
+    fetch(request)
+        .then(response => response.json())
+        .then(projects => {
+            var options = [];
+            for (var i = 0; i < projects.length; i++) {
+                options[i] = {text: projects[i], value: projects[i]};
+            }
+
+            bootbox.prompt({
+                title: 'Project',
+                inputType: 'select',
+                inputOptions: options,
+                closeButton: false,
+                callback: function(project) {
+                    if (project) {
+                        hash_set([project]);
+                    }
+                }
+            });
+        });
+}
+
+function project_get() {
+    if ('project' in project_table) {
+        return project_table.project;
+    }
+    return null;
+}
+
+function project_set(project) {
+    if (project == project_get()) {
+        return;
+    }
+    project_table.project = project;
+    project_table.setData(operator_url() + '/origin/list/' + project, {}, FETCH_JSON_CONFIG);
+    project_table.setHeaderFilterFocus('package');
+}
+
+function package_get() {
+    if (typeof potential_table !== 'undefined' && 'package' in potential_table) {
+        return potential_table.package;
+    }
+    return null;
+}
+
+function package_set(project, package) {
+    if (package == package_get()) {
+        return;
+    }
+    $('aside').toggle(package != null);
+
+    if (package == null) return;
+
+    potential_table.package = package;
+    potential_table.setData(
+        operator_url() + '/origin/potentials/' + project + '/' + package, {}, FETCH_JSON_CONFIG);
+
+    history_table.package = package;
+    history_table.setData(
+        operator_url() + '/origin/history/' + project + '/' + package, {}, FETCH_JSON_CONFIG);
+
+    package_select_set();
+}
+
+function package_select_set() {
+    var package = package_get();
+    if (package) {
+        table_selection_set(project_table, package);
+    }
+}
+
+function package_select_hash() {
+    hash_set([project_get(), table_selection_get(project_table),
+             origin_project(project_table.getSelectedRows()[0].getData()['origin'])]);
+}
+
+function potential_get() {
+    return $('#details').data('origin');
+}
+
+function potential_set(project, package, origin) {
+    if (project == $('#details').data('project') &&
+        package == $('#details').data('package') &&
+        origin == potential_get()) return;
+
+    $('#details').toggle(origin != null);
+    $('#details').data('project', project);
+    $('#details').data('package', package);
+    $('#details').data('origin', origin);
+
+    if (origin == null) return;
+
+    $('#details').html('<p>Loading...</p>');
+    var url = operator_url() + '/package/diff/' + project + '/' + package + '/' + origin;
+    fetch(url, FETCH_CONFIG)
+        .then(response => response.text())
+        .then(text => {
+            if (text == '') {
+                $('#details').html('<p>No difference</p>');
+                return;
+            }
+            $('#details').html(Diff2Html.getPrettyHtml(text));
+        });
+
+    potential_select_set();
+}
+
+function potential_select_set() {
+    var origin = potential_get();
+    if (origin) {
+        table_selection_set(potential_table, origin);
+    }
+}
+
+function potential_select_hash() {
+    hash_set([project_get(), package_get(), table_selection_get(potential_table)]);
+}
+
+function potential_external(e, cell) {
+    window.open(OBS_URL + '/package/rdiff/' + cell.getData()['origin'] + '/' + package_get() +
+      '?oproject=' + project_get(), '_blank');
+}
+
+function potential_submit_prompt(e, cell) {
+    bootbox.prompt({
+        title: 'Submit ' + cell.getData()['origin'] + '/' + package_get() + ' to ' + project_get() + '?',
+        size: 'large',
+        inputType: 'textarea',
+        closeButton: false,
+        callback: function(message) {
+            if (message === null) return;
+            potential_submit(project_get(), package_get(), cell.getData()['origin'], message);
+        }
+    });
+}
+
+function potential_submit(project, package, origin, message) {
+    fetch(operator_url() + '/request/submit/' + origin + '/' + package + '/' + project +
+            '?message=' + encodeURIComponent(message), POST_CONFIG)
+        .then(response => response.text())
+        .then(log => {
+            log = log.trim()
+            console.log(log);
+            var words = log.split(/\s+/);
+            var request = words[words.length - 1];
+            if (request == 'failed') {
+                bootbox.alert({
+                    title: 'Failed to submit ' + origin + '/' + package + ' to ' + project,
+                    message: '<pre>' + log.substr(0, log.length - 7) + '</pre>',
+                    size: 'large',
+                    closeButton: false,
+                });
+                return;
+            }
+            project_table.updateData([{'package': package, 'request': request}]);
+        });
+}
+
+var title_suffix;
+function hash_init() {
+    title_suffix = document.title;
+    window.onhashchange = hash_changed;
+    hash_changed();
+}
+
+function hash_parts() {
+    return window.location.hash.substr(1).replace(/\/+$/, '').split('/');
+}
+
+function hash_set(parts) {
+    window.location.hash = parts.join('/');
+}
+
+function hash_changed() {
+    var parts = hash_parts();
+    var project = null;
+    var package = null;
+    var origin = null;
+
+    // route: /*
+    if (parts[0] == '') {
+        project_prompt();
+        return;
+    }
+
+    // route: /:project
+    project = parts[0];
+    project_set(project);
+
+    // route: /:project/:package
+    if (parts.length >= 2) {
+        package = parts[1];
+    }
+    package_set(project, package);
+
+    // route: /:project/:package/:origin
+    if (parts.length >= 3) {
+        origin = parts[2];
+    }
+    potential_set(project, package, origin);
+    title_update(project, package, origin);
+}
+
+function title_update(project, package, origin) {
+    var parts = hash_parts();
+    var title = '';
+    if (project) {
+        title += project;
+    }
+    if (package) {
+        title += '/' + package;
+    }
+    if (origin) {
+        title += ' diff against ' + origin;
+    }
+
+    if (title) {
+        document.title = title + ' - ' + title_suffix;
+    } else {
+        document.title = title_suffix;
+    }
+}

--- a/web/origin-manager/util.js
+++ b/web/origin-manager/util.js
@@ -1,0 +1,10 @@
+function operator_url() {
+    var domain_parent = window.location.hostname.split('.').splice(1).join('.');
+    var subdomain = domain_parent.endsWith('suse.de') ? 'tortuga' : 'operator';
+    return 'https://' + subdomain + '.' + domain_parent;
+}
+
+function obs_url() {
+    var domain_parent = window.location.hostname.split('.').splice(1).join('.');
+    return 'https://build.' + domain_parent;
+}


### PR DESCRIPTION
Tested thoroughly for `openSUSE:Leap:15.1` and `openSUSE:Leap:15.1:NonFree`. An example can be seen below which demonstrates the usefulness of revision summary for finding problems.

![image](https://user-images.githubusercontent.com/22943929/57039572-a7b73380-6c22-11e9-84c6-8369c50bd0c2.png)

The interface uses anchors, instead of URL state changes, to allow for direct linking and forward-backward navigation while avoiding needing a server setup to redirect non-static requests to `index.html`. Alternatively, this could be changed to not use anchors.

The potential origin rows are clickable to see embedded diff with the diff icon (three lines) opening diff externally in OBS UI. The submit button prompts for a message (optional) and confirmation before generating a submit request.

A list of projects managed by origin-manager is presented when no project context is available.

![image](https://user-images.githubusercontent.com/22943929/57039861-6c693480-6c23-11e9-91a9-be888fb511d2.png)

The current origin is used to pre-select from the potential origins and diff immediately which should speed the workflow for common tasks.

Customized filtering and sorting is implemented for revisions and requests to provide intuitive response.

The history of origins for a package based on request annotations is also available and will be more useful the longer origin-manager is utilized.

![image](https://user-images.githubusercontent.com/22943929/57040058-f0bbb780-6c23-11e9-8032-418776b1301d.png)

An example of submit prompt follows.

![image](https://user-images.githubusercontent.com/22943929/57040117-1fd22900-6c24-11e9-86f2-c2e4ed6d90db.png)

With proper error handling if a problem is encountered.

![image](https://user-images.githubusercontent.com/22943929/57040195-4ee89a80-6c24-11e9-98a6-70904bf9f734.png)

Otherwise, on success the request ID is updated in the primary lookup table request column.

The primary table uses dynamic DOM loading to be performant even while containing more than 10,000 entries while filtering and sorting.

The OBS operator server has been updated to expose the necessary new data paths with some other improvements, including support for `OPTIONS` HTTP method necessary for COR pre-flight checks.

The lookup cache now includes the revision information and is designed to handler either cache structure so it should upgrade without issue. For scripting use as well all the new information paths are exposed via the `origin` subcommand as well. The new commands are as follows.

```
osc origin history [--format json|yaml] PACKAGE
osc origin potentials [--format json|yaml] PACKAGE
osc origin projects [--format json|yaml]
```

Once the operator server is updated, all that is needed is a static host for the html, css, and javascript files. Locally I have used the php development server since it is trivial to serve an adhoc directory: `php -S 0.0.0.0:8080`.

Additionally the origin userscript can be updated to provide links to the web interface on requests, packages, and projects once it is hosted and there is somewhere at which to point the links.

I have not run a full lookup cache generation with the new revision summary yet (as it is time consuming and slower from my location). As such once kubernetes deployment is updated the cron job will be the first to make a full run.