### PR TITLE
Add CNAME for github pages serving.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+osrt.opensuse.org


### PR DESCRIPTION
Utilized for serving content of web directory.

Requires [poo#51002](https://progress.opensuse.org/issues/51002) or local entry.