### PR TITLE
origin-manager: handle no origin when determining revision state.

### DIFF
--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -482,8 +482,8 @@ def policy_input_evaluate_reviews_not_allowed(policy, inputs):
 
     return reviews_not_allowed
 
-def origin_revision_state(apiurl, target_project, package, origin_info=None, limit=10):
-    if not origin_info:
+def origin_revision_state(apiurl, target_project, package, origin_info=False, limit=10):
+    if origin_info is False:
         origin_info = origin_find(apiurl, target_project, package)
 
     revisions = []

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -492,8 +492,11 @@ def origin_revision_state(apiurl, target_project, package, origin_info=False, li
     # considering double the limit of revisions. The goal is to know how many
     # revisions behind the package in target project is and if it deviated from
     # origin, not that it ended up with every revision found in origin project.
-    origin_project = origin_info.project.rstrip('~')
-    origin_hashes = list(package_source_hash_history(apiurl, origin_project, package, limit * 2, True))
+    if origin_info is None:
+        origin_hashes = []
+    else:
+        origin_project = origin_info.project.rstrip('~')
+        origin_hashes = list(package_source_hash_history(apiurl, origin_project, package, limit * 2, True))
     target_hashes = list(package_source_hash_history(apiurl, target_project, package, limit))
     for source_hash in origin_hashes:
         if source_hash not in target_hashes:


### PR DESCRIPTION
- e20725a482349e1f371917d9a7377543cc482bb7:
    osclib/origin: handle origin_info when None.

- cbd3e446e6fcec47b6263b7e2ef198db2f349021:
    osclib/origin: origin_revision_state(): do not find origin when None.
    
    Previously, there was no way to distinguish between a None origin and no
    origin_info passed in. Using False as default allows the two cases to be
    distinguished.