### PR TITLE
Add container for testing in leap 15.1

### DIFF
--- a/dist/ci/testenv-leap151/Dockerfile
+++ b/dist/ci/testenv-leap151/Dockerfile
@@ -1,0 +1,13 @@
+#!BuildTag: osrt_testenv_leap151
+FROM opensuse/leap:15.1
+
+RUN useradd tester -d /code/tests/home
+
+RUN zypper in -y osc python3-nose python3-httpretty python3-pyxdg python3-PyYAML \
+   python3-pika python3-mock python3-cmdln python3-lxml python3-python-dateutil python3-colorama \
+   python3-influxdb python3-coverage libxml2-tools curl \
+   vim vim-data strace git sudo patch
+
+COPY osc-hotpatch.diff /tmp
+RUN patch /usr/lib/python3.6/site-packages/osc/core.py /tmp/osc-hotpatch.diff
+COPY run_as_tester /usr/bin

--- a/dist/ci/testenv-leap151/README
+++ b/dist/ci/testenv-leap151/README
@@ -1,0 +1,2 @@
+This container is build on OBS:
+https://build.opensuse.org/package/show/openSUSE:Tools:Images/osrt-testenv-leap151

--- a/dist/ci/testenv-leap151/osc-hotpatch.diff
+++ b/dist/ci/testenv-leap151/osc-hotpatch.diff
@@ -1,0 +1,11 @@
+--- /usr/lib/python3.6/site-packages/osc/core.py.bak    2019-05-02 18:14:01.088380882 +0000
++++ /usr/lib/python3.6/site-packages/osc/core.py        2019-05-02 18:14:19.204341426 +0000
+@@ -6318,7 +6318,7 @@
+         try:
+             comment = node.find('comment').text.encode(locale.getpreferredencoding(), 'replace')
+         except:
+-            comment = b'<no message>'
++            comment = '<no message>'
+         try:
+             requestid = node.find('requestid').text.encode(locale.getpreferredencoding(), 'replace')
+         except:

--- a/dist/ci/testenv-leap151/run_as_tester
+++ b/dist/ci/testenv-leap151/run_as_tester
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+# This script is run from docker-compose within test container
+/usr/sbin/usermod -u $(stat -c %u /code/LICENSE) tester
+/usr/bin/sudo -u tester bash -c "cd /code && $*"


### PR DESCRIPTION
The container will be built on OBS and be used on travis to avoid waiting
for the container to build (or to error because of download.opensuse.org madness)