### PR TITLE
No longer build packages in travis but in OBS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,33 +14,6 @@ env:
 
 matrix:
   include:
-    - env: TEST_SUITE=distribution TARGET_REPO=openSUSE_Factory
-      sudo: required
-      services:
-        - docker
-      language: bash
-      before_install:
-        - docker build -f dist/ci/Dockerfile -t spec .
-      script:
-        - ./dist/ci/docker-run obs-build-target "$TARGET_REPO"
-    - env: TEST_SUITE=distribution TARGET_REPO=openSUSE_15.0
-      sudo: required
-      services:
-        - docker
-      language: bash
-      before_install:
-        - docker build -f dist/ci/Dockerfile -t spec .
-      script:
-        - ./dist/ci/docker-run obs-build-target "$TARGET_REPO"
-    - env: TEST_SUITE=distribution TARGET_REPO=SLE_15
-      sudo: required
-      services:
-        - docker
-      language: bash
-      before_install:
-        - docker build -f dist/ci/Dockerfile -t spec .
-      script:
-        - ./dist/ci/docker-run obs-build-target "$TARGET_REPO"
     - env: TEST_SUITE=flake8
       language: python
       install:


### PR DESCRIPTION
Together with ChrisBr I developed a solution to test the package build of a git report directly in OBS. It's currently in phase of refactoring, so I forked it temporarly to https://github.com/coolo/pull_request_package

and setup a local cron job to run 
`docker run -v=/space/puller-config:/config -t openqapusher/osrt_pull_request_package`

every 5 minutes. The OBS builds have a much quicker turn around time as they are closer to the binaries required. 