### PR TITLE
systemd: include OBS Operator origin manager report service template.

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -571,6 +571,8 @@ exit 0
 %files obs-operator
 %{_bindir}/osrt-obs_operator
 %{_unitdir}/osrt-obs-operator.service
+%{_unitdir}/osrt-obs-operator-origin-manager-report@.service
+%{_unitdir}/osrt-obs-operator-origin-manager-report@.timer
 
 %files origin-manager
 %{_bindir}/osrt-origin-manager

--- a/systemd/osrt-obs-operator-origin-manager-report@.service
+++ b/systemd/osrt-obs-operator-origin-manager-report@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=openSUSE Release Tools: OBS Operator origin-manager report for %i
+
+[Service]
+User=osrt-obs-operator
+SyslogIdentifier=osrt-obs-operator-origin-manager
+ExecStart=/usr/bin/osc origin -p "%i" report --force-refresh
+RuntimeMaxSec=12 hour
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/osrt-obs-operator-origin-manager-report@.timer
+++ b/systemd/osrt-obs-operator-origin-manager-report@.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=openSUSE Release Tools: OBS Operator origin-manager report for %i
+
+[Timer]
+OnCalendar=Sun,Tue,Thu *-*-* 04:00:00
+Unit=osrt-obs-operator-origin-manager-report@%i.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/osrt-obs-operator.service
+++ b/systemd/osrt-obs-operator.service
@@ -3,7 +3,7 @@ Description=openSUSE Release Tools: OBS Operator
 
 [Service]
 User=osrt-obs-operator
-ExecStart=/usr/bin/osrt-obs_operator --debug
+ExecStart=/usr/bin/osrt-obs_operator
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Same as kubernetes deployment, but for internal non-k8s use.