### PR TITLE
Remove more references to vcr

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1008,7 +1008,7 @@ class StagingAPI(object):
         """Determine if staging project is both active and no longer pending."""
         return status['overall_state'] in ['acceptable', 'review', 'failed']
 
-    # we use a private function to mock it - httpretty and vcr don't mix well
+    # we use a private function to mock it - httpretty is all or nothing
     def _fetch_project_meta(self, project):
         url = self.makeurl(['source', project, '_project'], {'meta': '1'})
         return http_GET(url).read()

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 import sys
 import unittest
-import httpretty
 import re
 
 import osc.core
@@ -18,20 +17,37 @@ class TestApiCalls(OBSLocal.TestCase):
     Tests for various api calls to ensure we return expected content
     """
 
+    def setUp(self):
+        super(TestApiCalls, self).setUp()
+        self.wf = OBSLocal.StagingWorkflow()
+        self.wf.setup_rings()
+        self.staging_b = self.wf.create_staging('B')
+        prj = self.staging_b.name
+
+        self.winerq = self.wf.create_submit_request('devel:wine', 'wine')
+        self.wf.api.rq_to_prj(self.winerq.reqid, prj)
+
+        # Get rq number
+        num = self.wf.api.get_request_id_for_package(prj, 'wine')
+        self.assertEqual(str(num), self.winerq.reqid)
+        self.assertIsNotNone(num)
+        self.assertTrue(self.wf.api.item_exists(prj, 'wine'))
+
+    def tearDown(self):
+        del self.wf
+        super(TestApiCalls, self).tearDown()
+
     def test_ring_packages(self):
         """
         Validate the creation of the rings.
         """
 
-        wf = OBSLocal.StagingWorkflow()
-        wf.setup_rings()
-
-        curl = wf.create_package('target', 'curl')
+        curl = self.wf.create_package('target', 'curl')
         curl.create_file('curl.spec')
         curl.create_file('curl-mini.spec')
-        cmini = wf.create_link(curl, target_project=wf.projects['target'], target_package='curl-mini')
-        cring1 = wf.create_link(curl, target_project=wf.projects['ring1'], target_package='curl')
-        cring0 = wf.create_link(cring1, target_project=wf.projects['ring0'], target_package='curl-mini')
+        cmini = self.wf.create_link(curl, target_project=self.wf.projects['target'], target_package='curl-mini')
+        cring1 = self.wf.create_link(curl, target_project=self.wf.projects['ring1'], target_package='curl')
+        cring0 = self.wf.create_link(cring1, target_project=self.wf.projects['ring0'], target_package='curl-mini')
 
         # test content for listonly ie. list command
         ring_packages = {
@@ -39,7 +55,7 @@ class TestApiCalls(OBSLocal.TestCase):
             'curl-mini': 'openSUSE:Factory:Rings:0-Bootstrap',
             'wine': 'openSUSE:Factory:Rings:1-MinimalX',
         }
-        self.assertEqual(ring_packages, wf.api.ring_packages_for_links)
+        self.assertEqual(ring_packages, self.wf.api.ring_packages_for_links)
 
         # test content for real usage
         ring_packages = {
@@ -47,26 +63,25 @@ class TestApiCalls(OBSLocal.TestCase):
             'curl-mini': 'openSUSE:Factory:Rings:0-Bootstrap',
             'wine': 'openSUSE:Factory:Rings:1-MinimalX',
         }
-        self.assertEqual(ring_packages, wf.api.ring_packages)
+        self.assertEqual(ring_packages, self.wf.api.ring_packages)
 
     def test_pseudometa_get_prj(self):
         """
         Test getting project metadata from YAML in project description
         """
 
-        wf = self.setup_vcr()
-        wf.create_staging('A')
+        self.wf.create_staging('A')
 
         # Try to get data from project that has no metadata
-        data = wf.api.get_prj_pseudometa('openSUSE:Factory:Staging:A')
+        data = self.wf.api.get_prj_pseudometa('openSUSE:Factory:Staging:A')
         # Should be empty, but contain structure to work with
         self.assertEqual(data, {'requests': []})
         # Add some sample data
         rq = {'id': '123', 'package': 'test-package'}
         data['requests'].append(rq)
         # Save them and read them back
-        wf.api.set_prj_pseudometa('openSUSE:Factory:Staging:A', data)
-        test_data = wf.api.get_prj_pseudometa('openSUSE:Factory:Staging:A')
+        self.wf.api.set_prj_pseudometa('openSUSE:Factory:Staging:A', data)
+        test_data = self.wf.api.get_prj_pseudometa('openSUSE:Factory:Staging:A')
         # Verify that we got back the same data
         self.assertEqual(data, test_data)
 
@@ -75,25 +90,21 @@ class TestApiCalls(OBSLocal.TestCase):
         List projects and their content
         """
 
-        wf = self.setup_vcr()
-        staging_a = wf.create_staging('A')
+        staging_a = self.wf.create_staging('A')
 
         # Prepare expected results
         data = [staging_a.name, self.staging_b.name]
 
         # Compare the results
-        self.assertEqual(data, wf.api.get_staging_projects())
+        self.assertEqual(data, self.wf.api.get_staging_projects())
 
     def test_open_requests(self):
         """
         Test searching for open requests
         """
-        wf = OBSLocal.StagingWorkflow()
-        wf.create_submit_request('devel:wine', 'wine')
+        self.wf.create_submit_request('devel:wine', 'wine2')
 
-        # get the open requests
-        requests = wf.api.get_open_requests()
-
+        requests = self.wf.api.get_open_requests()
         # Compare the results, we only care now that we got 1 of them not the content
         self.assertEqual(1, len(requests))
 
@@ -101,66 +112,41 @@ class TestApiCalls(OBSLocal.TestCase):
         """
         Test whether we can get correct id for sr in staging project
         """
-
-        wf = self.setup_vcr()
         prj = self.staging_b.name
 
         # Get rq
-        num = wf.api.get_request_id_for_package(prj, 'wine')
+        num = self.wf.api.get_request_id_for_package(prj, 'wine')
         self.assertEqual(str(num), self.winerq.reqid)
         # Get package name
-        self.assertEqual('wine', wf.api.get_package_for_request_id(prj, num))
-
-    def setup_vcr(self):
-        wf = OBSLocal.StagingWorkflow()
-        wf.setup_rings()
-        self.staging_b = wf.create_staging('B')
-        prj = self.staging_b.name
-
-        self.winerq = wf.create_submit_request('devel:wine', 'wine')
-        wf.api.rq_to_prj(self.winerq.reqid, prj)
-
-        # Get rq number
-        num = wf.api.get_request_id_for_package(prj, 'wine')
-        self.assertEqual(str(num), self.winerq.reqid)
-        self.assertIsNotNone(num)
-        self.assertTrue(wf.api.item_exists(prj, 'wine'))
-
-        return wf
+        self.assertEqual('wine', self.wf.api.get_package_for_request_id(prj, num))
 
     def test_rm_from_prj(self):
-        wf = self.setup_vcr()
-
         # Delete the package
-        wf.api.rm_from_prj(self.staging_b.name, package='wine')
-        self.verify_wine_is_gone(wf)
+        self.wf.api.rm_from_prj(self.staging_b.name, package='wine')
+        self.verify_wine_is_gone()
 
     def test_rm_from_prj_2(self):
-        wf = self.setup_vcr()
-
         # Try the same with request number
-        wf.api.rm_from_prj(self.staging_b.name, request_id=self.winerq.reqid)
-        self.verify_wine_is_gone(wf)
+        self.wf.api.rm_from_prj(self.staging_b.name, request_id=self.winerq.reqid)
+        self.verify_wine_is_gone()
 
-    def verify_wine_is_gone(self, wf):
+    def verify_wine_is_gone(self):
         prj = self.staging_b.name
         pkg = 'wine'
         num = self.winerq.reqid
 
         # Verify package is not there
-        self.assertFalse(wf.api.item_exists(prj, pkg))
+        self.assertFalse(self.wf.api.item_exists(prj, pkg))
 
         # RQ is gone
-        self.assertIsNone(wf.api.get_request_id_for_package(prj, pkg))
-        self.assertIsNone(wf.api.get_package_for_request_id(prj, num))
+        self.assertIsNone(self.wf.api.get_request_id_for_package(prj, pkg))
+        self.assertIsNone(self.wf.api.get_package_for_request_id(prj, num))
 
         # Verify that review is closed
         rq = self.winerq.xml()
         self.assertIsNotNone(rq.find('.//state[@name="new"]'))
 
     def test_add_sr(self):
-        wf = self.setup_vcr()
-
         prj = self.staging_b.name
         pkg = 'wine'
         num = self.winerq.reqid
@@ -168,116 +154,113 @@ class TestApiCalls(OBSLocal.TestCase):
         # Running it twice shouldn't change anything
         for i in range(2):
             # Add rq to the project
-            wf.api.rq_to_prj(num, prj)
+            self.wf.api.rq_to_prj(num, prj)
             # Verify that review is there
             reviews = [{'by_group': 'factory-staging', 'state': 'accepted'},
                        {'by_project': 'openSUSE:Factory:Staging:B', 'state': 'new'}]
             self.assertEqual(self.winerq.reviews(), reviews)
-            self.assertEqual(wf.api.get_prj_pseudometa(prj),
+            self.assertEqual(self.wf.api.get_prj_pseudometa(prj),
                     {'requests': [{'id': int(num), 'package': 'wine', 'author': 'Admin', 'type': 'submit'}]})
 
     def test_create_package_container(self):
         """Test if the uploaded _meta is correct."""
 
-        wf = OBSLocal.StagingWorkflow()
-        wf.create_staging('B')
-        wf.api.create_package_container('openSUSE:Factory:Staging:B', 'wine')
+        self.wf = OBSLocal.StagingWorkflow()
+        self.wf.create_staging('B')
+        self.wf.api.create_package_container('openSUSE:Factory:Staging:B', 'wine')
 
-        url = wf.api.makeurl(['source', 'openSUSE:Factory:Staging:B', 'wine', '_meta'])
+        url = self.wf.api.makeurl(['source', 'openSUSE:Factory:Staging:B', 'wine', '_meta'])
         self.assertEqual(osc.core.http_GET(url).read().decode('utf-8'), '<package name="wine" project="openSUSE:Factory:Staging:B">\n  <title/>\n  <description/>\n</package>\n')
 
-        wf.api.create_package_container('openSUSE:Factory:Staging:B', 'wine', disable_build=True)
+        self.wf.api.create_package_container('openSUSE:Factory:Staging:B', 'wine', disable_build=True)
         m = '<package name="wine" project="openSUSE:Factory:Staging:B">\n  <title/>\n  <description/>\n  <build>\n    <disable/>\n  </build>\n</package>\n'
         self.assertEqual(osc.core.http_GET(url).read().decode('utf-8'), m)
 
     def test_review_handling(self):
         """Test whether accepting/creating reviews behaves correctly."""
 
-        wf = self.setup_vcr()
-
-        request = wf.create_submit_request('devel:wine', 'winetools')
+        request = self.wf.create_submit_request('devel:wine', 'winetools')
         reviews = [{'state': 'new', 'by_group': 'factory-staging'}]
         self.assertEqual(request.reviews(), reviews)
         num = request.reqid
 
         # Add review
-        wf.api.add_review(num, by_project='openSUSE:Factory:Staging:B')
+        self.wf.api.add_review(num, by_project='openSUSE:Factory:Staging:B')
         reviews.append({'by_project': 'openSUSE:Factory:Staging:B', 'state': 'new'})
         self.assertEqual(request.reviews(), reviews)
 
         # Try to readd, should not do anything
-        wf.api.add_review(num, by_project='openSUSE:Factory:Staging:B')
+        self.wf.api.add_review(num, by_project='openSUSE:Factory:Staging:B')
         self.assertEqual(request.reviews(), reviews)
 
         # Accept review
-        wf.api.set_review(num, 'openSUSE:Factory:Staging:B')
+        self.wf.api.set_review(num, 'openSUSE:Factory:Staging:B')
         reviews[1]['state'] = 'accepted'
         self.assertEqual(request.reviews(), reviews)
 
         # Try to accept it again should do anything
-        wf.api.set_review(num, 'openSUSE:Factory:Staging:B')
+        self.wf.api.set_review(num, 'openSUSE:Factory:Staging:B')
         self.assertEqual(request.reviews(), reviews)
 
         # But we should be able to reopen it
-        wf.api.add_review(num, by_project='openSUSE:Factory:Staging:B')
+        self.wf.api.add_review(num, by_project='openSUSE:Factory:Staging:B')
         reviews.append({'by_project': 'openSUSE:Factory:Staging:B', 'state': 'new'})
         self.assertEqual(request.reviews(), reviews)
 
     def test_prj_from_letter(self):
 
-        wf = OBSLocal.StagingWorkflow()
+        self.wf = OBSLocal.StagingWorkflow()
         # Verify it works
-        self.assertEqual(wf.api.prj_from_letter('openSUSE:Factory'), 'openSUSE:Factory')
-        self.assertEqual(wf.api.prj_from_letter('A'), 'openSUSE:Factory:Staging:A')
+        self.assertEqual(self.wf.api.prj_from_letter('openSUSE:Factory'), 'openSUSE:Factory')
+        self.assertEqual(self.wf.api.prj_from_letter('A'), 'openSUSE:Factory:Staging:A')
 
     def test_frozen_mtime(self):
         """Test frozen mtime."""
 
-        wf = OBSLocal.StagingWorkflow()
-        wf.setup_rings()
-        wf.create_staging('A')
+        self.wf.create_staging('A')
 
         # unfrozen
-        self.assertTrue(wf.api.days_since_last_freeze('openSUSE:Factory:Staging:A') > 1000)
+        self.assertTrue(self.wf.api.days_since_last_freeze('openSUSE:Factory:Staging:A') > 1000)
 
         # Testing frozen mtime
-        wf.create_staging('B', freeze=True, rings=1)
-        self.assertLess(wf.api.days_since_last_freeze('openSUSE:Factory:Staging:B'), 1)
-        self.mock_project_meta(wf)
-        self.assertGreater(wf.api.days_since_last_freeze('openSUSE:Factory:Staging:B'), 8)
+        self.wf.create_staging('B', freeze=True, rings=1)
+        self.assertLess(self.wf.api.days_since_last_freeze('openSUSE:Factory:Staging:B'), 1)
+
+        self.mock_project_meta()
+        self.assertGreater(self.wf.api.days_since_last_freeze('openSUSE:Factory:Staging:B'), 8)
 
     def test_frozen_enough(self):
         """Test frozen enough."""
 
-        wf = OBSLocal.StagingWorkflow()
-        wf.setup_rings()
-        wf.create_staging('A')
+        # already has requests
+        self.assertEqual(self.wf.api.prj_frozen_enough('openSUSE:Factory:Staging:B'), True)
+
+        self.wf.create_staging('A')
 
         # Unfrozen
-        self.assertEqual(wf.api.prj_frozen_enough('openSUSE:Factory:Staging:A'), False)
+        self.assertEqual(self.wf.api.prj_frozen_enough('openSUSE:Factory:Staging:A'), False)
 
-        wf.create_staging('B', freeze=True, rings=1)
-        self.assertEqual(wf.api.prj_frozen_enough('openSUSE:Factory:Staging:B'), True)
+        self.wf.create_staging('C', freeze=True, rings=1)
+        self.assertEqual(self.wf.api.prj_frozen_enough('openSUSE:Factory:Staging:C'), True)
 
-        self.mock_project_meta(wf)
-        self.assertEqual(wf.api.prj_frozen_enough('openSUSE:Factory:Staging:B'), False)
+        self.mock_project_meta()
+        self.assertEqual(self.wf.api.prj_frozen_enough('openSUSE:Factory:Staging:C'), False)
 
-    def mock_project_meta(self, wf):
+    def mock_project_meta(self):
         body = """<directory name="_project" rev="3" vrev="" srcmd5="9dd1ec5b77a9e953662eb32955e9066a">
               <entry name="_frozenlinks" md5="64127b7a5dabbca0ec2bf04cd04c9195" size="16" mtime="1555000000"/>
               <entry name="_meta" md5="cf6fb1eac1a676d6c3707303ae2571ad" size="162" mtime="1555945413"/>
             </directory>"""
 
-        wf.api._fetch_project_meta = MagicMock(return_value=body)
+        self.wf.api._fetch_project_meta = MagicMock(return_value=body)
 
     def test_move(self):
         """Test package movement."""
 
-        wf = self.setup_vcr()
-        staging_a = wf.create_staging('A')
+        staging_a = self.wf.create_staging('A')
 
-        self.assertTrue(wf.api.item_exists('openSUSE:Factory:Staging:B', 'wine'))
-        self.assertFalse(wf.api.item_exists('openSUSE:Factory:Staging:A', 'wine'))
-        wf.api.move_between_project('openSUSE:Factory:Staging:B', self.winerq.reqid, 'openSUSE:Factory:Staging:A')
-        self.assertTrue(wf.api.item_exists('openSUSE:Factory:Staging:A', 'wine'))
-        self.assertFalse(wf.api.item_exists('openSUSE:Factory:Staging:B', 'wine'))
+        self.assertTrue(self.wf.api.item_exists('openSUSE:Factory:Staging:B', 'wine'))
+        self.assertFalse(self.wf.api.item_exists('openSUSE:Factory:Staging:A', 'wine'))
+        self.wf.api.move_between_project('openSUSE:Factory:Staging:B', self.winerq.reqid, 'openSUSE:Factory:Staging:A')
+        self.assertTrue(self.wf.api.item_exists('openSUSE:Factory:Staging:A', 'wine'))
+        self.assertFalse(self.wf.api.item_exists('openSUSE:Factory:Staging:B', 'wine'))


### PR DESCRIPTION
I tried to replace the Mocking of functions with httpretty, but unfortunately httpretty replaces all other API calls with 404s then.

What we'd need is a library sniping out single requests - possibly by mocking the http_GET function, but that's tricky as well with caching already overwriting it.