### PR TITLE
Fix repository_path_expand to also work in Factory stagings

### DIFF
--- a/tests/fixtures/repository/openSUSE:Factory.xml
+++ b/tests/fixtures/repository/openSUSE:Factory.xml
@@ -1,0 +1,18 @@
+<project name="openSUSE:Factory">
+  <title/>
+  <description/>
+  <repository name="standard" rebuild="local">
+    <arch>x86_64</arch>
+    <arch>i586</arch>
+  </repository>
+  <repository name="snapshot">
+    <arch>x86_64</arch>
+    <arch>i586</arch>
+  </repository>
+  <repository name="ports">
+    <arch>ppc64</arch>
+    <arch>ppc</arch>
+    <arch>armv6l</arch>
+    <arch>aarch64</arch>
+  </repository>
+</project>

--- a/tests/fixtures/repository/openSUSE:Factory:Staging.xml
+++ b/tests/fixtures/repository/openSUSE:Factory:Staging.xml
@@ -1,0 +1,7 @@
+<project name="openSUSE:Factory:Staging">
+  <title>openSUSE Factory Staging</title>
+  <description>This is just a namespace for various staging projects</description>
+  <repository name="standard">
+    <path project="openSUSE:Factory" repository="ports"/>
+  </repository>
+</project>

--- a/tests/fixtures/repository/openSUSE:Factory:Staging:H.xml
+++ b/tests/fixtures/repository/openSUSE:Factory:Staging:H.xml
@@ -1,0 +1,18 @@
+<project name="openSUSE:Factory:Staging:H">
+  <title/>
+  <description/>
+  <repository name="standard" rebuild="direct" linkedbuild="all">
+    <path project="openSUSE:Factory:Staging:H" repository="bootstrap_copy"/>
+    <arch>i586</arch>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="images" linkedbuild="all">
+    <path project="openSUSE:Factory:Staging:H" repository="standard"/>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="bootstrap_copy">
+    <path project="openSUSE:Factory:Staging" repository="standard"/>
+    <arch>i586</arch>
+    <arch>x86_64</arch>
+  </repository>
+</project>

--- a/tests/repository_tests.py
+++ b/tests/repository_tests.py
@@ -62,3 +62,13 @@ class TestRepository(unittest.TestCase):
                           ['SUSE:SLE-12-SP1:GA', 'standard'],
                           ['SUSE:SLE-12:Update', 'snapshot-SP5'],
                           ['SUSE:SLE-12:GA', 'standard']], repos)
+
+    def test_factory_staging(self):
+        self.add_project('openSUSE:Factory')
+        self.add_project('openSUSE:Factory:Staging')
+        self.add_project('openSUSE:Factory:Staging:H')
+        repos = repository_path_expand(self.wf.api.apiurl, 'openSUSE:Factory:Staging:H', 'standard')
+        self.assertEqual([['openSUSE:Factory:Staging:H', 'standard'],
+                          ['openSUSE:Factory:Staging:H', 'bootstrap_copy'],
+                          ['openSUSE:Factory:Staging', 'standard'],
+                          ['openSUSE:Factory', 'ports']], repos)


### PR DESCRIPTION
I got the algorithm wrong - it overwrites repositories only when used in the same path, not by recursion