### PR TITLE
suppkg_rebuild: Fix TypeError on python3

### DIFF
--- a/suppkg_rebuild.py
+++ b/suppkg_rebuild.py
@@ -18,6 +18,7 @@ import osc.conf
 import osc.core
 
 from osc import oscerr
+from osc.util.helper import decode_list
 from osclib.conf import Config
 from osclib.stagingapi import StagingAPI
 
@@ -36,7 +37,7 @@ class StagingHelper(object):
         self.api = StagingAPI(self.apiurl, self.project)
 
     def get_support_package_list(self, project, repository):
-        f = osc.core.get_buildconfig(self.apiurl, project, repository).splitlines()
+        f = decode_list(osc.core.get_buildconfig(self.apiurl, project, repository).splitlines())
         pkg_list = []
         for line in f:
             if re.match('Preinstall', line) or re.match('VM[Ii]nstall', line) or re.match('Support', line):
@@ -154,10 +155,10 @@ class StagingHelper(object):
                 osc.core.rebuild(self.apiurl, stgname, None, None, None)
                 stg.find('rebuild').text = 'unneeded'
 
-        logging.info('Updating support pkg list...')
         rebuild_data_updated = ET.tostring(root)
         logging.debug(rebuild_data_updated)
         if rebuild_data_updated != rebuild_data:
+            logging.info('Updating support pkg list...')
             self.api.pseudometa_file_save(
                 'support_pkg_rebuild', rebuild_data_updated, 'support package rebuild')
 


### PR DESCRIPTION
Convert all items to String in a List to fix TypeError when executing on python3.

File "suppkg_rebuild.py", line 42, in get_support_package_list
    if re.match('Preinstall', line) or re.match('VM[Ii]nstall', line) or re.match('Support', line):
  File "/usr/lib64/python3.6/re.py", line 172, in match
    return _compile(pattern, flags).match(string)
TypeError: cannot use a string pattern on a bytes-like object