### PR TITLE
osclib/core: rework as package_list_kind_filtered().

### DIFF
--- a/devel-project.py
+++ b/devel-project.py
@@ -16,7 +16,7 @@ from osclib.comments import CommentAPI
 from osclib.conf import Config
 from osclib.core import devel_project_fallback
 from osclib.core import entity_email
-from osclib.core import package_list_without_links
+from osclib.core import package_list_kind_filtered
 from osclib.core import request_age
 from osclib.stagingapi import StagingAPI
 from osclib.util import mail_send
@@ -107,7 +107,7 @@ def notify(args):
     # devel_project_fallback() must be used on a per package basis.
     packages = args.packages
     if not packages:
-        packages = package_list_without_links(apiurl, args.project)
+        packages = package_list_kind_filtered(apiurl, args.project)
     maintainer_map = {}
     for package in packages:
         devel_project, devel_package = devel_project_fallback(apiurl, args.project, package)

--- a/osc-origin.py
+++ b/osc-origin.py
@@ -10,7 +10,7 @@ from osc import oscerr
 from osc.core import get_request_list
 from osclib.cache import Cache
 from osclib.cache_manager import CacheManager
-from osclib.core import package_list_without_links
+from osclib.core import package_list_kind_filtered
 from osclib.core import project_attribute_list
 from osclib.origin import config_load
 from osclib.origin import config_origin_list
@@ -139,8 +139,7 @@ def osrt_origin_lookup(apiurl, project, force_refresh=False, previous=False, qui
         if previous:
             return None
 
-        packages = package_list_without_links(apiurl, project)
-        logging.debug('{} packages found in {}'.format(len(packages), project))
+        packages = package_list_kind_filtered(apiurl, project)
 
         lookup = {}
         for package in packages:


### PR DESCRIPTION
- 9302407e33e86e516a02b78f583706e72d4dc2be:
    osclib/core: rework as package_list_kind_filtered().

- 0857bdfb9aaf6ec896b49f9b098119dc3aaceea9:
    osclib/core: provide package_kind().

Per [mailing list discussion](https://lists.opensuse.org/opensuse-buildservice/2019-05/msg00020.html) not going anywhere fast. As such better to have something to mostly works than mostly does not (for SLE and Leap :Update projects).

Still running a full set locally to see if anything crops up.