### PR TITLE
userscript/origin: do not show failed when no OriginConfig.

### DIFF
--- a/userscript/origin.user.js
+++ b/userscript/origin.user.js
@@ -22,7 +22,11 @@
     $('ul.clean_list, ul.list-unstyled').append('<li id="osrt-origin"><i class="fas fa-spinner fa-spin text-info"></i> loading origin...</li>');
     $.get({url: url, crossDomain: true, xhrFields: {withCredentials: true}, success: function(origin) {
         if (origin.endsWith('failed')) {
-            $('#osrt-origin').html('<i class="fas fa-bug text-warning"></i> failed to get origin info');
+            if (origin.startsWith('OSRT:OriginConfig attribute missing')) {
+                $('#osrt-origin').html('');
+            } else {
+                $('#osrt-origin').html('<i class="fas fa-bug text-warning"></i> failed to get origin info');
+            }
         } else {
             project = origin.trim();
             if (project.endsWith('~')) {


### PR DESCRIPTION
Rather it should be assumed that the project does not intend to have
origin information.

Follow-up on #1982 which introducing error message which really does not apply when no OriginConfig attribute.