### PR TITLE
userscript/origin: rework to handle requests and interface link.

### DIFF
--- a/userscript/origin.user.js
+++ b/userscript/origin.user.js
@@ -1,10 +1,11 @@
 // ==UserScript==
 // @name         OSRT Origin
 // @namespace    openSUSE/openSUSE-release-tools
-// @version      0.1.0
+// @version      0.2.0
 // @description  Supplement OBS interface with origin information.
 // @author       Jimmy Berry
 // @match        */package/show/*
+// @match        */request/show/*
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @grant        none
 // ==/UserScript==
@@ -12,27 +13,123 @@
 (function()
 {
     var pathParts = window.location.pathname.split('/');
-    var project = pathParts[pathParts.length - 2];
-    var package = pathParts[pathParts.length - 1];
 
-    var domain_parent = window.location.hostname.split('.').splice(1).join('.');
-    var subdomain = domain_parent.endsWith('suse.de') ? 'tortuga' : 'operator';
-    var url = 'https://' + subdomain + '.' + domain_parent + '/origin/package/' + project + '/' + package;
+    if (pathParts[1] == 'package') {
+        var project = pathParts[pathParts.length - 2];
+        var package = pathParts[pathParts.length - 1];
+        origin_load(document.querySelector('ul.clean_list, ul.list-unstyled'), project, package);
+    } else if (pathParts[1] == 'request') {
+        request_actions_handle();
+    }
+})();
 
-    $('ul.clean_list, ul.list-unstyled').append('<li id="osrt-origin"><i class="fas fa-spinner fa-spin text-info"></i> loading origin...</li>');
+function request_actions_handle() {
+    // Select all action tabs and store to avoid modification exceptions.
+    var action_elements = document.evaluate(
+        '//div[@class="card mb-3"][2]/div/div[@class="tab-content"]/div', document);
+    var actions = [];
+    var action;
+    while (action = action_elements.iterateNext()) {
+        actions.push(action);
+    }
+
+    for (var i = 0; i < actions.length; i++) {
+        action = actions[i];
+
+        // Select the side column containing build results.
+        var column = document.evaluate(
+            '//div[@class="row"][2]/div[@class="col-md-4"]',
+            action, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+
+        // Select the text represtation of action. All other sources are
+        // inconsistent and do not always have the right values depending on
+        // request type or state.
+        var summary = document.evaluate(
+            'div[1]/div[1]',
+            action, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+        var parts = $(summary).text().trim().split(' ');
+
+        // Maintenance incidents are so special.
+        var release_project = document.evaluate(
+            'i[1]',
+            action, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+        var project, package;
+        if (release_project) {
+            parts = parts.splice(4, 3);
+            project = $(release_project).text().trim().split(' ').splice(-1)[0];
+        } else {
+            parts = parts.splice(-3);
+            project = parts[0];
+        }
+        package = parts[2];
+
+        var card = document.createElement('div');
+        card.classList.add('card');
+
+        var list = document.createElement('ul');
+        list.classList.add('list-unstyled');
+        card.appendChild(list);
+
+        column.insertBefore(card, column.childNodes[0]);
+
+        origin_load(list, project, package);
+    }
+}
+
+function origin_load(element, project, package) {
+    // Add placeholder to indicated loading.
+    var item = document.createElement('li');
+    item.innerHTML = '<i class="fas fa-spinner fa-spin text-info"></i> Origin: loading...';
+    element.appendChild(item);
+
+    var url = operator_url() + '/origin/package/' + project + '/' + package;
     $.get({url: url, crossDomain: true, xhrFields: {withCredentials: true}, success: function(origin) {
         if (origin.endsWith('failed')) {
             if (origin.startsWith('OSRT:OriginConfig attribute missing')) {
-                $('#osrt-origin').html('');
+                item.innerHTML = '';
             } else {
-                $('#osrt-origin').html('<i class="fas fa-bug text-warning"></i> failed to get origin info');
+                item.innerHTML = '<i class="fas fa-bug text-warning"></i> Origin: failed to load';
             }
         } else {
-            project = origin.trim();
-            if (project.endsWith('~')) {
-                project = project.slice(0, -1);
+            var origin_project = origin.trim();
+            if (origin_project.endsWith('~')) {
+                origin_project = origin_project.slice(0, -1);
             }
-            $('#osrt-origin').html('<i class="fas fa-external-link-alt text-info"></i> <a href="/package/show/' + project + '/' + package + '">' + origin + '</a>');
+            item.innerHTML = '<i class="fas fa-external-link-alt text-info"></i> Origin: ';
+            if (origin_project != 'None') {
+                item.innerHTML += '<a href="/package/show/' + origin_project + '/' +
+                    package + '">' + origin + '</a>'
+            } else {
+                item.innerHTML += origin;
+            }
+
+            url = web_interface_url() + '/web/origin-manager/#' + project + '/' + package;
+            if (origin_project != 'None') {
+                url += '/' + origin_project;
+            }
+            item = document.createElement('li');
+            item.innerHTML = '<i class="fas fa-external-link-alt text-info"></i> ' +
+                '<a target="_blank" href="' + url + '">Origin Manager Interface</a>';
+            element.appendChild(item);
         }
     }});
-})();
+}
+
+function operator_url() {
+    var domain_parent = window.location.hostname.split('.').splice(-2).join('.');
+    var subdomain = domain_parent.endsWith('suse.de') ? 'tortuga' : 'operator';
+    return 'https://' + subdomain + '.' + domain_parent;
+}
+
+function web_interface_url() {
+    var domain_parent = window.location.hostname.split('.').splice(-2).join('.');
+    var subdomain, path;
+    if (domain_parent.endsWith('suse.de')) {
+        subdomain = 'jberry.io';
+        path = '/osrt-web';
+    } else {
+        subdomain = 'osrt';
+        path = '';
+    }
+    return 'http://' + subdomain + '.' + domain_parent + path;
+}


### PR DESCRIPTION
# package

![image](https://user-images.githubusercontent.com/22943929/57667298-a5f95280-75c8-11e9-8167-30b32ea4ec6f.png)

# request

Handles multiple actions properly, although still a giant PITA.

![image](https://user-images.githubusercontent.com/22943929/57667362-db05a500-75c8-11e9-93a2-f5b7eb502771.png)

# deployment

Works live for SLE-12-SP5 as everything is deployed internally. Proper package list pending #2014 (running that job currently). openSUSE deployment pending kubernetes access to update deployment and DNS cname (#1975).

# interface theme

Only bother to test request interface against beta OBS theme as they differ enough that it is difficult to support both with multiple actions.

# known issue

When package or projects are abbreviated by OBS it messes up the userscript. There are data values present in the page, but they are incredibly inconsistent depending on the type of request and underlying state. It may end up making sense to try and add operator call to assist, but mapping the resulting data back to the page when be similarly difficult unless the order of actions can be counted on.