### PR TITLE
Some TypeError fixes for python3

### DIFF
--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -301,8 +301,7 @@ class AcceptCommand(object):
         for product in products.findall('product'):
             product_name = product.get('name') + '.product'
             product_pkg = product.get('originpackage')
-            url = self.api.makeurl(['source', project, product_pkg,  product_name])
-            product_spec = http_GET(url).read()
+            product_spec = source_file_load(self.api.apiurl, project, product_pkg, product_name)
             new_product = re.sub(r'<version>\d{8}</version>', '<version>%s</version>' % curr_version, product_spec)
 
             if product_spec != new_product:

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -26,6 +26,7 @@ from osc.core import search
 from osc.core import show_package_meta
 from osc.core import show_project_meta
 from osc.core import show_results_meta
+from osc.util.helper import decode_it
 from osclib.conf import Config
 from osclib.memoize import memoize
 
@@ -261,7 +262,7 @@ def source_file_load(apiurl, project, package, filename, revision=None):
         query['rev'] = revision
     url = makeurl(apiurl, ['source', project, package, filename], query)
     try:
-        return http_GET(url).read()
+        return decode_it(http_GET(url).read())
     except HTTPError:
         return None
 
@@ -288,7 +289,7 @@ def project_pseudometa_file_load(apiurl, project, filename, revision=None):
     project, package = project_pseudometa_package(apiurl, project)
     source_file = source_file_load(apiurl, project, package, filename, revision)
     if source_file is not None:
-        source_file = source_file.decode('utf-8').rstrip()
+        source_file = source_file.rstrip()
     return source_file
 
 def project_pseudometa_file_save(apiurl, project, filename, content, comment=None):

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1162,8 +1162,8 @@ class StagingAPI(object):
         # If adi project, check for baselibs.conf in all specs to catch both
         # dynamically generated and static baselibs.conf.
         baselibs = False if self.is_adi_project(project) else None
-        if baselibs is False and 'baselibs.conf' in str(source_file_load(
-                self.apiurl, src_prj, src_pkg, '{}.spec'.format(src_pkg), src_rev)):
+        if baselibs is False and 'baselibs.conf' in source_file_load(
+                self.apiurl, src_prj, src_pkg, '{}.spec'.format(src_pkg), src_rev):
             baselibs = True
 
         for sub_pkg in self.get_sub_packages(tar_pkg, project):
@@ -1173,8 +1173,8 @@ class StagingAPI(object):
             url = self.makeurl(['source', project, sub_pkg, '_link'])
             http_PUT(url, data=ET.tostring(root))
 
-            if baselibs is False and 'baselibs.conf' in str(source_file_load(
-                    self.apiurl, src_prj, src_pkg, '{}.spec'.format(sub_pkg), src_rev)):
+            if baselibs is False and 'baselibs.conf' in source_file_load(
+                    self.apiurl, src_prj, src_pkg, '{}.spec'.format(sub_pkg), src_rev):
                 baselibs = True
 
         if baselibs:


### PR DESCRIPTION
Fixes https://github.com/openSUSE/openSUSE-release-tools/issues/2022

Use `source_file_load()` to get product file. And make `source_file_load()` always return string.