### PR TITLE
check_tags_in_requests: issue state is deleted not removed.

### DIFF
--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -84,7 +84,7 @@ by OBS on which this bot relies.
             self.logger.debug("reject: diff contains no tags")
             return False
         if deleted > 0:
-            self.review_messages['accepted'] = 'Warning: {} issues reference(s) deleted'.format(deleted)
+            self.review_messages['accepted'] = 'Warning: {} issue reference(s) deleted'.format(deleted)
             return True
         return True
 

--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -79,12 +79,12 @@ by OBS on which this bot relies.
 
         xml = ET.parse(f)
         issues = len(xml.findall('./issues/issue'))
-        removed = len(xml.findall('./issues/issue[@state="removed"]'))
+        deleted = len(xml.findall('./issues/issue[@state="deleted"]'))
         if issues == 0:
             self.logger.debug("reject: diff contains no tags")
             return False
-        if removed > 0:
-            self.review_messages['accepted'] = 'Warning: {} issues reference(s) removed'.format(removed)
+        if deleted > 0:
+            self.review_messages['accepted'] = 'Warning: {} issues reference(s) deleted'.format(deleted)
             return True
         return True
 

--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -84,8 +84,8 @@ by OBS on which this bot relies.
             self.logger.debug("reject: diff contains no tags")
             return False
         if deleted > 0:
-            self.review_messages['accepted'] = 'Warning: {} issue reference(s) deleted'.format(deleted)
-            return True
+            self.review_messages['declined'] = '{} issue reference(s) deleted'.format(deleted)
+            return False
         return True
 
     def checkTagNotRequired(self, req, a):


### PR DESCRIPTION
- 655bac280fe44e6c01cc28ef4227415c8997068b:
    check_tags_in_requests: escalate loss of issue references to a decline.

- 45e6b617e10bf627c191f56dc7edec7921ce5437:
    check_tags_in_requests: make issue singular since references is plural.

- a309e1c85b680a99a968987918ed5440c8775d61:
    check_tags_in_requests: issue state is deleted not removed.
    
    See #679, where it was originally added and provides example output.

Fixes #1991.