### PR TITLE
origin-manager: port and switch to python3.

### DIFF
--- a/origin-manager.py
+++ b/origin-manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from osclib.core import package_source_hash
 from osclib.origin import origin_annotation_dump

--- a/osc-origin.py
+++ b/osc-origin.py
@@ -131,7 +131,7 @@ def osrt_origin_lookup(apiurl, project, force_refresh=False, previous=False, qui
         with open(lookup_path, 'r') as lookup_stream:
             lookup = yaml.safe_load(lookup_stream)
 
-            if not isinstance(lookup.itervalues().next(), dict):
+            if not isinstance(next(iter(lookup.values())), dict):
                 # Convert flat format to dictionary.
                 for package, origin in lookup.items():
                     lookup[package] = {'origin': origin}

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -86,7 +86,7 @@ def config_resolve(apiurl, project, config):
     origins = config['origins']
     i = 0
     while i < len(origins):
-        origin = origins[i].keys()[0]
+        origin = next(iter(origins[i]))
         values = origins[i][origin]
 
         if origin == '*':

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -354,9 +354,9 @@ def policy_get(apiurl, project, package, origin):
 def policy_get_preprocess(apiurl, origin, policy):
     project = origin.rstrip('~')
     config_project = Config.get(apiurl, project)
-    policy['pending_submission_allowed_reviews'] = filter(None, [
+    policy['pending_submission_allowed_reviews'] = list(filter(None, [
         config_resolve_variable(v, config_project, 'config_source')
-        for v in policy['pending_submission_allowed_reviews']])
+        for v in policy['pending_submission_allowed_reviews']]))
 
     return policy
 

--- a/osclib/util.py
+++ b/osclib/util.py
@@ -159,4 +159,4 @@ def sha1_short(data):
     if isinstance(data, list):
         data = '::'.join(data)
 
-    return hashlib.sha1(data).hexdigest()[:7]
+    return hashlib.sha1(data.encode('utf-8')).hexdigest()[:7]


### PR DESCRIPTION
- 69f3fd13c8f48bbe74d635f868139e79737dbece:
    origin-manager: switch to python3.

- ceb4a9cea9598659a1970d57a367c9e4fd7b7d14:
    osclib/origin: cast filter() to list() to improve debug output [python3].

- 743b3a6cd63ce51b891a53ee39f6739b5d417282:
    osc-origin, osclib/origin: port first dict key/value access [python3].

- 7a1ff946cd2abf5cc4ca2873dd2553eacc739ac5:
    osclib/util: sha1_short(): encode data as utf-8 [python3].