### PR TITLE
There is no use of urlgrabber left

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -48,7 +48,6 @@ BuildRequires:  %{use_python}-lxml
 BuildRequires:  %{use_python}-pycurl
 BuildRequires:  %{use_python}-python-dateutil
 BuildRequires:  %{use_python}-pyxdg
-BuildRequires:  %{use_python}-urlgrabber
 
 # Spec related requirements.
 %if 0%{?is_opensuse}
@@ -69,7 +68,6 @@ Requires:       %{use_python}-pycurl
 Requires:       %{use_python}-python-dateutil
 Requires:       %{use_python}-pyxdg
 Requires:       %{use_python}-requests
-Requires:       %{use_python}-urlgrabber
 # ttm/manager.py
 %if %{without python3}
 Requires:       python-enum34

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,11 @@ lxml
 PyYAML
 pycurl
 python-dateutil
-urlgrabber
 pyxdg
 cmdln
 git+https://github.com/openSUSE/osc
 influxdb
 
 # Dependencies for testing
-httpretty<0.9.6
+httpretty
 mock


### PR DESCRIPTION
As the package does not exist as python3 variant in leap 15.1, we
better remove it now