### PR TITLE
dist/k8s/heroes: include openSUSE:Leap:15.1:NonFree in origin_manager_report.

### DIFF
--- a/dist/kubernetes/environments/heroes/params.libsonnet
+++ b/dist/kubernetes/environments/heroes/params.libsonnet
@@ -13,6 +13,7 @@ local envParams = params + {
     "obs-operator.origin_manager_report"+: {
       projects: [
         "openSUSE:Leap:15.1",
+        "openSUSE:Leap:15.1:NonFree",
       ],
     },
     "repo-checker.project_only"+: {

--- a/osclib/util.py
+++ b/osclib/util.py
@@ -35,7 +35,7 @@ def project_list_family(apiurl, project, include_update=False):
 
     prefix = ':'.join(project.split(':')[:-1])
     projects = project_list_prefix(apiurl, prefix)
-    projects = filter(family_filter, projects)
+    projects = list(filter(family_filter, projects))
 
     if project_suffix:
         for i, project in enumerate(projects):
@@ -44,7 +44,7 @@ def project_list_family(apiurl, project, include_update=False):
             else:
                 projects[i] += project_suffix
 
-    return list(projects)
+    return projects
 
 def project_list_family_prior(apiurl, project, include_self=False, last=None, include_update=False):
     """


### PR DESCRIPTION
- c4dccf80ab91f933a893b6faf5e0bc60abbb7210:
    dist/k8s/heroes: include openSUSE:Leap:15.1:NonFree in origin_manager_report.

- 14ae392743ff8d71abd530779dc0569f8d324ab9:
    osclib/util: correct python3 port by casting to list directly after filter.
    
    8bf2602 cast to list during on the return line, but that does not work
    if a project_suffix is present.

The python3 commit is needed since :NonFree project triggers the other branch which causes a crash with the prior port attempt.