### PR TITLE
.gitignore: ignore osc symlink commonly used to develop against git osc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .docker-tmp/
 .open-build-service/
 .bash_history
+osc

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ If working on an `osc` plugin create symlinks for the plugin and `osclib` in eit
 
     ln -sr ./osc-staging.py ./osclib ~/.osc-plugins
 
+It can also be useful to work against a development copy of `osc` either to utilize new features or to debug/fix functionality. To do so one must place the development copy in the path to be loaded and utilize the wrapper script if working on `osc` plugins. One method to accomplish this is shown below.
+
+    # outside of openSUSE-release-tools checkout
+    git clone git clone https://github.com/openSUSE/osc.git
+
+    # inside openSUSE-release-tools checkout
+    # note the ending /osc which points to the osc directory within the checkout
+    ln -s /path/to/osc/osc ./
+
+    # to utilize the wrapper for working on osc plugins from osrt checkout
+    $(realpath ./osc)/../osc-wrapper.py --version
+
 A containerized OBS can be started via one command. The default credentials are `Admin` and `opensuse` on [0.0.0.0:3000](http://0.0.0.0:3000).
 
     ./dist/ci/docker-compose-obs


### PR DESCRIPTION
While going through never merged branched and stash to get small origin-manager follow-ups I decided to add a bit for developing against git osc since it became especially relevant again with python 3 porting.