### PR TITLE
origin-manager: small follow-ups.

### DIFF
--- a/osclib/core.py
+++ b/osclib/core.py
@@ -642,7 +642,7 @@ def package_version(apiurl, project, package):
 
         raise e
 
-    return root.xpath('(//version)[last()]/text()')[0]
+    return str(root.xpath('(//version)[last()]/text()')[0])
 
 def project_attribute_list(apiurl, attribute, value=None):
     xpath = 'attribute/@name="{}"'.format(attribute)

--- a/systemd/osrt-obs-operator-origin-manager-report@.service
+++ b/systemd/osrt-obs-operator-origin-manager-report@.service
@@ -5,7 +5,7 @@ Description=openSUSE Release Tools: OBS Operator origin-manager report for %i
 User=osrt-obs-operator
 SyslogIdentifier=osrt-obs-operator-origin-manager
 ExecStart=/usr/bin/osc origin -p "%i" report --force-refresh
-RuntimeMaxSec=12 hour
+RuntimeMaxSec=24 hour
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/osrt-origin-manager-report@.service
+++ b/systemd/osrt-origin-manager-report@.service
@@ -5,7 +5,7 @@ Description=openSUSE Release Tools: origin-manager report for %i
 User=osrt-origin-manager
 SyslogIdentifier=osrt-origin-manager
 ExecStart=/usr/bin/osc origin -p "%i" report --diff --force-refresh --mail
-RuntimeMaxSec=12 hour
+RuntimeMaxSec=24 hour
 
 [Install]
 WantedBy=multi-user.target

--- a/userscript/staging-move-drag-n-drop.user.js
+++ b/userscript/staging-move-drag-n-drop.user.js
@@ -271,7 +271,7 @@ var initMoveInterface = function() {
         var project = pathParts[pathParts.length - 1];
 
         var data = JSON.stringify({'user': user, 'project': project, 'move': true, 'selection': summary});
-        var domain_parent = window.location.hostname.split('.').splice(1).join('.');
+        var domain_parent = window.location.hostname.split('.').splice(-2).join('.');
         var subdomain = domain_parent.endsWith('suse.de') ? 'tortuga' : 'operator';
         var url = 'https://' + subdomain + '.' + domain_parent + '/staging/select';
         $.post({url: url, data: data, crossDomain: true, xhrFields: {withCredentials: true},


### PR DESCRIPTION
- 84ead945f36bb05107268aa251e8348345e3feae:
    userscript/staging*: only utilize the last two domain components.
    
    Allows for the hostname to contain multilevel subdomain and still access
    the same operator server. Consistent with changes made to operator and
    origin userscript.

- dde0edef40625b76f3f30dfb463d6fd9f37a741c:
    osclib/core: package_version(): drop lxml element and return string version.
    
    Resolves undesirable output when formatting a data structure that includes
    the result from this function as yaml.

- fb34f6214347fc5404da290e0fde57ce5d3f89dd:
    systemd: increase timeout to 24 hours for origin-manager report services.

A few follow-ups.