### PR TITLE
accept_command: fix missing the url for uploading product file change

### DIFF
--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -306,6 +306,7 @@ class AcceptCommand(object):
 
             if product_spec != new_product:
                 update_version_attr = True
+                url = self.api.makeurl(['source', project, product_pkg,  product_name])
                 http_PUT(url + '?comment=Update+version', data=new_product)
 
         if update_version_attr:


### PR DESCRIPTION
Regression from acc0ffc3852700cc996109f350f72dcb9ff1b3fe , we still need url for uploading product file change. That's why my testing on Leap works but now it's a problem on TW.