### PR TITLE
Move legaldb import of projects into gocd

### DIFF
--- a/gocd/checkers.opensuse.gocd.yaml
+++ b/gocd/checkers.opensuse.gocd.yaml
@@ -63,6 +63,27 @@ pipelines:
             - staging-bot3
             tasks:
             - script: ./legal-auto.py -A https://api.opensuse.org --debug --legaldb http://legaldb.suse.de review
+  openSUSE.Legal.Import:
+    group: openSUSE.Checkers
+    lock_behavior: unlockWhenFinished
+    timer:
+      spec: 0 0 12 ? * *
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-legal-auto
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    stages:
+    - Run:
+        approval:
+          type: manual
+        jobs:
+          Run:
+            timeout: 0
+            resources:
+            - legal-auto
+            tasks:
+            - script: ./legal-auto.py -A https://api.opensuse.org --debug --legaldb http://legaldb.suse.de project $(cat /home/go/config/legal-auto-projects-opensuse)
   Factory.Staging.Report:
     group: openSUSE.Checkers
     lock_behavior: unlockWhenFinished

--- a/gocd/checkers.suse.gocd.yaml
+++ b/gocd/checkers.suse.gocd.yaml
@@ -218,6 +218,27 @@ pipelines:
             - staging-bot3
             tasks:
             - script: ./legal-auto.py -A https://api.suse.de --debug --legaldb http://legaldb.suse.de review
+  SLE.Legal.Import:
+    group: SLE.Checkers
+    lock_behavior: unlockWhenFinished
+    timer:
+      spec: 0 0 0 ? * *
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-legal-auto
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    stages:
+    - Run:
+        approval:
+          type: manual
+        jobs:
+          Run:
+            timeout: 0
+            resources:
+            - legal-auto
+            tasks:
+            - script: ./legal-auto.py -A https://api.suse.de --debug --legaldb http://legaldb.suse.de project $(cat /home/go/config/legal-auto-projects-suse)
   SLE12.SP5.InstallCheck.A:
     group: SLE.Checkers
     lock_behavior: unlockWhenFinished

--- a/gocd/checkers.suse.gocd.yaml.erb
+++ b/gocd/checkers.suse.gocd.yaml.erb
@@ -218,6 +218,27 @@ pipelines:
             - staging-bot3
             tasks:
             - script: ./legal-auto.py -A https://api.suse.de --debug --legaldb http://legaldb.suse.de review
+  SLE.Legal.Import:
+    group: SLE.Checkers
+    lock_behavior: unlockWhenFinished
+    timer:
+      spec: 0 0 0 ? * *
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-legal-auto
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    stages:
+    - Run:
+        approval:
+          type: manual
+        jobs:
+          Run:
+            timeout: 0
+            resources:
+            - legal-auto
+            tasks:
+            - script: ./legal-auto.py -A https://api.suse.de --debug --legaldb http://legaldb.suse.de project $(cat /home/go/config/legal-auto-projects-suse)
 <% %w(A B C D H S V Y).each do |letter| -%>
   SLE12.SP5.InstallCheck.<%= letter %>:
     group: SLE.Checkers


### PR DESCRIPTION
This is mainly to tag the sources that are in the projects for safer
cleanup strategies