### PR TITLE
Run obs-autosubmit on gocd

### DIFF
--- a/gocd/autosubmit.gocd.yaml
+++ b/gocd/autosubmit.gocd.yaml
@@ -1,0 +1,20 @@
+format_version: 3
+pipelines:
+  Factory.Auto.Submit:
+    group: openSUSE.Checkers
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-factory-maintainer
+    materials:
+      script:
+        git: https://github.com/openSUSE/obs-autosubmit
+    timer:
+      spec: 0 0 * ? * *
+      only_on_changes: false
+    stages:
+    - Run:
+        resources:
+        - autosubmit
+        tasks:
+        - script: |-
+            ./obs-autosubmit -v --debug --cache-dir /home/go/.cache/openSUSE-release-tools/autosubmit/


### PR DESCRIPTION
It was stuck for 2 months on packagelists without one noticing, so put it on the bot dashboard (needs to be ported to python3 though)