### PR TITLE
Use a temporary directory for staging plugin

### DIFF
--- a/gocd/check-duplicated-binaries.gocd.yaml
+++ b/gocd/check-duplicated-binaries.gocd.yaml
@@ -17,4 +17,10 @@ pipelines:
         resources:
         - staging-bot
         tasks:
-        - script: osc staging -p openSUSE:Factory check_duplicate_binaries --save
+        - script: |-
+            tempdir=$(mktemp -d)
+            mkdir -p $tempdir/.osc-plugins
+            ln -s $PWD/osc-staging.py $tempdir/.osc-plugins
+            ln -s $PWD/osclib $tempdir/.osc-plugins
+            HOME=$tempdir osc staging -p openSUSE:Factory check_duplicate_binaries --save
+            rm -rf $tempdir

--- a/gocd/staging.bot.gocd.yaml
+++ b/gocd/staging.bot.gocd.yaml
@@ -23,7 +23,7 @@ pipelines:
             - repo-checker
             tasks:
             - script: |-
-                python3 ./scripts/staging-installcheck.py -A https://api.opensuse.org -p openSUSE:Factory
+                ./scripts/staging-installcheck.py -A https://api.opensuse.org -p openSUSE:Factory
   SBot.Regular.Factory:
     group: Factory.pkglistgen
     lock_behavior: unlockWhenFinished
@@ -44,12 +44,22 @@ pipelines:
             resources:
             - staging-bot
             tasks:
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:Factory rebuild
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:Factory list --supersede
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:Factory adi --by-develproject
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:Factory select --non-interactive --merge --try-strategies
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:Factory unselect --cleanup
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:Factory repair --cleanup
+            - script: |-
+               set -e
+               tempdir=$(mktemp -d)
+               mkdir -p $tempdir/.osc-plugins
+               ln -s $PWD/osc-staging.py $tempdir/.osc-plugins
+               ln -s $PWD/osclib $tempdir/.osc-plugins
+               export HOME=$tempdir
+
+               osc -A https://api.opensuse.org staging -p openSUSE:Factory rebuild
+               osc -A https://api.opensuse.org staging -p openSUSE:Factory list --supersede
+               osc -A https://api.opensuse.org staging -p openSUSE:Factory adi --by-develproject
+               osc -A https://api.opensuse.org staging -p openSUSE:Factory select --non-interactive --merge --try-strategies
+               osc -A https://api.opensuse.org staging -p openSUSE:Factory unselect --cleanup
+               osc -A https://api.opensuse.org staging -p openSUSE:Factory repair --cleanup
+               rm -rf $tempdir
+
   AdiChecker.Leap.15.1:
     group: openSUSE.Checkers
     lock_behavior: unlockWhenFinished
@@ -73,7 +83,7 @@ pipelines:
             - repo-checker
             tasks:
             - script: |-
-                python3 ./scripts/staging-installcheck.py -A https://api.opensuse.org -p openSUSE:Leap:15.1
+                ./scripts/staging-installcheck.py -A https://api.opensuse.org -p openSUSE:Leap:15.1
   SBot.Regular.Leap.15.1:
     group: Leap.15.1.pkglistgen
     lock_behavior: unlockWhenFinished
@@ -94,12 +104,22 @@ pipelines:
             resources:
             - staging-bot
             tasks:
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:Leap:15.1 rebuild
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:Leap:15.1 list --supersede
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:Leap:15.1 adi --by-develproject
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:Leap:15.1 select --non-interactive --merge --try-strategies
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:Leap:15.1 unselect --cleanup
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:Leap:15.1 repair --cleanup
+            - script: |-
+               set -e
+               tempdir=$(mktemp -d)
+               mkdir -p $tempdir/.osc-plugins
+               ln -s $PWD/osc-staging.py $tempdir/.osc-plugins
+               ln -s $PWD/osclib $tempdir/.osc-plugins
+               export HOME=$tempdir
+
+               osc -A https://api.opensuse.org staging -p openSUSE:Leap:15.1 rebuild
+               osc -A https://api.opensuse.org staging -p openSUSE:Leap:15.1 list --supersede
+               osc -A https://api.opensuse.org staging -p openSUSE:Leap:15.1 adi --by-develproject
+               osc -A https://api.opensuse.org staging -p openSUSE:Leap:15.1 select --non-interactive --merge --try-strategies
+               osc -A https://api.opensuse.org staging -p openSUSE:Leap:15.1 unselect --cleanup
+               osc -A https://api.opensuse.org staging -p openSUSE:Leap:15.1 repair --cleanup
+               rm -rf $tempdir
+
   Project.Only:
     group: openSUSE.Checkers
     lock_behavior: unlockWhenFinished

--- a/gocd/staging.bot.gocd.yaml.erb
+++ b/gocd/staging.bot.gocd.yaml.erb
@@ -25,7 +25,7 @@ pipelines:
             - repo-checker
             tasks:
             - script: |-
-                python3 ./scripts/staging-installcheck.py -A https://api.opensuse.org -p openSUSE:<%= project %>
+                ./scripts/staging-installcheck.py -A https://api.opensuse.org -p openSUSE:<%= project %>
   SBot.Regular.<%= nickname %>:
     group: <%= nickname %>.pkglistgen
     lock_behavior: unlockWhenFinished
@@ -46,12 +46,22 @@ pipelines:
             resources:
             - staging-bot
             tasks:
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> rebuild
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> list --supersede
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> adi --by-develproject
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> select --non-interactive --merge --try-strategies
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> unselect --cleanup
-            - script: osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> repair --cleanup
+            - script: |-
+               set -e
+               tempdir=$(mktemp -d)
+               mkdir -p $tempdir/.osc-plugins
+               ln -s $PWD/osc-staging.py $tempdir/.osc-plugins
+               ln -s $PWD/osclib $tempdir/.osc-plugins
+               export HOME=$tempdir
+
+               osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> rebuild
+               osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> list --supersede
+               osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> adi --by-develproject
+               osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> select --non-interactive --merge --try-strategies
+               osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> unselect --cleanup
+               osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> repair --cleanup
+               rm -rf $tempdir
+
 <% end -%>
   Project.Only:
     group: openSUSE.Checkers


### PR DESCRIPTION
This way we don't rely on installed plugin (to avoid the deployment cycle) and we don't need to install into the real home of the go user to avoid risking that a broken plugin breaks all future jobs of the agent