### PR TITLE
Fix inner-staging links to use cicount=copy

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1165,7 +1165,7 @@ class StagingAPI(object):
         for sub_pkg in self.get_sub_packages(tar_pkg, project):
             self.create_package_container(project, sub_pkg)
 
-            root = ET.Element('link', package=tar_pkg, project=project)
+            root = ET.Element('link', package=tar_pkg, cicount='copy')
             url = self.makeurl(['source', project, sub_pkg, '_link'])
             http_PUT(url, data=ET.tostring(root))
 


### PR DESCRIPTION
We need to keep the cicount in sync for the kernel as kernel-syms requires kernel-default of kernel-source