### PR TITLE
rebuildpacs: ignore issues of petsc:openmpi

### DIFF
--- a/rebuildpacs.pl
+++ b/rebuildpacs.pl
@@ -304,6 +304,7 @@ while (<INSTALLCHECK>) {
         patterns-openSUSE
         patterns-yast
         petsc:serial
+        petsc:openmpi
         python-numpy:gnu-hpc
         scalapack:gnu-mvapich2-hpc
         scalapack:gnu-openmpi-hpc


### PR DESCRIPTION
A further workaround for https://github.com/openSUSE/openSUSE-release-tools/issues/1222