### PR TITLE
origin-manager: handle maintenance workflow at multiple levels

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 from osclib.cache import Cache
 from osclib.comments import CommentAPI
 from osclib.conf import Config
+from osclib.core import action_is_patchinfo
 from osclib.core import devel_project_fallback
 from osclib.core import group_members
 from osclib.core import maintainers_get
@@ -406,12 +407,8 @@ class ReviewBot(object):
         method_type = '_default'
         return '_'.join([method_prefix, method_type])
 
-    @staticmethod
-    def _is_patchinfo(pkgname):
-        return pkgname == 'patchinfo' or pkgname.startswith('patchinfo.')
-
     def check_action_maintenance_incident(self, req, a):
-        if self._is_patchinfo(a.src_package):
+        if action_is_patchinfo(a):
             self.logger.debug('ignoring patchinfo action')
             return True
 
@@ -434,7 +431,7 @@ class ReviewBot(object):
 
     def check_action_maintenance_release(self, req, a):
         pkgname = a.src_package
-        if self._is_patchinfo(pkgname):
+        if action_is_patchinfo(a):
             self.logger.debug('ignoring patchinfo action')
             return True
 

--- a/check_maintenance_incidents.py
+++ b/check_maintenance_incidents.py
@@ -17,6 +17,7 @@ from urllib.error import HTTPError, URLError
 import yaml
 
 from osclib.memoize import memoize
+from osclib.core import action_is_patchinfo
 from osclib.core import owner_fallback
 from osclib.core import maintainers_get
 
@@ -33,7 +34,7 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
     def add_devel_project_review(self, req, package):
         """ add devel project/package as reviewer """
         a = req.actions[0]
-        if self._is_patchinfo(a.src_package):
+        if action_is_patchinfo(a):
             a = req.actions[1]
         project = a.tgt_releaseproject if a.type == 'maintenance_incident' else req.actions[0].tgt_project
         root = owner_fallback(self.apiurl, project, package)
@@ -71,7 +72,7 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
             (linkprj, linkpkg) = self._get_linktarget(a.src_project, pkgname)
             if linkpkg is not None:
                 pkgname = linkpkg
-            if self._is_patchinfo(a.src_package):
+            if action_is_patchinfo(a):
                 return None
 
             project = a.tgt_releaseproject

--- a/origin-manager.py
+++ b/origin-manager.py
@@ -66,11 +66,12 @@ class OriginManager(ReviewBot.ReviewBot):
             override = self.request_override_check(self.request, True)
             if override:
                 self.review_messages['accepted'] = origin_annotation_dump(
-                    origin_info_new, origin_info_old, self.review_messages['accepted'])
+                    origin_info_new, origin_info_old, self.review_messages['accepted'], raw=True)
                 return override
         else:
             if result.accept:
-                self.review_messages['accepted'] = origin_annotation_dump(origin_info_new, origin_info_old)
+                self.review_messages['accepted'] = origin_annotation_dump(
+                    origin_info_new, origin_info_old, raw=True)
             return result.accept
 
         return None

--- a/origin-manager.py
+++ b/origin-manager.py
@@ -49,13 +49,13 @@ class OriginManager(ReviewBot.ReviewBot):
     def config_validate(self, target_project):
         config = config_load(self.apiurl, target_project)
         if not config:
-            if self.multiple_actions:
-                # Completely ignore actions for projects without a config.
-                self.review_messages['accepted'] = 'skipping since no config'
-                return False, True
-
-            self.review_messages['declined'] = 'OSRT:OriginConfig attribute missing'
-            return False, False
+            # No perfect solution for lack of a config. For normal projects a
+            # decline seems best, but in the event of failure to return proper
+            # config no good behavior. For maintenance the situation is further
+            # complicated since multiple actions some of which are not intended
+            # to be reviewed, but not always guaranteed to see multiple actions.
+            self.review_messages['accepted'] = 'skipping since no OSRT:OriginConfig'
+            return False, True
         if not config.get('fallback-group'):
             self.review_messages['declined'] = 'OSRT:OriginConfig.fallback-group missing'
             return False, False

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -768,3 +768,7 @@ def search(apiurl, path, xpath, query={}):
     query['match'] = xpath
     url = makeurl(apiurl, ['search', path], query)
     return ETL.parse(http_GET(url)).getroot()
+
+def action_is_patchinfo(action):
+    return (action.type == 'maintenance_incident' and (
+        action.src_package == 'patchinfo' or action.src_package.startswith('patchinfo.')))

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -337,9 +337,12 @@ def attribute_value_load(apiurl, project, name, namespace='OSRT'):
 
         raise e
 
-    value = root.xpath(
-        './attribute[@namespace="{}" and @name="{}"]/value/text()'.format(namespace, name))
+    xpath_base = './attribute[@namespace="{}" and @name="{}"]'.format(namespace, name)
+    value = root.xpath('{}/value/text()'.format(xpath_base))
     if not len(value):
+        if root.xpath(xpath_base):
+            # Handle boolean attributes that are present, but have no value.
+            return True
         return None
 
     return str(value[0])

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -775,3 +775,32 @@ def search(apiurl, path, xpath, query={}):
 def action_is_patchinfo(action):
     return (action.type == 'maintenance_incident' and (
         action.src_package == 'patchinfo' or action.src_package.startswith('patchinfo.')))
+
+def request_action_key(action):
+    identifier = []
+
+    if action.type in ['add_role', 'change_devel', 'maintenance_release', 'submit']:
+        identifier.append(action.tgt_project)
+        identifier.append(action.tgt_package)
+
+        if action.type in ['add_role', 'set_bugowner']:
+            if action.person_name is not None:
+                identifier.append(action.person_name)
+                if action.type == 'add_role':
+                    identifier.append(action.person_role)
+            else:
+                identifier.append(action.group_name)
+                if action.type == 'add_role':
+                    identifier.append(action.group_role)
+    elif action.type == 'delete':
+        identifier.append(action.tgt_project)
+        if action.tgt_package is not None:
+            identifier.append(action.tgt_package)
+        elif action.tgt_repository is not None:
+            identifier.append(action.tgt_repository)
+    elif action.type == 'maintenance_incident':
+        if not action_is_patchinfo(action):
+            identifier.append(action.tgt_releaseproject)
+        identifier.append(action.src_package)
+
+    return '::'.join(['/'.join(identifier), action.type])

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -296,7 +296,7 @@ def origin_find_fallback(apiurl, target_project, package, source_hash, user):
 
     return None
 
-def origin_annotation_dump(origin_info_new, origin_info_old, override=False):
+def origin_annotation_dump(origin_info_new, origin_info_old, override=False, raw=False):
     data = {'origin': str(origin_info_new.project)}
     if origin_info_old and origin_info_new.project != origin_info_old.project:
         data['origin_old'] = str(origin_info_old.project)
@@ -304,6 +304,9 @@ def origin_annotation_dump(origin_info_new, origin_info_old, override=False):
     if override:
         data['origin'] = origin_workaround_ensure(data['origin'])
         data['comment'] = override
+
+    if raw:
+        return data
 
     return yaml.dump(data, default_flow_style=False)
 

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -12,9 +12,9 @@ from osclib.core import package_version
 from osclib.core import project_remote_apiurl
 from osclib.core import request_action_key
 from osclib.core import request_action_list_source
+from osclib.core import request_remote_identifier
 from osclib.core import review_find_last
 from osclib.core import reviews_remaining
-from osclib.core import request_remote_identifier
 from osclib.memoize import memoize
 from osclib.util import project_list_family
 from osclib.util import project_list_family_prior_pattern

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -10,6 +10,8 @@ from osclib.core import package_source_hash
 from osclib.core import package_source_hash_history
 from osclib.core import package_version
 from osclib.core import project_remote_apiurl
+from osclib.core import request_action_key
+from osclib.core import request_action_list_source
 from osclib.core import review_find_last
 from osclib.core import reviews_remaining
 from osclib.core import request_remote_identifier
@@ -267,13 +269,12 @@ def project_source_log(key, project, source_hash_consider, source_hash):
 def origin_find_fallback(apiurl, target_project, package, source_hash, user):
     # Search accepted requests (newest to oldest), find the last review made by
     # the specified user, load comment as annotation, and extract origin.
-    requests = get_request_list(apiurl, target_project, package, None, ['accepted'], 'submit')
-    for request in sorted(requests, key=lambda r: r.reqid, reverse=True):
-        review = review_find_last(request, user)
-        if not review:
+    request_actions = request_action_list_source(apiurl, target_project, package, states=['accepted'])
+    for request, action in sorted(request_actions, key=lambda i: i[0].reqid, reverse=True):
+        annotation = origin_annotation_load(request, action, user)
+        if not annotation:
             continue
 
-        annotation = origin_annotation_load(review.comment)
         return OriginInfo(annotation.get('origin'), False)
 
     # Fallback to searching workaround project.
@@ -310,10 +311,31 @@ def origin_annotation_dump(origin_info_new, origin_info_old, override=False, raw
 
     return yaml.dump(data, default_flow_style=False)
 
-def origin_annotation_load(annotation):
-    # For some reason OBS insists on indenting every subsequent line which
-    # screws up yaml parsing since indentation has meaning.
-    return yaml.safe_load(re.sub(r'^\s+', '', annotation, flags=re.MULTILINE))
+def origin_annotation_load(request, action, user):
+    review = review_find_last(request, user)
+    if not review:
+        return False
+
+    try:
+        annotation = yaml.safe_load(review.comment)
+    except yaml.scanner.ScannerError as e:
+        # OBS used to prefix subsequent review lines with two spaces. At some
+        # point it was changed to no longer indent, but still need to be able
+        # to load older annotations.
+        comment_stripped = re.sub(r'^  ', '', review.comment, flags=re.MULTILINE)
+        annotation = yaml.safe_load(comment_stripped)
+
+    if not annotation:
+        return None
+
+    if len(request.actions) > 1:
+        action_key = request_action_key(action)
+        if action_key not in annotation:
+            return False
+
+        return annotation[action_key]
+
+    return annotation
 
 def origin_find_highest(apiurl, project, package):
     config = config_load(apiurl, project)
@@ -531,13 +553,9 @@ def origin_potentials(apiurl, target_project, package):
 def origin_history(apiurl, target_project, package, user):
     history = []
 
-    requests = get_request_list(apiurl, target_project, package, None, ['all'], 'submit')
-    for request in sorted(requests, key=lambda r: r.reqid, reverse=True):
-        review = review_find_last(request, user)
-        if not review:
-            continue
-
-        annotation = origin_annotation_load(review.comment)
+    request_actions = request_action_list_source(apiurl, target_project, package, states=['all'])
+    for request, action in sorted(request_actions, key=lambda i: i[0].reqid, reverse=True):
+        annotation = origin_annotation_load(request, action, user)
         if not annotation:
             continue
 

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -247,17 +247,17 @@ def project_source_contain(apiurl, project, package, source_hash):
 
 def project_source_pending(apiurl, project, package, source_hash):
     apiurl_remote, project_remote = project_remote_apiurl(apiurl, project)
-    requests = get_request_list(apiurl_remote, project_remote, package, None, ['new', 'review'], 'submit')
-    for request in requests:
-        for action in request.actions:
-            source_hash_consider = package_source_hash(
-                apiurl_remote, action.src_project, action.src_package, action.src_rev)
+    request_actions = request_action_list_source(apiurl_remote, project_remote, package,
+                                                 states=['new', 'review'], include_release=True)
+    for request, action in request_actions:
+        source_hash_consider = package_source_hash(
+            apiurl_remote, action.src_project, action.src_package, action.src_rev)
 
-            project_source_log('pending', project, source_hash_consider, source_hash)
-            if source_hash_consider == source_hash:
-                return PendingRequestInfo(
-                    request_remote_identifier(apiurl, apiurl_remote, request.reqid),
-                    reviews_remaining(request))
+        project_source_log('pending', project, source_hash_consider, source_hash)
+        if source_hash_consider == source_hash:
+            return PendingRequestInfo(
+                request_remote_identifier(apiurl, apiurl_remote, request.reqid),
+                reviews_remaining(request))
 
     return False
 


### PR DESCRIPTION
- 25d1584899852c82a67757ced4ed3640f7ae5a0c:
    osclib/origin: correct import order.

- cd3c011c756c1ea7b296690e317bcecef5827276:
    osclib/origin: support pending source lookup against maintenance origin.
    
    Works for both maintenance incident (both states) and release.

- 05cc79a1f823c86ae015cc01c5eabd352b8e966e:
    osclib/origin: handle nested annotation loading and support maintenance incidents.

- 086117e4ca2b05c31f152ede7a5087cec8c69126:
    osclib/core: provide a series of request list generators.
    
    Given the broken design of multi-action requests which continually wreaks
    havoc on code attempting to handle them properly a series of methods for
    searching for requests are provided to simplify the process. The core
    principal is that both a request and action are returned since the
    specific action that matched the search query is important.
    
    Further poorly designed maintenance data structure is also abstracted to
    provide a consistent interface for querying source changes regardless of
    their state in the workflow.

- 08da40848a415e3d22e21ece129b53b1af4023de:
    origin-manager: allow for skipping actions with no config when multiple.
    
    Skipping actions that are not relevant for origin review is essential for
    the maintenance workflow where multi-actions may include projects not
    managed by origin-manager, but the remaining actions should be reviewed.

- 9018a8cabd9cdaf6767e62a75d8cef20254921ec:
    ReviewBot: nest review messages by action key when multiple actions.
    
    Not only does this expose previously hidden messages on multi-action
    requests, but also provides clarity as to which action triggered a
    specific response. Since the keys are generated in a standard way and
    the data formatted as YAML it can also be retrieved.

- fa41d3ae214f88ce76fdc5dc3a810e2fb10174ca:
    osclib/origin: origin_annotation_dump() provide raw option.

- 0f1b9d667e728c16ad1079b75f5f6e3aa18aa1ef:
    osclib/core: provide request_action_key().
    
    Intended to facilitate standardized keys for action specific information
    placed in review scoped storage (ie. reviews/comments).

- aa444f79e614bec9f4b52854c2a9201e8abaa093:
    osclib/core: enhance attribute_value_load() to handle boolean attributes.

- a8ff27b81f71ec6065e4e3cfc1588b3d80db8064:
    osclib/core: provide action_is_patchinfo() from ReviewBot.
    
    Allows for usage outside of ReviewBot children.

- e991b446339d1a38b144dc68022ffc14faffdd92:
    osclib/core: provide simplified search() and utilize.

Fixes #1961.
Also handles a maintenance project being the target project.

I've run through quite a few test scenarios, but a lot of details here and fun things like OBS changing it's behavior in a way that older requests look different from newer ones with the same data. :) The maintenance workflow data-structure is awful. As such I'll spend the next day or so testing more thoroughly and merge if nothing outstanding.

I no longer seem to have the ability to edit `OSRT` attribute definitions and thus cannot add a config for `openSUSE:Leap:15.1:Update`, but tested with local override. Once merged and deployed enabling `pending_submission_(allow|consider)` on `openSUSE:Leap:15.2` will make sense to complete the feature request from @lnussel.

This also technically makes all `ReviewBot`s have improved context when working on multi-action requests. Hopefully no unknown uses of the message data that this would effect.