### PR TITLE
Filter out release numbers from problem output

### DIFF
--- a/osclib/repochecks.py
+++ b/osclib/repochecks.py
@@ -81,6 +81,11 @@ def _fileconflicts(pfile, target_packages, whitelist):
         if len(output):
             return output
 
+def filter_release(line):
+    line = re.sub(r'(package [^ ]*\-[^-]*)\-[^-]*(\.\w+) ', r'\1\2 ', line)
+    line = re.sub(r'(needed by [^ ]*\-[^-]*)\-[^-]*(\.\w+)$', r'\1\2', line)
+    line = re.sub(r'(provided by [^ ]*\-[^-]*)\-[^-]*(\.\w+)$', r'\1\2', line)
+    return line
 
 def parsed_installcheck(pfile, arch, target_packages, whitelist):
     reported_problems = dict()
@@ -109,7 +114,7 @@ def parsed_installcheck(pfile, arch, target_packages, whitelist):
                 in_problem = True
                 continue
             if in_problem:
-                reported_problems[package]['output'].append(line[2:])
+                reported_problems[package]['output'].append(filter_release(line[2:]))
 
         return reported_problems
 


### PR DESCRIPTION
Otherwise the output will differ on rebuilds, making the whole stunt
useless