### PR TITLE
osclib/origin: always include project link when fetching source history.

### DIFF
--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -238,7 +238,8 @@ def origin_find(apiurl, target_project, package, source_hash=None, current=False
     return None
 
 def project_source_contain(apiurl, project, package, source_hash):
-    for source_hash_consider in package_source_hash_history(apiurl, project, package):
+    for source_hash_consider in package_source_hash_history(
+        apiurl, project, package, include_project_link=True):
         project_source_log('contain', project, source_hash_consider, source_hash)
         if source_hash_consider == source_hash:
             return True
@@ -285,7 +286,8 @@ def origin_find_fallback(apiurl, target_project, package, source_hash, user):
 
     # Attempt to find a revision of target package that matches an origin.
     first = True
-    for source_hash_consider in package_source_hash_history(apiurl, target_project, package):
+    for source_hash_consider in package_source_hash_history(
+        apiurl, target_project, package, include_project_link=True):
         if first:
             first = False
             continue
@@ -522,7 +524,7 @@ def origin_revision_state(apiurl, target_project, package, origin_info=False, li
     else:
         origin_project = origin_info.project.rstrip('~')
         origin_hashes = list(package_source_hash_history(apiurl, origin_project, package, limit * 2, True))
-    target_hashes = list(package_source_hash_history(apiurl, target_project, package, limit))
+    target_hashes = list(package_source_hash_history(apiurl, target_project, package, limit, True))
     for source_hash in origin_hashes:
         if source_hash not in target_hashes:
             revisions.append(-1)


### PR DESCRIPTION
This was debated as for SLE this would add some repetition when not
going to match a SLE origin anyway, but it is necessary to stabilize
maintenance origins.

When an :Update project is first created all sources are inherited which
means all the revisions from the top project's source container are
considered. Once an update is provided via a maintenance incident the
inherited sources are no longer presented and instead the only revision
seen is the maintenance update and future updates.

When a new version of Leap is created and all source containers are copied
from the previous version the origin will first be considered :Update of
the previous Leap version, but once a maintenance update is created it
will drop the the non-:Update prior version since the matching revision is
missing. If the update is submitted the origin will flip back to :Update.

In order to avoid this mess always utilize include_project_link=True
which will effective consider the maintenance update as the newest
revision while continuing to consider the inherited revisions.

For SLE, were all projects are stacked this means there will almost always
be 10 revisions to review after the first could releases.

Realistically this is yet another failing of the OBS source control model since
the original source revision available (via inheritance) in the :Update project is
lost after the first update.

An example, [request 720684](https://build.opensuse.org/request/show/720684).