### PR TITLE
origin-manager: provide equivalent to update_crawler as osc-origin update command

### DIFF
--- a/gocd/checkers.opensuse.gocd.yaml
+++ b/gocd/checkers.opensuse.gocd.yaml
@@ -247,3 +247,21 @@ pipelines:
           - staging-bot
         tasks:
           - script: ./origin-manager.py -A https://api.opensuse.org --debug review
+  OS.Origin.Manager.Update:
+    group: openSUSE.Checkers
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-origin-manager
+    materials:
+      script:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    timer:
+      spec: 0 7 * ? * *
+      only_on_changes: false
+    stages:
+    - Run:
+        approval: manual
+        resources:
+          - staging-bot
+        tasks:
+          - script: osc -A https://api.opensuse.org origin -p openSUSE:Leap:15.2 update

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -272,10 +272,7 @@ def source_file_load(apiurl, project, package, filename, revision=None):
         return None
 
 def source_file_save(apiurl, project, package, filename, content, comment=None):
-    if not comment:
-        comment = 'update by OSRT tools'
-    comment += ' (host {})'.format(socket.gethostname())
-
+    comment = message_suffix('updated', comment)
     url = makeurl(apiurl, ['source', project, package, filename], {'comment': comment})
     http_PUT(url, data=content)
 
@@ -920,3 +917,10 @@ def request_action_list_source(apiurl, project, package, states=['new', 'review'
         types.append('submit')
 
     yield from request_action_list(apiurl, project, package, states, types)
+
+def message_suffix(action, message=None):
+    if not message:
+        message = '{} by OSRT tools'.format(action)
+
+    message += ' (host {})'.format(socket.gethostname())
+    return message


### PR DESCRIPTION
- ff7bfdca711bc6f6c2e44828b09d298cb74860b8:
    gocd: provide OS.Origin.Manager.Update.

- 40aa37edb98ef9b570dcf09067d6053a39ce9bca:
    osc-origin: provide update command.

- 5230864d7271d2bd69ac643182ad31a57cfc55e3:
    osclib/origin: provide origin_update() to process updating single package.

- 7478a428820a86e70748e2b657c0b1aee5145876:
    osclib/core: provide request_create_delete().

- f441d8e41ddc2eac9d06a0daba23ca013a245c0c:
    osclib/core: provide request_create_submit() and RequestFuture.

- 844a9d28a5e78da37d83d14812665e363b5e3927:
    osclib/core: provide message_suffix() and utilize in source_file_save().

Already generated 214 submit requests for packages whose origins contained updates against `openSUSE:Leap:15.2` using this code or earlier revisions of it. Based on discussions have disabled submission of pending update due desiring additional filter for maintenance flow and a way around the source review automatically added by OBS.

This provides a variety of new features, bug fixes, and usability improvements. Some are described in the following 12 issues this PR resolves.

- Fixes #1032.
- Fixes #1048.
- Fixes #1111.
- Fixes #1178.
- Fixes #1226.
- Fixes #1282.
- Fixes #1543.
- Fixes #1556.
- Fixes #1606.
- Fixes #1643.
- Fixes #1784.
- Fixes #1902.