### PR TITLE
gocd/checkers.opensuse: wrap OS.Origin.Manager.Update with osc-origin install.

### DIFF
--- a/gocd/checkers.opensuse.gocd.yaml
+++ b/gocd/checkers.opensuse.gocd.yaml
@@ -264,4 +264,10 @@ pipelines:
         resources:
           - staging-bot
         tasks:
-          - script: osc -A https://api.opensuse.org origin -p openSUSE:Leap:15.2 update
+          - script: |-
+              tempdir=$(mktemp -d)
+              mkdir -p $tempdir/.osc-plugins
+              ln -s $PWD/osc-origin.py $tempdir/.osc-plugins
+              ln -s $PWD/osclib $tempdir/.osc-plugins
+              HOME=$tempdir osc -A https://api.opensuse.org origin -p openSUSE:Leap:15.2 update
+              rm -rf $tempdir


### PR DESCRIPTION
This is very ugly, but following the pattern laid forth.