### PR TITLE
Initial sentry integration and configuration for obs_operator, osc-{origin,staging}, and ReviewBot.

### DIFF
--- a/obs_operator.py
+++ b/obs_operator.py
@@ -12,8 +12,8 @@ import tempfile
 import os
 from osc import conf
 from osclib import common
+from osclib.sentry import sentry_client
 from osclib.sentry import sentry_init
-from osclib.sentry import sentry_dsn
 import subprocess
 import sys
 import time
@@ -164,10 +164,14 @@ class RequestHandler(BaseHTTPRequestHandler):
         return None
 
     def oscrc_create(self, oscrc_file, apiurl, cookiejar_file, user):
+        sentry_dsn = sentry_client().dsn
+        sentry_environment = sentry_client().options.get('environment')
+
         oscrc_file.write('\n'.join([
             '[general]',
-            # Passthru sentry_sdk.dsn to allow for reporting on subcommands.
-            'sentry_sdk.dsn = {}'.format(sentry_dsn()) if sentry_dsn() else '',
+            # Passthru sentry_sdk options to allow for reporting on subcommands.
+            'sentry_sdk.dsn = {}'.format(sentry_dsn) if sentry_dsn else '',
+            'sentry_sdk.environment = {}'.format(sentry_environment) if sentry_environment else '',
             'apiurl = {}'.format(apiurl),
             'cookiejar = {}'.format(cookiejar_file.name),
             'staging.color = 0',

--- a/osc-origin.py
+++ b/osc-origin.py
@@ -20,6 +20,7 @@ from osclib.origin import origin_history
 from osclib.origin import origin_potentials
 from osclib.origin import origin_revision_state
 from osclib.origin import origin_update
+from osclib.sentry import sentry_init
 from osclib.util import mail_send
 from shutil import copyfile
 import sys
@@ -89,6 +90,8 @@ def do_origin(self, subcmd, opts, *args):
         config = config_load(apiurl, opts.project)
         if not config:
             raise oscerr.WrongArgs('OSRT:OriginConfig attribute missing from {}'.format(opts.project))
+
+    sentry_init(apiurl, {'osc_plugin': subcmd})
 
     function = 'osrt_origin_{}'.format(command)
     globals()[function](apiurl, opts, *args[1:])

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -36,6 +36,7 @@ from osclib.unselect_command import UnselectCommand
 from osclib.repair_command import RepairCommand
 from osclib.rebuild_command import RebuildCommand
 from osclib.request_splitter import RequestSplitter
+from osclib.sentry import sentry_init
 from osclib.supersede_command import SupersedeCommand
 from osclib.prio_command import PrioCommand
 
@@ -429,6 +430,8 @@ def do_staging(self, subcmd, opts, *args):
             value = conf.config.get('staging.color.' + name.lower())
             if value:
                 setattr(Fore, name, ansi.code_to_chars(value))
+
+    sentry_init(opts.apiurl, {'osc_plugin': subcmd})
 
     if opts.wipe_cache:
         Cache.delete_all()

--- a/osclib/sentry.py
+++ b/osclib/sentry.py
@@ -1,0 +1,45 @@
+from osc import conf
+from osclib.common import VERSION
+
+def sentry_init(obs_apiurl=None, tags=None):
+    try:
+        import sentry_sdk
+    except ImportError:
+        return sentry_sdk_dummy()
+
+    instance = sentry_sdk.init(conf.config.get('sentry_sdk.dsn'), release=VERSION)
+    sentry_dsn.value = instance._client.dsn
+
+    with sentry_sdk.configure_scope() as scope:
+        if obs_apiurl:
+            scope.set_tag('obs_apiurl', obs_apiurl)
+            scope.user = {'username': conf.get_apiurl_usr(obs_apiurl)}
+
+        if tags:
+            for key, value in tags.items():
+                scope.set_tag(key, value)
+
+    return sentry_sdk
+
+def sentry_dsn():
+    return sentry_dsn.value
+
+class sentry_sdk_dummy:
+    def configure_scope(*args, **kw):
+        return nop_class()
+
+    def __getattr__(self, _):
+        return nop_func
+
+class nop_class:
+    def __enter__(self):
+        return nop_class()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def __getattr__(self, _):
+        return nop_func
+
+def nop_func(*args, **kw):
+    pass

--- a/osclib/sentry.py
+++ b/osclib/sentry.py
@@ -7,8 +7,10 @@ def sentry_init(obs_apiurl=None, tags=None):
     except ImportError:
         return sentry_sdk_dummy()
 
-    instance = sentry_sdk.init(conf.config.get('sentry_sdk.dsn'), release=VERSION)
-    sentry_dsn.value = instance._client.dsn
+    sentry_init.client = sentry_sdk.init(
+        conf.config.get('sentry_sdk.dsn'),
+        environment=conf.config.get('sentry_sdk.environment'),
+        release=VERSION)
 
     with sentry_sdk.configure_scope() as scope:
         if obs_apiurl:
@@ -21,8 +23,8 @@ def sentry_init(obs_apiurl=None, tags=None):
 
     return sentry_sdk
 
-def sentry_dsn():
-    return sentry_dsn.value
+def sentry_client():
+    return sentry_init.client
 
 class sentry_sdk_dummy:
     def configure_scope(*args, **kw):


### PR DESCRIPTION
- 776747c9b5350267f5db6ba5c6288f45fcdf381b:
    osclib/sentry: expose environment configuration.

- 8b82d024f62400e9b97ccc4b66f2a91b5a41574b:
    obs_operator: provide sentry_sdk integration.

- 7915299229cd780338448246dc285ed32a3024bb:
    osc-origin: provide sentry_sdk integration.

- c71949f12bff044b93c53424a1a876b786799baf:
    osc-staging: provide sentry_sdk integration.

- 5dd0a9906892e29c492802395e798c671602085c:
    ReviewBot: provide sentry_sdk integration.

- 6003bff62a2f1e22b282aad6c0d8594e70c991f6:
    osclib/sentry: provide initial sentry_sdk handling.
    
    Allows for DSN to be configured via oscrc general.sentry_sdk.dsn.

Given the various different deployment environments and machines it is non-trivial to monitor and extract errors. With this integration some context is provided and once deployed should aid in tacking down errors. I have four cases currently that are intermittent and reported by this.

I have local commits for `metrics.py`, but would be blocked by deployment as box needs to be updated for python3 bits to work properly. Also on the deployment front linking in `openSUSE:Factory / python-sentry-sdk` to `openSUSE:Tools` would simplify deployment as [requested](https://build.opensuse.org/request/show/723155).

We could also end up hosting our own sentry servers without too much trouble and at that point I would propose we add a default DSN so all deployments and osc plugin users send reports by default, but for now only enabled when a DSN is configured.