### PR TITLE
Revert "userscript/origin: hide request card when no OSRT:OriginConfig."

### DIFF
--- a/userscript/origin.user.js
+++ b/userscript/origin.user.js
@@ -84,7 +84,6 @@ function origin_load(element, project, package) {
         if (origin.endsWith('failed')) {
             if (origin.startsWith('OSRT:OriginConfig attribute missing')) {
                 item.innerHTML = '';
-                $(element).hide();
             } else {
                 item.innerHTML = '<i class="fas fa-bug text-warning"></i> Origin: failed to load';
             }


### PR DESCRIPTION
This reverts commit 249a35efe6be9ebbf516fc4c5969cdc33e9cb767.

Undesired hide on package pages and acceptable on request.