### PR TITLE
osclib/origin: origin_annotation_dump(): allow origin_info_new to be None.

### DIFF
--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -302,7 +302,7 @@ def origin_find_fallback(apiurl, target_project, package, source_hash, user):
     return None
 
 def origin_annotation_dump(origin_info_new, origin_info_old, override=False, raw=False):
-    data = {'origin': str(origin_info_new.project)}
+    data = {'origin': str(origin_info_new.project) if origin_info_new else 'None'}
     if origin_info_old and origin_info_new.project != origin_info_old.project:
         data['origin_old'] = str(origin_info_old.project)
 


### PR DESCRIPTION
A None origin annotation can be generated when `unknown_origin_wait` is `True`
and an override comment is detected.

Fixes #2166.