### PR TITLE
ReviewBot: reduce unhandled request type log message from error to info.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -501,7 +501,7 @@ class ReviewBot(object):
         self.comment_handler_remove()
 
         message = 'unhandled request type {}'.format(a.type)
-        self.logger.error(message)
+        self.logger.info(message)
         self.review_messages['accepted'] += ': ' + message
         return self.request_default_return
 


### PR DESCRIPTION
Uninteresting request action types are intentionally left to the default handler and does not constitute and error.