### PR TITLE
web/origin-manager: allow a request to be diffed against a potential origin (and related fixes).

### DIFF
--- a/obs_operator.py
+++ b/obs_operator.py
@@ -270,7 +270,14 @@ class RequestHandler(BaseHTTPRequestHandler):
         return command
 
     def handle_package_diff(self, args, query):
-        return ['osc', 'rdiff', args[0], args[1], args[2]]
+        # source_project source_package target_project [target_package] [source_revision] [target_revision]
+        command = ['osc', 'rdiff', args[0], args[1], args[2]] # len(args) == 3
+        if len(args) >= 4:
+            command.append(args[3]) # target_package
+        if len(args) >= 5:
+            command.append('--revision')
+            command.append(':'.join(args[4:6]))
+        return command
 
     def handle_request_submit(self, args, query, data):
         command = ['osc', 'sr', args[0], args[1], args[2]]

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -577,6 +577,9 @@ def origin_history(apiurl, target_project, package, user):
             'origin': annotation.get('origin', 'None'),
             'request': request.reqid,
             'state': request.state.name,
+            'source_project': action.src_project,
+            'source_package': action.src_package,
+            'source_revision': action.src_rev,
         })
 
     return history

--- a/web/origin-manager/main.css
+++ b/web/origin-manager/main.css
@@ -30,6 +30,6 @@ aside {
   overflow: auto;
 }
 
-#details p {
+#details p, #details pre {
   margin: 20px;
 }

--- a/web/origin-manager/main.js
+++ b/web/origin-manager/main.js
@@ -422,6 +422,14 @@ function hash_parts() {
 }
 
 function hash_set(parts) {
+    // Shorten the parts array to before the first null.
+    for (var i = 0; i < parts.length; i++) {
+        if (parts[i] == null) {
+            parts.length = i;
+            break
+        }
+    }
+
     window.location.hash = parts.join('/');
 }
 

--- a/web/origin-manager/main.js
+++ b/web/origin-manager/main.js
@@ -95,6 +95,8 @@ function table_selection_get(table) {
 }
 
 function table_selection_set(table, value) {
+    if (typeof table === 'undefined') return;
+
     if (table.getSelectedRows().length > 0) {
         if (table.getSelectedRows()[0].getIndex() != value) {
             table.getSelectedRows()[0].deselect();

--- a/web/origin-manager/main.js
+++ b/web/origin-manager/main.js
@@ -278,6 +278,7 @@ function project_set(project) {
         return;
     }
     project_table.project = project;
+    project_table.clearData();
     project_table.setData(operator_url() + '/origin/list/' + project, {}, FETCH_JSON_CONFIG);
     project_table.setHeaderFilterFocus('package');
 }
@@ -297,10 +298,12 @@ function package_set(project, package) {
 
     if (package == null) return;
 
+    potential_table.clearData();
     potential_table.package = package;
     potential_table.setData(
         operator_url() + '/origin/potentials/' + project + '/' + package, {}, FETCH_JSON_CONFIG);
 
+    history_table.clearData();
     history_table.package = package;
     history_table.setData(
         operator_url() + '/origin/history/' + project + '/' + package, {}, FETCH_JSON_CONFIG);

--- a/web/origin-manager/main.js
+++ b/web/origin-manager/main.js
@@ -352,6 +352,10 @@ function potential_set(project, package, origin) {
             if (text == '') {
                 $('#details').html('<p>No difference</p>');
                 return;
+            } else if (text.startsWith('# diff failed')) {
+                $('#details').html('<p>Failed to generate diff</p><pre></pre>');
+                $('#details pre').text(text);
+                return;
             }
             $('#details').html(Diff2Html.getPrettyHtml(text));
         });

--- a/web/origin-manager/main.js
+++ b/web/origin-manager/main.js
@@ -296,15 +296,16 @@ function package_set(project, package) {
     }
     $('aside').toggle(package != null);
 
+    potential_table.package = package;
+    history_table.package = package;
+
     if (package == null) return;
 
     potential_table.clearData();
-    potential_table.package = package;
     potential_table.setData(
         operator_url() + '/origin/potentials/' + project + '/' + package, {}, FETCH_JSON_CONFIG);
 
     history_table.clearData();
-    history_table.package = package;
     history_table.setData(
         operator_url() + '/origin/history/' + project + '/' + package, {}, FETCH_JSON_CONFIG);
 
@@ -319,8 +320,12 @@ function package_select_set() {
 }
 
 function package_select_hash() {
-    hash_set([project_get(), table_selection_get(project_table),
-             origin_project(project_table.getSelectedRows()[0].getData()['origin'])]);
+    if (table_selection_get(project_table)) {
+        hash_set([project_get(), table_selection_get(project_table),
+                 origin_project(project_table.getSelectedRows()[0].getData()['origin'])]);
+    } else {
+        hash_set([project_get()]);
+    }
 }
 
 function potential_get() {


### PR DESCRIPTION
- a189e946154b18d98f8685cf1942a4b0f2a3ed16:
    web/origin-manager: allow a request to be diffed against a potential origin.

- e3d67622e9be7c4a51333f9cff50e8674e4d7c45:
    web/origin-manager: display the reason for a diff failure.

- 114f25e004ca0cdeb6a4f5635c2149c84578766a:
    web/origin-manager: properly handle potential origin de-selection.

- 0e1d9ef25a43c17587a51b480930bc282ed42bff:
    web/origin-manager: properly handle package de-selection.

- 275db9b0d2aea9562621706fc60e014b5d51b4b0:
    web/origin-manager: clear table data before loading new data.
    
    Further clarifies new data is being loaded and when an error occurs the
    prior data does not remain after the error messsage.

- 5ee09feb2749f927676b7b1ffa60ba02875c7d7e:
    web/origin-manager: table_selection_set(): handle undefined table.

- edfef91b3d65be208022a2fc5f6a3c24d4062a5b:
    osclib/origin: origin_history(): expose source_(project,package,revision).
    
    This is the best location to expose the information as the action context
    is already available. Alternatively, a lookup function accepting a request
    target_project and target_package could perform the equivalent of the
    client-side filter operation that is part of the initial search. This also
    alleviates additional queries that would be needed later.

- b46644226096087c6f58cbf578efe4beebb12c1c:
    obs_operator: handle_package_diff(): expose target package and revision.

Examples:

With a request selected:
![image](https://user-images.githubusercontent.com/22943929/63896699-7d9b3580-c9b8-11e9-989d-8290f60a047b.png)

Without a request selected:
![image](https://user-images.githubusercontent.com/22943929/63896701-7ecc6280-c9b8-11e9-96c1-1cc78687774b.png)

The potential origin can also be changed while the request remains selected.

Fixes #2144.