### PR TITLE
obs_operator: allow illegal cookie keys.

### DIFF
--- a/obs_operator.py
+++ b/obs_operator.py
@@ -3,6 +3,7 @@
 # kubernetes logs.
 
 import argparse
+import http
 from http.cookies import SimpleCookie
 from http.cookiejar import Cookie, LWPCookieJar
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -19,6 +20,12 @@ import sys
 import time
 from urllib.parse import urlparse
 from urllib.parse import parse_qs
+
+# A cookie with an invalid key is intermittently generated on opensuse.org
+# domain which causes the operator to crash when parsing the cookie. The desired
+# cookie is valid, but cannot be utilize due to the exception. As suggested in
+# https://stackoverflow.com/a/47012250, workaround by making EVERYTHING LEGAL!
+http.cookies._is_legal_key = lambda _: True
 
 # Available in python 3.7.
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):


### PR DESCRIPTION
An example stack trace from production:

```
Exception happened during processing of request from ('172.16.4.0', 59122)
Traceback (most recent call last):
  File "/usr/lib64/python3.7/socketserver.py", line 650, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib64/python3.7/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib64/python3.7/socketserver.py", line 720, in __init__
    self.handle()
  File "/usr/lib64/python3.7/http/server.py", line 426, in handle
    self.handle_one_request()
  File "/usr/lib64/python3.7/http/server.py", line 414, in handle_one_request
    method()
  File "/usr/bin/osrt-obs_operator", line 75, in do_GET
    with OSCRequestEnvironment(self) as oscrc_file:
  File "/usr/bin/osrt-obs_operator", line 305, in __enter__
    session = self.handler.session_get()
  File "/usr/bin/osrt-obs_operator", line 157, in session_get
    cookie = SimpleCookie(cookie)
  File "/usr/lib64/python3.7/http/cookies.py", line 480, in __init__
    self.load(input)
  File "/usr/lib64/python3.7/http/cookies.py", line 529, in load
    self.__parse_string(rawdata)
  File "/usr/lib64/python3.7/http/cookies.py", line 593, in __parse_string
    self.__set(key, rval, cval)
  File "/usr/lib64/python3.7/http/cookies.py", line 485, in __set
    M.set(key, real_value, coded_value)
  File "/usr/lib64/python3.7/http/cookies.py", line 352, in set
    raise CookieError('Illegal key %r' % (key,))
http.cookies.CookieError: Illegal key 'TbBx5iTmnWSKRFAUrQu4szPJGqJCpw@@'
```