### PR TITLE
sentry: update for 0.11.x, general improvements, and operator exception handling

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -268,6 +268,8 @@ BuildArch:      noarch
 Requires:       %{name} = %{version}
 Requires:       osc >= 0.165.1
 Requires:       python3-osc
+# internal API change related to accessing DSN in osclib/sentry.py
+Suggests:       python3-sentry-sdk >= 0.11.0
 
 %description -n osclib
 Supplemental osc libraries utilized by release tools.

--- a/obs_operator.py
+++ b/obs_operator.py
@@ -27,9 +27,13 @@ from urllib.parse import parse_qs
 # https://stackoverflow.com/a/47012250, workaround by making EVERYTHING LEGAL!
 http.cookies._is_legal_key = lambda _: True
 
+sentry_sdk = sentry_init()
+
 # Available in python 3.7.
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
-    pass
+    def handle_error(self, request, client_address):
+        super().handle_error(request, client_address)
+        sentry_sdk.capture_exception()
 
 class RequestHandler(BaseHTTPRequestHandler):
     COOKIE_NAME = 'openSUSE_session' # Both OBS and IBS.
@@ -361,7 +365,7 @@ class OSCRequestEnvironmentException(Exception):
 
 def main(args):
     conf.get_config() # Allow sentry DSN to be available.
-    sentry_init()
+    sentry_sdk = sentry_init()
 
     RequestHandler.apiurl = args.apiurl
     RequestHandler.session = args.session

--- a/osclib/sentry.py
+++ b/osclib/sentry.py
@@ -1,4 +1,5 @@
 from osc import conf
+from osc import core
 from osclib.common import VERSION
 
 def sentry_init(obs_apiurl=None, tags=None):
@@ -14,6 +15,8 @@ def sentry_init(obs_apiurl=None, tags=None):
         release=VERSION)
 
     with sentry_sdk.configure_scope() as scope:
+        scope.set_tag('osc', core.__version__)
+
         if obs_apiurl:
             scope.set_tag('obs_apiurl', obs_apiurl)
             scope.user = {'username': conf.get_apiurl_usr(obs_apiurl)}

--- a/osclib/sentry.py
+++ b/osclib/sentry.py
@@ -24,7 +24,7 @@ def sentry_init(obs_apiurl=None, tags=None):
     return sentry_sdk
 
 def sentry_client():
-    return sentry_init.client
+    return sentry_init.client._client
 
 class sentry_sdk_dummy:
     def configure_scope(*args, **kw):

--- a/osclib/sentry.py
+++ b/osclib/sentry.py
@@ -5,6 +5,7 @@ def sentry_init(obs_apiurl=None, tags=None):
     try:
         import sentry_sdk
     except ImportError:
+        sentry_init.client = sentry_client_dummy()
         return sentry_sdk_dummy()
 
     sentry_init.client = sentry_sdk.init(
@@ -42,6 +43,9 @@ class nop_class:
 
     def __getattr__(self, _):
         return nop_func
+
+class sentry_client_dummy(nop_class):
+    options = {}
 
 def nop_func(*args, **kw):
     pass


### PR DESCRIPTION
- 3a2aed7f333b43fbd8b00a0d2db4cd0b7ddd677e:
    obs_operator: override HTTPServer.handle_error() to capture exceptions.

- d10a359c0c6bf0e12926b10fc7da43420eb6b122:
    osclib/sentry: tag osc version.

- eb0a6c46594ab14b181a367b4b3a2bd4ce944c18:
    osclib/sentry: provide dummy client.

- cbfbb880488a184f218a4fb84c012044e81c48f0:
    osclib/sentry: sentry_client(): handle 0.11.x API change.