### PR TITLE
oqamaint: fix more python3 issues and add _OBSOLETE=1

### DIFF
--- a/oqamaint/openqabot.py
+++ b/oqamaint/openqabot.py
@@ -85,7 +85,7 @@ class OpenQABot(ReviewBot.ReviewBot):
     def calculate_repo_hash(repos, incidents):
         m = hashlib.md5()
         # if you want to force it, increase this number
-        m.update('b')
+        m.update(b'b')
         for url in repos:
             url += '/repodata/repomd.xml'
             try:
@@ -94,9 +94,9 @@ class OpenQABot(ReviewBot.ReviewBot):
                 raise
             cs = root.find(
                 './/{http://linux.duke.edu/metadata/repo}data[@type="primary"]/{http://linux.duke.edu/metadata/repo}checksum')
-            m.update(cs.text)
+            m.update(cs.text.encode('utf-8'))
         # now add the open incidents
-        m.update(json.dumps(incidents, sort_keys=True))
+        m.update(json.dumps(incidents, sort_keys=True).encode('utf-8'))
         digest = m.hexdigest()
         open_incidents = sorted(incidents.keys())
         if open_incidents:
@@ -211,6 +211,7 @@ class OpenQABot(ReviewBot.ReviewBot):
                 s[x] = y
         s['BUILD'] = buildnr
         s['REPOHASH'] = repohash
+        s['_OBSOLETE'] = '1'
         self.logger.debug("Prepared: {}".format(pformat(s)))
         if not self.dryrun:
             try:

--- a/oqamaint/update.py
+++ b/oqamaint/update.py
@@ -4,23 +4,8 @@ import re
 import requests
 
 
-# python 3 has gzip decompress function
-try:
-    from gzip import decompress
-except ImportError:
-    from gzip import GzipFile
-    import io
-
-    def decompress(data):
-        with GzipFile(fileobj=io.BytesIO(data)) as f:
-            return f.read()
-
-# use cElementTree by default, fallback to pure python
-try:
-    from xml.etree import cElementTree as ET
-except ImportError:
-    from xml.etree import ElementTree as ET
-
+from gzip import decompress
+from xml.etree import cElementTree as ET
 import osc.core
 
 from osclib.memoize import memoize
@@ -31,7 +16,6 @@ class Update(object):
 
     def __init__(self, settings):
         self._settings = settings
-        self._settings['_NOOBSOLETEBUILD'] = '1'
         self.opensuse = True
 
     def get_max_revision(self, job):


### PR DESCRIPTION
The default of openQA changed - _NO_OBSOLETE no longer exists, but for
the test repo we want obsoletion