### PR TITLE
osclib/core: request_action_key(): handle add_role/set_bugowner against project.

### DIFF
--- a/osclib/core.py
+++ b/osclib/core.py
@@ -783,7 +783,8 @@ def request_action_key(action):
 
     if action.type in ['add_role', 'change_devel', 'maintenance_release', 'set_bugowner', 'submit']:
         identifier.append(action.tgt_project)
-        identifier.append(action.tgt_package)
+        if action.tgt_package is not None:
+            identifier.append(action.tgt_package)
 
         if action.type in ['add_role', 'set_bugowner']:
             if action.person_name is not None:

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -781,7 +781,7 @@ def action_is_patchinfo(action):
 def request_action_key(action):
     identifier = []
 
-    if action.type in ['add_role', 'change_devel', 'maintenance_release', 'submit']:
+    if action.type in ['add_role', 'change_devel', 'maintenance_release', 'set_bugowner', 'submit']:
         identifier.append(action.tgt_project)
         identifier.append(action.tgt_package)
 


### PR DESCRIPTION
- 016bca069d79768ce70b12fe90d0b6fd6912fc5e:
    osclib/core: request_action_key(): handle add_role/set_bugowner against project.

- a6d0974e27a041edba031ae2103b6e51d01b5f00:
    osclib/core: request_action_key(): include set_bugowner in top level condition.

[request 728279](https://build.opensuse.org/request/show/728279) caused:

```
TypeError: sequence item 1: expected str instance, NoneType found
  File "ReviewBot.py", line 187, in check_requests
    good = self.check_one_request(req)
  File "ReviewBot.py", line 397, in check_one_request
    key = request_action_key(a)
  File "osclib/core.py", line 808, in request_action_key
    return '::'.join(['/'.join(identifier), action.type])
```