### PR TITLE
osclib/comments: command_find(): allow seperators after user.

### DIFF
--- a/osclib/comments.py
+++ b/osclib/comments.py
@@ -103,7 +103,7 @@ class CommentAPI(object):
         Usage (in comment):
             @<user> <command> [args...]
         """
-        command_re = re.compile(r'^@(?P<user>[^ ]+) (?P<args>.*)$', re.MULTILINE)
+        command_re = re.compile(r'^@(?P<user>[^ ,:]+)[,:]? (?P<args>.*)$', re.MULTILINE)
 
         # Search for commands in the order the comment was created.
         for comment in sorted(comments.values(), key=lambda c: c['when']):


### PR DESCRIPTION
Users attempt both with and without seperators so might as well support.

Occurred in [request 727959](https://build.opensuse.org/request/show/727959) most recently.