### PR TITLE
osclib/request_splitter: utilize osclib.util.sha1_short() for encoding.

### DIFF
--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -1,11 +1,11 @@
 from datetime import datetime
 import dateutil.parser
-import hashlib
 from lxml import etree as ET
 from osc import conf
 from osc.core import show_project_meta
 from osclib.core import devel_project_fallback
 from osclib.core import request_age
+from osclib.util import sha1_short
 import re
 
 class RequestSplitter(object):
@@ -386,7 +386,7 @@ class Strategy(object):
         self.name = self.__class__.__name__[8:].lower()
         self.key = self.name
         if kwargs:
-            self.key += '_' + hashlib.sha1(str(kwargs)).hexdigest()[:7]
+            self.key += '_' + sha1_short(str(kwargs))
 
     def info(self):
         info = {'name': self.name}


### PR DESCRIPTION
```
Without this, python 3 execution will fail with:
  TypeError: Unicode-objects must be encoded before hashing

The requests strategy is the only strategy to utilize kwargs besides
custom so this code is not executed often which is why this has not been
encountered. In fact it was executed mistakenly and reported.
```

Fixes #2206.