### PR TITLE
check_source: check_action_delete_repository(): gate behind conf.mail-release-list.

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -48,6 +48,7 @@ class CheckSource(ReviewBot.ReviewBot):
         self.in_air_rename_allow = str2bool(config.get('check-source-in-air-rename-allow', 'False'))
         self.add_review_team = str2bool(config.get('check-source-add-review-team', 'True'))
         self.review_team = config.get('review-team')
+        self.mail_release_list = config.get('mail-release-list')
         self.staging_group = config.get('staging-group')
         self.repo_checker = config.get('repo-checker')
         self.devel_whitelist = config.get('devel-whitelist', '').split()
@@ -355,7 +356,9 @@ class CheckSource(ReviewBot.ReviewBot):
         return False
 
     def check_action_delete_repository(self, request, action):
-        if action.tgt_project.startswith('openSUSE:'):
+        self.target_project_config(action.tgt_project)
+
+        if self.mail_release_list:
             self.review_messages['declined'] = 'The repositories in the openSUSE:* namespace ' \
                 'are managed by the Release Managers. For suggesting changes, send a mail ' \
                 'to opensuse-releaseteam@opensuse.org with an explanation of why the change ' \

--- a/check_source.py
+++ b/check_source.py
@@ -359,10 +359,8 @@ class CheckSource(ReviewBot.ReviewBot):
         self.target_project_config(action.tgt_project)
 
         if self.mail_release_list:
-            self.review_messages['declined'] = 'The repositories in the openSUSE:* namespace ' \
-                'are managed by the Release Managers. For suggesting changes, send a mail ' \
-                'to opensuse-releaseteam@opensuse.org with an explanation of why the change ' \
-                'makes sense.'
+            self.review_messages['declined'] = 'Deleting repositories is not allowed. ' \
+                'Contact {} to discuss further.'.format(self.mail_release_list)
             return False
 
         self.review_messages['accepted'] = 'unhandled: removing repository'


### PR DESCRIPTION
- 4e4379a4d563bfc179359d4d68b3aeda55db4969:
    check_source: check_action_delete_repository(): simplify decline message.

- a7cf9026dbf2ae8640829266015299233d3c395a:
    check_source: check_action_delete_repository(): gate behind conf.mail-release-list.
    
    Works for SLE and maintenance properly with this option.

Noticed while skimming to respond to maintenance inquiry related to utilizing on IBS so figured best to generalize it.