### PR TITLE
gocd: remove PackageHub15SP1.Manager42 as project is locked.

### DIFF
--- a/config/manager_42/README.txt
+++ b/config/manager_42/README.txt
@@ -1,0 +1,1 @@
+Create an OSRT:OriginManager config instead.

--- a/config/manager_42/openSUSE:Backports:SLE-15-SP1.yml
+++ b/config/manager_42/openSUSE:Backports:SLE-15-SP1.yml
@@ -1,4 +1,0 @@
----
-from_prj: openSUSE:Backports:SLE-15-SP1
-project_preference_order:
-    - openSUSE:Leap:15.1

--- a/gocd/checkers.opensuse.gocd.yaml
+++ b/gocd/checkers.opensuse.gocd.yaml
@@ -127,27 +127,6 @@ pipelines:
             - staging-bot
             tasks:
             - script: ./leaper.py -A https://api.opensuse.org --verbose project openSUSE:Maintenance maintenance_incident
-  PackageHub15SP1.Manager42:
-    group: openSUSE.Checkers
-    lock_behavior: unlockWhenFinished
-    timer:
-      spec: 0 */30 * ? * *
-    environment_variables:
-      OSC_CONFIG: /home/go/config/oscrc-leaper
-    materials:
-      git:
-        git: https://github.com/openSUSE/openSUSE-release-tools.git
-    stages:
-    - Run:
-        approval: manual
-        jobs:
-          Run:
-            timeout: 0
-            resources:
-            - staging-bot
-            tasks:
-            - script: ./manager_42.py -A https://api.opensuse.org -c config/manager_42/openSUSE:Backports:SLE-15-SP1.yml
-
   Factory.Staging.Report:
     group: openSUSE.Checkers
     lock_behavior: unlockWhenFinished


### PR DESCRIPTION
Leave a README file in config/manager_42 to preserve directory until ready
to remove leaper/manager_42 stack.

[openSUSE:Backports:SLE-15-SP1](https://build.opensuse.org/project/show/openSUSE:Backports:SLE-15-SP1) is locked so no point in running the job. Not yet ready to nuke the stack (which I will do when appropriate) so just leave note and preserve directory for packaging.