### PR TITLE
osclib/origin_listener: utilize apiurl as thread name for remote listener.

### DIFF
--- a/osc-origin.py
+++ b/osc-origin.py
@@ -77,7 +77,11 @@ def do_origin(self, subcmd, opts, *args):
         raise oscerr.WrongArgs('A package must be indicated.')
 
     level = logging.DEBUG if opts.debug else None
-    logging.basicConfig(level=level, format='[%(levelname).1s] %(message)s')
+    if command == 'update':
+        # Only way to include thread in pika log message.
+        logging.basicConfig(level=level, format='<%(threadName)s> [%(levelname).1s] %(message)s')
+    else:
+        logging.basicConfig(level=level, format='[%(levelname).1s] %(message)s')
 
     # Allow for determining project from osc store.
     if not opts.project and core.is_project_dir('.'):

--- a/osc-origin.py
+++ b/osc-origin.py
@@ -347,7 +347,6 @@ def osrt_origin_report(apiurl, opts, *args):
 
 def osrt_origin_update(apiurl, opts, *packages):
     if opts.listen:
-        import logging
         from osclib.origin_listener import OriginSourceChangeListener
 
         logger = logging.getLogger()

--- a/osclib/origin_listener.py
+++ b/osclib/origin_listener.py
@@ -113,6 +113,7 @@ class OriginSourceChangeListener(PubSubConsumer):
 
             kind = package_kind(self.apiurl, project, package)
             if kind == 'source':
+                self.logger.info('checking for updates to {}/{}...'.format(project, package))
                 request_future = origin_update(self.apiurl, project, package)
                 if request_future:
                     request_future.print_and_create(self.dry)

--- a/osclib/origin_listener.py
+++ b/osclib/origin_listener.py
@@ -96,7 +96,7 @@ class OriginSourceChangeListener(PubSubConsumer):
                 if origin.startswith(remote + ':') and apiurl not in self.listeners:
                     self.logger.info('starting remote listener due to {} origin'.format(origin))
                     self.listeners[apiurl] = OriginSourceChangeListenerRemote(apiurl, self, remote)
-                    threading.Thread(target=self.listeners[apiurl].run).start()
+                    threading.Thread(target=self.listeners[apiurl].run, name=apiurl).start()
 
     def origin_updatable_map(self, pending=None):
         return origin_updatable_map(self.apiurl, pending=pending)


### PR DESCRIPTION
Related to #2220.