### PR TITLE
osclib/origin_listener: skip patchinfo packages.

### DIFF
--- a/osclib/origin_listener.py
+++ b/osclib/origin_listener.py
@@ -69,6 +69,8 @@ class OriginSourceChangeListener(PubSubConsumer):
                 project = action['targetproject']
                 package = action['targetpackage']
             elif action['type'] == 'maintenance_incident':
+                if action['sourcepackage'] == 'patchinfo':
+                    continue
                 project = action['target_releaseproject']
                 if not action.get('targetpackage'):
                     package = action['sourcepackage']
@@ -76,6 +78,8 @@ class OriginSourceChangeListener(PubSubConsumer):
                     repository_suffix_length = len(project) + 1 # package.project
                     package = action['targetpackage'][:-repository_suffix_length]
             elif action['type'] == 'maintenance_release':
+                if action['sourcepackage'] == 'patchinfo':
+                    continue
                 project = action['targetproject']
                 repository_suffix_length = len(project) + 1 # package.project
                 package = action['sourcepackage'][:-repository_suffix_length]


### PR DESCRIPTION
Not only are patchinfo packages never useful for origin updates, but they
cause an exception since the package is set to an empty string.

Made infinitely easier with detailed stack including context variables not passed through to next function.

![screencapture-sentry-io-organizations-opensuse-release-team-issues-1222381634-2019-09-18-16_53_05](https://user-images.githubusercontent.com/22943929/65188920-1f9cc380-da35-11e9-9c11-f0028767096f.png)