### PR TITLE
gocd/monitors: *.OriginManagerUpdate: set timeout to 10 minutes.

### DIFF
--- a/gocd/monitors.gocd.yaml
+++ b/gocd/monitors.gocd.yaml
@@ -129,7 +129,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 10 # 5 minute still alive message
             resources:
             - monitor
             tasks:
@@ -156,7 +156,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 10 # 5 minute still alive message
             resources:
             - monitor
             tasks:


### PR DESCRIPTION
Would seem like this should be the default on all monitors since they run with same base class that spits out the still alive message (specifically for gocd). Will at least insure that a stuck state does not last a long time.

Related to #2220 
