### PR TITLE
osclib/cache: utilize rmtree_nfs_safe().

### DIFF
--- a/osclib/cache.py
+++ b/osclib/cache.py
@@ -5,7 +5,6 @@ import hashlib
 import os
 import osc.core
 import re
-import shutil
 import sys
 
 try:
@@ -25,6 +24,7 @@ from io import BytesIO
 from osc import conf
 from osc.core import urlopen
 from osclib.cache_manager import CacheManager
+from osclib.util import rmtree_nfs_safe
 from time import time
 
 try:
@@ -246,12 +246,12 @@ class Cache(object):
 
         if os.path.exists(path):
             if conf.config['debug']: print('CACHE_DELETE_PROJECT', apiurl, project, file=sys.stderr)
-            shutil.rmtree(path)
+            rmtree_nfs_safe(path)
 
     @staticmethod
     def delete_all():
         if os.path.exists(Cache.CACHE_DIR):
-            shutil.rmtree(Cache.CACHE_DIR)
+            rmtree_nfs_safe(Cache.CACHE_DIR)
 
     @staticmethod
     def match(url):

--- a/osclib/util.py
+++ b/osclib/util.py
@@ -177,3 +177,17 @@ def sha1_short(data):
         data = data.encode('utf-8')
 
     return hashlib.sha1(data).hexdigest()[:7]
+
+def rmtree_nfs_safe(path, attempts=5):
+    import shutil
+    try:
+        shutil.rmtree(path)
+    except OSError as e:
+        # Directory not empty due to slow filesystem (see #1326 old occurance).
+        if attempts <= 0 or e.errno != 39:
+            raise e
+
+        from time import sleep
+        sleep(0.25)
+
+        rmtree_nfs_safe(path, attempts - 1)


### PR DESCRIPTION
Resolves #1326 which causes intermittent errors on Tortuga.