### PR TITLE
check_source: don't enforce name for kiwi images

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -145,7 +145,7 @@ class CheckSource(ReviewBot.ReviewBot):
         shutil.rmtree(os.path.join(target_package, '.osc'))
 
         new_info = self.package_source_parse(source_project, source_package, source_revision)
-        if new_info['name'] != target_package:
+        if not new_info['filename'].endswith('.kiwi') and new_info['name'] != target_package:
             shutil.rmtree(dir)
             self.review_messages['declined'] = "A package submitted as %s has to build as 'Name: %s' - found Name '%s'" % (target_package, target_package, new_info['name'])
             return False
@@ -293,6 +293,9 @@ class CheckSource(ReviewBot.ReviewBot):
 
         if xml.find('version') is not None:
             ret['version'] = xml.find('version').text
+
+        if xml.find('filename') is not None:
+            ret['filename'] = xml.find('filename').text
 
         return ret
 


### PR DESCRIPTION
The benefit of this check is unclear to me. It enforces the Name tag
inside he kiwi file to be the same as the package name in OBS while the
kiwi file name itself can be arbitrary.
So that means that kiwi package names end up encoding their distribution
and version (eg "openSUSE-Leap-15.2-Vagrant") and have to be renamed for
each release. Also means diffing between released versions isn't as
straight forward as it could be if the name was more flexibel.
If we wanted to enforce something then we should make sure the actual
kiwi file name is the same as the OBS package name. That is what the
spec file name check actually does after all (package hello needs to
have hello.spec ie srpm name hello).