### PR TITLE
origin-manager: skip package of type not (None or source) and similar for check_source.

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -82,6 +82,9 @@ class CheckSource(ReviewBot.ReviewBot):
         if kind == 'meta':
             self.review_messages['accepted'] = 'Skipping all checks for meta packages'
             return True
+        elif kind != 'source':
+            self.review_messages['accepted'] = 'May not modify a non-source package of type {}'.format(kind)
+            return False
 
         inair_renamed = target_package != source_package
 

--- a/check_source.py
+++ b/check_source.py
@@ -18,6 +18,7 @@ from osclib.conf import Config
 from osclib.core import devel_project_get
 from osclib.core import devel_project_fallback
 from osclib.core import group_members
+from osclib.core import package_kind
 from osclib.core import source_file_load
 from osclib.core import target_archs
 from urllib.error import HTTPError
@@ -77,8 +78,9 @@ class CheckSource(ReviewBot.ReviewBot):
             self.review_messages['declined'] = 'Only one action per request allowed'
             return False
 
-        if target_package.startswith('00') or target_package.startswith('_'):
-            self.review_messages['accepted'] = 'Skipping all checks for product related packages'
+        kind = package_kind(self.apiurl, target_project, target_package)
+        if kind == 'meta':
+            self.review_messages['accepted'] = 'Skipping all checks for meta packages'
             return True
 
         inair_renamed = target_package != source_package

--- a/origin-manager.py
+++ b/origin-manager.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 from osclib.core import package_source_hash
+from osclib.core import package_kind
 from osclib.origin import origin_annotation_dump
 from osclib.origin import config_load
 from osclib.origin import origin_find
@@ -31,6 +32,11 @@ class OriginManager(ReviewBot.ReviewBot):
         return True
 
     def check_source_submission(self, src_project, src_package, src_rev, tgt_project, tgt_package):
+        kind = package_kind(self.apiurl, tgt_project, tgt_package)
+        if not (kind is None or kind == 'source'):
+            self.review_messages['accepted'] = 'skipping {} package since not source'.format(kind)
+            return True
+
         advance, result = self.config_validate(tgt_project)
         if not advance:
             return result

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -511,7 +511,7 @@ def entity_exists(apiurl, project, package=None):
     return True
 
 def package_kind(apiurl, project, package):
-    if package.startswith('00'):
+    if package.startswith('00') or package.startswith('_'):
         return 'meta'
 
     if ':' in package:


### PR DESCRIPTION
- 160225b5e983057381f92a973054cf67219bac37:
    origin-manager: skip package of type not (None or source).
    
    Should skip review of meta packages and such. Although same logic would
    seem to apply to deletes origin-manager is used to enforce manual review
    of all deletes and as such even deleting of a meta package should be
    included.

- afd288b87d946df3464c4037b50eea41653ecec3:
    check_source: decline package of kind not (meta or source).

- 91aeaf1f55fd58bee0e0a1454c0a114fe9297a5e:
    check_source: replace meta check with package_kind() == meta.

- f63da476c21719a8634b7ab4427182ef68419f13:
    osclib/core: package_kind(): include underscore as meta prefix.
    
    Previously used by _product which is still used in SLE-12.

Fixes #2229.

An active example:

```
$ ./origin-manager.py --dry --debug id 732664
[I] checking 732664
[I] 732664 accepted: skipping meta package since not source
[D] 732664 review not changed
```