### PR TITLE
check_source: when kind is None then it can be a new package

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -82,7 +82,7 @@ class CheckSource(ReviewBot.ReviewBot):
         if kind == 'meta':
             self.review_messages['accepted'] = 'Skipping all checks for meta packages'
             return True
-        elif kind != 'source':
+        elif (kind is not None and kind != 'source'):
             self.review_messages['accepted'] = 'May not modify a non-source package of type {}'.format(kind)
             return False
 


### PR DESCRIPTION
if package_kind() returned None then the submission can be a new package submission, check_source should continue the process instead of decline the request.

local run:

    [I] checking 733090
    [I] devel:tools:compiler/llvm9@1 -> openSUSE:Factory/llvm9
    [I] checking if target package exists and has devel project
    [I] target package does not exist openSUSE:Factory/llvm9
    [I] POST https://api.opensuse.org/request/733090?cmd=addreview&by_group=opensuse-review-team
    [I] 733090 accepted: Check script succeeded
    [D] 733090 review not changed

fixes https://build.opensuse.org/request/show/733090 , it has been declined by bot without a verbose reason.