### PR TITLE
gocd/checkers: revert Origin.Manager.Update frequency back to daily.

### DIFF
--- a/gocd/checkers.opensuse.gocd.yaml
+++ b/gocd/checkers.opensuse.gocd.yaml
@@ -235,7 +235,7 @@ pipelines:
       script:
         git: https://github.com/openSUSE/openSUSE-release-tools.git
     timer:
-      spec: 0 0 7 ? * SUN
+      spec: 0 0 7 ? * *
       only_on_changes: false
     stages:
     - Run:

--- a/gocd/checkers.suse.gocd.yaml
+++ b/gocd/checkers.suse.gocd.yaml
@@ -95,7 +95,7 @@ pipelines:
       script:
         git: https://github.com/openSUSE/openSUSE-release-tools.git
     timer:
-      spec: 0 0 7 ? * SUN
+      spec: 0 0 7 ? * *
       only_on_changes: false
     stages:
     - Run:

--- a/gocd/checkers.suse.gocd.yaml.erb
+++ b/gocd/checkers.suse.gocd.yaml.erb
@@ -95,7 +95,7 @@ pipelines:
       script:
         git: https://github.com/openSUSE/openSUSE-release-tools.git
     timer:
-      spec: 0 0 7 ? * SUN
+      spec: 0 0 7 ? * *
       only_on_changes: false
     stages:
     - Run:


### PR DESCRIPTION
With the lack of events from OBS for SLE updates #2239 and the troubles
with the pika base class for IBS #2220 it seems best to keep the full
run daily to ensure expedient updates.