### PR TITLE
origin-manager: provide and utilize ReviewBot.request_age_wait().

### DIFF
--- a/origin-manager.py
+++ b/origin-manager.py
@@ -15,6 +15,9 @@ class OriginManager(ReviewBot.ReviewBot):
         ReviewBot.ReviewBot.__init__(self, *args, **kwargs)
 
         # ReviewBot options.
+        # Younger than default splitter-request-age-threshold to allow for quick
+        # strategy to still be useful which requires a completed review.
+        self.request_age_min_default = 30 * 60
         self.request_default_return = True
         self.override_allow = False
 
@@ -40,6 +43,10 @@ class OriginManager(ReviewBot.ReviewBot):
         advance, result = self.config_validate(tgt_project)
         if not advance:
             return result
+
+        if self.request_age_wait():
+            # Allow for parallel submission to be created.
+            return None
 
         source_hash_new = package_source_hash(self.apiurl, src_project, src_package, src_rev)
         origin_info_new = origin_find(self.apiurl, tgt_project, tgt_package, source_hash_new)


### PR DESCRIPTION
- 4c31f7754d711fb8dfc941d307308a1be05b43ca:
    origin-manager: utilize ReviewBot.request_age_wait().
    
    Configure a default of 30 minutes to work well with staging-bot quick
    strategy.

- 7033044469fc478e97c676041b455dbed85af4c2:
    ReviewBot: provide request_age_wait().
    
    Provides configurable default, config key, and config override value.

Works best as callable method rather than built-in behavior since bots may desire more complex behavior such as origin-manager only on source submissions (not deletes) and after static checks are completed.

An example with local config:

```
[openSUSE:Leap:15.2]
# 5 hours
originmanager-request-age-min = 18000
```

```
$ ./origin-manager.py --dry --debug id 733210
[I] checking 733210
[I] skipping 733210 of age 10593.94s since it is younger than 18000s
[I] 733210 ignored
```

Fixes #2180.