### PR TITLE
osclib/origin: origin_annotation_load(): improve robustness by tolerating invalid data.

### DIFF
--- a/osclib/core.py
+++ b/osclib/core.py
@@ -708,9 +708,9 @@ def project_remote_apiurl(apiurl, project):
 
     return apiurl, project
 
-def review_find_last(request, user):
+def review_find_last(request, user, states=['all']):
     for review in reversed(request.reviews):
-        if review.by_user == user:
+        if review.by_user == user and ('all' in states or review.state in states):
             return review
 
     return None

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -318,7 +318,8 @@ def origin_annotation_dump(origin_info_new, origin_info_old, override=False, raw
     return yaml.dump(data, default_flow_style=False)
 
 def origin_annotation_load(request, action, user):
-    review = review_find_last(request, user)
+    # Find last accepted review which means it was reviewed and annotated.
+    review = review_find_last(request, user, ['accepted'])
     if not review:
         return False
 

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -332,7 +332,8 @@ def origin_annotation_load(request, action, user):
         comment_stripped = re.sub(r'^  ', '', review.comment, flags=re.MULTILINE)
         annotation = yaml.safe_load(comment_stripped)
 
-    if not annotation:
+    if not annotation or type(annotation) is not dict:
+        # Only returned structured data (ie. dict), otherwise None.
         return None
 
     if len(request.actions) > 1:


### PR DESCRIPTION
- 0b34e1629bc688d0fe4008239bc2ec9947af749f:
    osclib/origin: origin_annotation_load(): only return dict annotation.
    
    To improve robustness and handle invalid/corrupt data in the annotation
    just return None if it is anything other than a dict after parsing. The
    most likely occurrence is someone accepts the origin-manager review with
    a plain-text message.

- bc0ec5c6c9247fbb42efff2913dab28d346ae4dd:
    osclib/origin: origin_annotation_load(): only consider accepted reviews.
    
    This excludes reviews that were added and never reviewed possibly because
    the request was rejected before the review could be accepted. In such
    cases the comment specified when adding the review will be loaded as the
    annotation which is not desirable.

- cc03a3561775fcfdfc7b05f5aced0556ff2dbe0f:
    osclib/core: review_find_last(): provide states filter.

Fixes #2187.