### PR TITLE
osclib/origin_listener: change from package.update to package.commit event.

### DIFF
--- a/osclib/origin_listener.py
+++ b/osclib/origin_listener.py
@@ -36,7 +36,7 @@ class OriginSourceChangeListener(PubSubConsumer):
 
     def routing_keys(self):
         return [self._prefix + k for k in [
-            '.obs.package.update',
+            '.obs.package.commit',
             '.obs.request.create',
         ]]
 
@@ -44,7 +44,7 @@ class OriginSourceChangeListener(PubSubConsumer):
         super().on_message(unused_channel, method, properties, body)
 
         payload = json.loads(body)
-        if method.routing_key == '{}.obs.package.update'.format(self._prefix):
+        if method.routing_key == '{}.obs.package.commit'.format(self._prefix):
             self.on_message_package_update(payload)
         elif method.routing_key == '{}.obs.request.create'.format(self._prefix):
             self.on_message_request_create(payload)


### PR DESCRIPTION
In theory fixes the problem of not picking up SLE events as it is claimed they generate `.commit` events while not generating `.update` events (unlike all other packages). In theory no harm from this (although I remember debating between the two events and feel like there was a reason for sticking to update).

Fixes #2239.