### PR TITLE
Kill review bots if they didn't output anything for 30 minutes

### DIFF
--- a/gocd/checkers.opensuse.gocd.yaml
+++ b/gocd/checkers.opensuse.gocd.yaml
@@ -16,7 +16,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -37,7 +37,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - repo-checker
             tasks:
@@ -58,7 +58,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -80,7 +80,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -101,7 +101,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -122,7 +122,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -143,7 +143,7 @@ pipelines:
          type: manual
        jobs:
          Run:
-           timeout: 0
+           timeout: 30
            resources:
            - staging-bot
            tasks:
@@ -164,7 +164,7 @@ pipelines:
          type: manual
        jobs:
          Run:
-           timeout: 0
+           timeout: 30
            resources:
            - staging-bot
            tasks:
@@ -185,7 +185,7 @@ pipelines:
          type: manual
        jobs:
          Run:
-           timeout: 0
+           timeout: 30
            resources:
            - staging-bot
            tasks:

--- a/gocd/checkers.suse.gocd.yaml
+++ b/gocd/checkers.suse.gocd.yaml
@@ -16,7 +16,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -37,13 +37,13 @@ pipelines:
         approval: manual
         jobs:
           SLE_15_SP2:
-            timeout: 0
+            timeout: 30
             resources:
             - repo-checker
             tasks:
             - script: ./project-installcheck.py -A https://api.suse.de --debug check --store SUSE:SLE-15-SP2:GA:Staging/dashboard --no-rebuild SUSE:SLE-15-SP2:GA
           SLE_12_SP5:
-            timeout: 0
+            timeout: 30
             resources:
             - repo-checker
             tasks:
@@ -63,7 +63,7 @@ pipelines:
         approval: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - leaper
             tasks:
@@ -126,7 +126,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -161,7 +161,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -182,7 +182,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -203,7 +203,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -225,7 +225,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -248,7 +248,7 @@ pipelines:
           - SUSE:SLE-12-SP5:GA:Staging:A_-_standard.yaml
     stages:
     - Run:
-        timeout: 0
+        timeout: 30
         resources:
         - repo-checker
         tasks:
@@ -273,7 +273,7 @@ pipelines:
           - SUSE:SLE-12-SP5:GA:Staging:B_-_standard.yaml
     stages:
     - Run:
-        timeout: 0
+        timeout: 30
         resources:
         - repo-checker
         tasks:
@@ -298,7 +298,7 @@ pipelines:
           - SUSE:SLE-12-SP5:GA:Staging:C_-_standard.yaml
     stages:
     - Run:
-        timeout: 0
+        timeout: 30
         resources:
         - repo-checker
         tasks:
@@ -323,7 +323,7 @@ pipelines:
           - SUSE:SLE-12-SP5:GA:Staging:D_-_standard.yaml
     stages:
     - Run:
-        timeout: 0
+        timeout: 30
         resources:
         - repo-checker
         tasks:
@@ -348,7 +348,7 @@ pipelines:
           - SUSE:SLE-12-SP5:GA:Staging:H_-_standard.yaml
     stages:
     - Run:
-        timeout: 0
+        timeout: 30
         resources:
         - repo-checker
         tasks:
@@ -373,7 +373,7 @@ pipelines:
           - SUSE:SLE-12-SP5:GA:Staging:S_-_standard.yaml
     stages:
     - Run:
-        timeout: 0
+        timeout: 30
         resources:
         - repo-checker
         tasks:
@@ -398,7 +398,7 @@ pipelines:
           - SUSE:SLE-12-SP5:GA:Staging:V_-_standard.yaml
     stages:
     - Run:
-        timeout: 0
+        timeout: 30
         resources:
         - repo-checker
         tasks:
@@ -423,7 +423,7 @@ pipelines:
           - SUSE:SLE-12-SP5:GA:Staging:Y_-_standard.yaml
     stages:
     - Run:
-        timeout: 0
+        timeout: 30
         resources:
         - repo-checker
         tasks:

--- a/gocd/checkers.suse.gocd.yaml.erb
+++ b/gocd/checkers.suse.gocd.yaml.erb
@@ -16,7 +16,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -37,13 +37,13 @@ pipelines:
         approval: manual
         jobs:
           SLE_15_SP2:
-            timeout: 0
+            timeout: 30
             resources:
             - repo-checker
             tasks:
             - script: ./project-installcheck.py -A https://api.suse.de --debug check --store SUSE:SLE-15-SP2:GA:Staging/dashboard --no-rebuild SUSE:SLE-15-SP2:GA
           SLE_12_SP5:
-            timeout: 0
+            timeout: 30
             resources:
             - repo-checker
             tasks:
@@ -63,7 +63,7 @@ pipelines:
         approval: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - leaper
             tasks:
@@ -126,7 +126,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -161,7 +161,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -182,7 +182,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -203,7 +203,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -225,7 +225,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -249,7 +249,7 @@ pipelines:
           - SUSE:SLE-12-SP5:GA:Staging:<%= letter %>_-_standard.yaml
     stages:
     - Run:
-        timeout: 0
+        timeout: 30
         resources:
         - repo-checker
         tasks:

--- a/gocd/monitors.gocd.yaml
+++ b/gocd/monitors.gocd.yaml
@@ -18,7 +18,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - monitor
             tasks:
@@ -44,7 +44,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - monitor
             tasks:
@@ -71,7 +71,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - monitor
             tasks:
@@ -101,7 +101,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - monitor
             tasks:

--- a/gocd/staging-bot-reminder.gocd.yaml
+++ b/gocd/staging-bot-reminder.gocd.yaml
@@ -14,7 +14,7 @@ pipelines:
     - Run:
         approval:
           type: manual
-        timeout: 0
+        timeout: 30
         resources:
         - staging-bot
         tasks:

--- a/gocd/staging.bot.gocd.yaml
+++ b/gocd/staging.bot.gocd.yaml
@@ -40,7 +40,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -100,7 +100,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:

--- a/gocd/staging.bot.gocd.yaml.erb
+++ b/gocd/staging.bot.gocd.yaml.erb
@@ -42,7 +42,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 0
+            timeout: 30
             resources:
             - staging-bot
             tasks:


### PR DESCRIPTION
We start most jobs with --debug to generate output, but we had the case that OBS network caused the connection to just get stuck and then it 'paused' for 18 hours