### PR TITLE
osc-staging,issue-diff: open temporary file in write without binary mode.

### DIFF
--- a/issue-diff.py
+++ b/issue-diff.py
@@ -117,7 +117,7 @@ def prompt_continue(change_count):
     return prompt_continue(change_count)
 
 def prompt_interactive(changes, project, package):
-    with tempfile.NamedTemporaryFile(suffix='.yml') as temp:
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yml') as temp:
         temp.write(yaml.safe_dump(changes, default_flow_style=False, default_style="'") + '\n')
         temp.write('# {}/{}\n'.format(project, package))
         temp.write('# comment or remove lines to whitelist issues')

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -593,7 +593,7 @@ def do_staging(self, subcmd, opts, *args):
                     return
 
                 if opts.interactive:
-                    with tempfile.NamedTemporaryFile(suffix='.yml') as temp:
+                    with tempfile.NamedTemporaryFile(mode='w', suffix='.yml') as temp:
                         temp.write(yaml.safe_dump(splitter.proposal, default_flow_style=False) + '\n\n')
 
                         if len(splitter.requests):


### PR DESCRIPTION
Otherwise, all write calls complain about passing a string instead of
binary data. Given the yaml dump and subsequent comments are all strings
it makes more sense to change file mode.

Resolve issue reported in IRC by @lnussel.