### PR TITLE
build-fail-reminder: update api path to projects/:project/status

### DIFF
--- a/build-fail-reminder.py
+++ b/build-fail-reminder.py
@@ -99,7 +99,7 @@ def main(args):
     project = args.project
 
     logger.debug('loading build fails for %s'%project)
-    url = osc.core.makeurl(apiurl, ['project', 'status', project],
+    url = osc.core.makeurl(apiurl, ['projects', project, 'status'],
         { 'ignore_pending': True,
            'limit_to_fails': True,
            'include_versions': False,


### PR DESCRIPTION
Recently the status api path changed from `project/status/:project` to `projects/:project/status`, update the api path in build-fail-reminder. This should also fixes travis failure.