### PR TITLE
userscript/origin: run in no-conflict mode.

### DIFF
--- a/userscript/origin.user.js
+++ b/userscript/origin.user.js
@@ -10,6 +10,8 @@
 // @grant        none
 // ==/UserScript==
 
+jQuery.noConflict();
+
 (function()
 {
     var pathParts = window.location.pathname.split('/');


### PR DESCRIPTION
Otherwise, conflicts with OBS jquery version and plugins.

Verified on [package that is unresolvable in the target project](https://build.suse.de/package/show/SUSE:SLE-15-SP2:GA/drbd) where valid origin lookup can be observed to still work.

Fixes #2261.