### PR TITLE
Fix check_source on public cloud images

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -83,7 +83,7 @@ class CheckSource(ReviewBot.ReviewBot):
             self.review_messages['accepted'] = 'Skipping all checks for meta packages'
             return True
         elif (kind is not None and kind != 'source'):
-            self.review_messages['accepted'] = 'May not modify a non-source package of type {}'.format(kind)
+            self.review_messages['declined'] = 'May not modify a non-source package of type {}'.format(kind)
             return False
 
         inair_renamed = target_package != source_package

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -6,12 +6,7 @@ import re
 import socket
 from xml.etree import cElementTree as ET
 from lxml import etree as ETL
-
-try:
-    from urllib.error import HTTPError
-except ImportError:
-    #python 2.x
-    from urllib2 import HTTPError
+from urllib.error import HTTPError
 
 from osc.core import create_submit_request
 from osc.core import get_binarylist
@@ -532,9 +527,6 @@ def package_kind(apiurl, project, package):
 
     if root.find('releasename') is not None:
         return 'maintenance_update'
-
-    if root.find('bcntsynctag') is not None:
-        return 'multispec_subpackage'
 
     # Some multispec subpackages do not have bcntsynctag, so check link.
     link = entity_source_link(apiurl, project, package)


### PR DESCRIPTION
The check for bcntsynctag can be very misleading - just because we align the build counters between 2 packages doesn't make them invalid submission targets. Better rely on the link check which is already implemented as fallback

And set a verbose decline reason for this case