### PR TITLE
origin-manager: full handling of various devel project workflows, addition of significant tests, and many underlying fixes

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -240,7 +240,8 @@ class ReviewBot(object):
                 self.review_messages['declined'] = message
                 return False
 
-    def request_commands(self, command, who_allowed=None, request=None, action=None):
+    def request_commands(self, command, who_allowed=None, request=None, action=None,
+                         include_description=True):
         if not request:
             request = self.request
         if not action:
@@ -249,6 +250,10 @@ class ReviewBot(object):
             who_allowed = self.request_override_check_users(action.tgt_project)
 
         comments = self.comment_api.get_comments(request_id=request.reqid)
+        if include_description:
+            request_comment = self.comment_api.request_as_comment_dict(request)
+            comments[request_comment['id']] = request_comment
+
         yield from self.comment_api.command_find(comments, self.review_user, command, who_allowed)
 
     def _set_review(self, req, state):

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -182,20 +182,16 @@ class ReviewBot(object):
             with sentry_sdk.configure_scope() as scope:
                 scope.set_extra('request.id', self.request.reqid)
 
-            override = self.request_override_check(req)
-            if override is not None:
-                good = override
-            else:
-                try:
-                    good = self.check_one_request(req)
-                except Exception as e:
-                    good = None
+            try:
+                good = self.check_one_request(req)
+            except Exception as e:
+                good = None
 
-                    import traceback
-                    traceback.print_exc()
-                    return_value = 1
+                import traceback
+                traceback.print_exc()
+                return_value = 1
 
-                    sentry_sdk.capture_exception(e)
+                sentry_sdk.capture_exception(e)
 
             if self.review_mode == 'no':
                 good = None
@@ -228,15 +224,12 @@ class ReviewBot(object):
 
         return users
 
-    def request_override_check(self, request, force=False):
+    def request_override_check(self, force=False):
         """Check for a comment command requesting review override."""
         if not force and not self.override_allow:
             return None
 
-        comments = self.comment_api.get_comments(request_id=request.reqid)
-        users = self.request_override_check_users(request.actions[0].tgt_project)
-        for args, who in self.comment_api.command_find(
-            comments, self.review_user, 'override', users):
+        for args, who in self.request_commands('override'):
             message = 'overridden by {}'.format(who)
             override = args[1] if len(args) >= 2 else 'accept'
             if override == 'accept':
@@ -246,6 +239,17 @@ class ReviewBot(object):
             if override == 'decline':
                 self.review_messages['declined'] = message
                 return False
+
+    def request_commands(self, command, who_allowed=None, request=None, action=None):
+        if not request:
+            request = self.request
+        if not action:
+            action = self.action
+        if not who_allowed:
+            who_allowed = self.request_override_check_users(action.tgt_project)
+
+        comments = self.comment_api.get_comments(request_id=request.reqid)
+        yield from self.comment_api.command_find(comments, self.review_user, command, who_allowed)
 
     def _set_review(self, req, state):
         doit = self.can_accept_review(req.reqid)
@@ -407,8 +411,12 @@ class ReviewBot(object):
             with sentry_sdk.configure_scope() as scope:
                 scope.set_extra('action.key', key)
 
-            func = getattr(self, self.action_method(a))
-            ret = func(req, a)
+            override = self.request_override_check()
+            if override is not None:
+                ret = override
+            else:
+                func = getattr(self, self.action_method(a))
+                ret = func(req, a)
 
             # In the case of multiple actions take the "lowest" result where the
             # order from lowest to highest is: False, None, True.

--- a/dist/ci/flake-extra
+++ b/dist/ci/flake-extra
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 # Should never contain references to products.
-! grep -iP 'leap|factory|sle' origin-manager.py osc-origin.py osclib/origin.py
+! grep -iP 'leap|factory|sle' \
+  origin-manager.py osc-origin.py osclib/origin.py osclib/origin_listener.py

--- a/origin-manager.py
+++ b/origin-manager.py
@@ -50,6 +50,14 @@ class OriginManager(ReviewBot.ReviewBot):
             if key in ('fallback', 'maintainer'):
                 reviews[key] = comment
 
+        if result.accept:
+            config = config_load(self.apiurl, action.tgt_project)
+            if request.creator == config['review-user']:
+                # Remove all reviews since the request was generated via
+                # origin_update() which indicates it was approved already. Acts
+                # as workaround for to lack of set devel on a submit request.
+                reviews = {}
+
         if len(reviews) != len(result.reviews):
             result = PolicyResult(result.wait, result.accept, reviews, result.comments)
 

--- a/origin-manager.py
+++ b/origin-manager.py
@@ -81,6 +81,17 @@ class OriginManager(ReviewBot.ReviewBot):
 
         return True, True
 
+    def devel_project_simulate_check_command(self, source_project, target_project):
+        who_allowed = self.request_override_check_users(target_project)
+        if self.request.creator not in who_allowed:
+            who_allowed.append(self.request.creator)
+
+        for args, who in self.request_commands('change_devel', who_allowed):
+            override = args[1] if len(args) >= 2 else source_project
+            return override, who
+
+        return False, None
+
     def policy_result_handle(self, project, package, origin_info_new, origin_info_old, result):
         self.policy_result_reviews_add(project, package, result.reviews, origin_info_new, origin_info_old)
         self.policy_result_comment_add(project, package, result.comments)

--- a/origin-manager.py
+++ b/origin-manager.py
@@ -86,7 +86,7 @@ class OriginManager(ReviewBot.ReviewBot):
         if result.wait:
             # Allow overriding a policy wait by accepting as workaround with the
             # hope that pending request will be accepted.
-            override = self.request_override_check(self.request, True)
+            override = self.request_override_check(True)
             if override:
                 self.review_messages['accepted'] = origin_annotation_dump(
                     origin_info_new, origin_info_old, self.review_messages['accepted'], raw=True)

--- a/osclib/cache.py
+++ b/osclib/cache.py
@@ -24,6 +24,7 @@ from io import BytesIO
 from osc import conf
 from osc.core import urlopen
 from osclib.cache_manager import CacheManager
+from osclib.conf import str2bool
 from osclib.util import rmtree_nfs_safe
 from time import time
 
@@ -126,6 +127,12 @@ class Cache(object):
         Cache.CACHE_DIR = CacheManager.directory('request', directory)
 
         Cache.patterns = []
+
+        conf.get_config()
+        if str2bool(conf.config.get('osrt.cache.disable', '')):
+            if conf.config['debug']: print('CACHE_DISABLE via osrt.cache.disable', file=sys.stderr)
+            return
+
         for pattern in Cache.PATTERNS:
             Cache.patterns.append(re.compile(pattern))
 

--- a/osclib/comments.py
+++ b/osclib/comments.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from dateutil.parser import parse as date_parse
 import re
 from xml.etree import cElementTree as ET
 
@@ -48,6 +49,15 @@ class CommentAPI(object):
             'comment': comment_element.text,
         }
         return comment
+
+    def request_as_comment_dict(self, request):
+        return {
+            'who': request.creator,
+            'when': date_parse(request.statehistory[0].when),
+            'id': '-1',
+            'parent': None,
+            'comment': request.description,
+        }
 
     def get_comments(self, request_id=None, project_name=None,
                      package_name=None):

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -212,13 +212,15 @@ def devel_projects(apiurl, project):
 
     return sorted(devel_projects)
 
-def request_age(request):
+def request_created(request):
     if isinstance(request, Request):
         created = request.statehistory[0].when
     else:
         created = request.find('history').get('when')
-    created = date_parse(created)
-    return datetime.utcnow() - created
+    return date_parse(created)
+
+def request_age(request):
+    return datetime.utcnow() - request_created(request)
 
 def project_list_prefix(apiurl, prefix):
     """Get a list of project with the same prefix."""

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -83,6 +83,14 @@ def maintainers_get(apiurl, project, package=None):
 
     return maintainers
 
+def meta_role_expand(apiurl, meta, role='maintainer'):
+    users = meta.xpath('//person[@role="{}"]/@userid'.format(role))
+
+    groups = meta.xpath('//group[@role="{}"]/@groupid'.format(role))
+    users.extend(groups_members(apiurl, groups))
+
+    return users
+
 def package_list(apiurl, project):
     url = makeurl(apiurl, ['source', project], { 'expand': 1 })
     root = ET.parse(http_GET(url)).getroot()

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -1013,6 +1013,24 @@ def request_create_delete(apiurl, target_project, target_package, message=None):
 
     return RequestFuture('delete {}/{}'.format(target_project, target_package), create_function)
 
+def request_create_change_devel(apiurl, source_project, source_package,
+                                target_project, target_package=None, message=None):
+    if not target_package:
+        target_package = source_package
+
+    for request, action in request_action_list(
+        apiurl, target_project, target_package, REQUEST_STATES_MINUS_ACCEPTED, ['change_devel']):
+        return False
+
+    message = message_suffix('created', message)
+
+    def create_function():
+        return create_change_devel_request(apiurl, source_project, source_package,
+                                           target_project, target_package, message)
+
+    return RequestFuture('change_devel {}/{} -> {}/{}'.format(
+        source_project, source_package, target_project, target_package), create_function)
+
 # Should exist within osc.core like create_submit_request(), but rather it was
 # duplicated in osc.commandline.
 def create_delete_request(apiurl, target_project, target_package=None, message=None):
@@ -1037,6 +1055,41 @@ def create_delete_request(apiurl, target_project, target_package=None, message=N
     target.set('project', target_project)
     if target_package:
         target.set('package', target_package)
+    action.append(target)
+
+    url = makeurl(apiurl, ['request'], {'cmd': 'create'})
+    root = ETL.parse(http_POST(url, data=ETL.tostring(request))).getroot()
+    return root.get('id')
+
+# Should exist within osc.core like create_submit_request(), but rather it was
+# duplicated in osc.commandline.
+def create_change_devel_request(apiurl, source_project, source_package,
+                                target_project, target_package=None, message=None):
+    if not message:
+        message = message_suffix('created')
+
+    request = ETL.Element('request')
+
+    state = ETL.Element('state')
+    state.set('name', 'new')
+    request.append(state)
+
+    description = ETL.Element('description')
+    description.text = message
+    request.append(description)
+
+    action = ETL.Element('action')
+    action.set('type', 'change_devel')
+    request.append(action)
+
+    source = ETL.Element('source')
+    source.set('project', source_project)
+    source.set('package', source_package)
+    action.append(source)
+
+    target = ETL.Element('target')
+    target.set('project', target_project)
+    target.set('package', target_package)
     action.append(target)
 
     url = makeurl(apiurl, ['request'], {'cmd': 'create'})

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -83,6 +83,11 @@ def maintainers_get(apiurl, project, package=None):
 
     return maintainers
 
+@memoize(session=True)
+def project_role_expand(apiurl, project, role='maintainer'):
+    meta = ETL.fromstringlist(show_project_meta(apiurl, project))
+    return meta_role_expand(apiurl, meta, role)
+
 def meta_role_expand(apiurl, meta, role='maintainer'):
     users = meta.xpath('//person[@role="{}"]/@userid'.format(role))
 

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -1130,3 +1130,8 @@ def message_suffix(action, message=None):
 
     message += ' (host {})'.format(socket.gethostname())
     return message
+
+def request_state_change(apiurl, request_id, state):
+    query = { 'newstate': state, 'cmd': 'changestate' }
+    url = makeurl(apiurl, ['request', request_id], query)
+    return ETL.parse(http_POST(url)).getroot().get('code')

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -84,6 +84,16 @@ def maintainers_get(apiurl, project, package=None):
     return maintainers
 
 @memoize(session=True)
+def package_role_expand(apiurl, project, package, role='maintainer', inherit=True):
+    meta = ETL.fromstringlist(show_package_meta(apiurl, project, package))
+    users = meta_role_expand(apiurl, meta, role)
+
+    if inherit:
+        users.extend(project_role_expand(apiurl, project, role))
+
+    return users
+
+@memoize(session=True)
 def project_role_expand(apiurl, project, role='maintainer'):
     meta = ETL.fromstringlist(show_project_meta(apiurl, project))
     return meta_role_expand(apiurl, meta, role)

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -337,8 +337,9 @@ def origin_annotation_load(request, action, user):
         comment_stripped = re.sub(r'^  ', '', review.comment, flags=re.MULTILINE)
         annotation = yaml.safe_load(comment_stripped)
 
-    if not annotation or type(annotation) is not dict:
-        # Only returned structured data (ie. dict), otherwise None.
+    if not annotation or type(annotation) is not dict or 'origin' not in annotation:
+        # Only returned structured data (ie. dict) with a minimum of the origin
+        # key available, otherwise None.
         return None
 
     if len(request.actions) > 1:

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -464,9 +464,6 @@ def policy_input_evaluate(policy, inputs):
         if not inputs['from_highest_priority']:
             result.reviews['fallback'] = 'Not from the highest priority origin which provides the package.'
     else:
-        if inputs['direction'] == 'none':
-            return PolicyResult(False, False, {}, ['Identical source.'])
-
         if inputs['origin_change']:
             if inputs['higher_priority']:
                 if not inputs['same_family'] and inputs['direction'] != 'forward':
@@ -480,6 +477,9 @@ def policy_input_evaluate(policy, inputs):
             else:
                 result.reviews['fallback'] = 'Changing to a lower priority origin.'
         else:
+            if inputs['direction'] == 'none':
+                return PolicyResult(False, False, {}, ['Identical source.'])
+
             if inputs['direction'] == 'forward':
                 if not policy['automatic_updates']:
                     result.reviews['fallback'] = 'Forward direction, but automatic updates not allowed.'

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -677,7 +677,7 @@ def origin_updatable_map(apiurl, pending=None):
                 continue
 
             if origin == '<devel>':
-                for devel in devel_projects(apiurl, project):
+                for devel in origin_devel_projects(apiurl, project):
                     origins.setdefault(devel, set())
                     origins[devel].add(project)
             else:
@@ -735,6 +735,18 @@ def origin_devel_project(apiurl, project, package):
         return devel_project, devel_package
 
     return devel_project_get(apiurl, project, package)
+
+@memoize(session=True)
+def origin_devel_projects(apiurl, project):
+    projects = set(devel_projects(apiurl, project))
+
+    for devel_project, _ in origin_devel_project_requests(apiurl, project):
+        projects.add(devel_project)
+
+    devel_whitelist = Config.get(apiurl, project).get('devel-whitelist', '').split()
+    projects.update(devel_whitelist)
+
+    return sorted(projects)
 
 def origin_devel_project_requests(apiurl, project, package=None):
     config = config_load(apiurl, project)

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -699,7 +699,7 @@ def origin_updatable(apiurl):
     return projects
 
 @memoize(session=True)
-def origin_updatable_map(apiurl, pending=None):
+def origin_updatable_map(apiurl, pending=None, include_self=False):
     origins = {}
     for project in origin_updatable(apiurl):
         config = config_load(apiurl, project)
@@ -714,6 +714,10 @@ def origin_updatable_map(apiurl, pending=None):
             else:
                 origins.setdefault(origin, set())
                 origins[origin].add(project)
+
+        if include_self:
+            origins.setdefault(project, set())
+            origins[project].add(project)
 
     return origins
 

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -200,6 +200,11 @@ def origin_workaround_ensure(origin):
         return origin + '~'
     return origin
 
+def origin_workaround_strip(origin):
+    if origin_workaround_check(origin):
+        return origin[:-1]
+    return origin
+
 @memoize(session=True)
 def origin_find(apiurl, target_project, package, source_hash=None, current=False,
                 pending_allow=True, fallback=True):

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -421,14 +421,18 @@ def policy_input_calculate(apiurl, project, package,
             config = config_load(apiurl, project)
             origins = config_origin_list(config, apiurl, project, package)
 
-            inputs['higher_priority'] = \
-                origins.index(origin_info_new.project) < origins.index(origin_info_old.project)
-            if workaround_new:
-                inputs['same_family'] = True
+            if origin_info_old.project in origins:
+                inputs['higher_priority'] = \
+                    origins.index(origin_info_new.project) < origins.index(origin_info_old.project)
+                if workaround_new:
+                    inputs['same_family'] = True
+                else:
+                    inputs['same_family'] = \
+                        origin_info_new.project in project_list_family(
+                            apiurl, origin_info_old.project.rstrip('~'), True)
             else:
-                inputs['same_family'] = \
-                    origin_info_new.project in project_list_family(
-                        apiurl, origin_info_old.project.rstrip('~'), True)
+                inputs['higher_priority'] = None
+                inputs['same_family'] = False
         else:
             inputs['higher_priority'] = None
             inputs['same_family'] = True

--- a/osclib/origin_listener.py
+++ b/osclib/origin_listener.py
@@ -103,7 +103,10 @@ class OriginSourceChangeListener(PubSubConsumer):
                     threading.Thread(target=self.listeners[apiurl].run, name=apiurl).start()
 
     def origin_updatable_map(self, pending=None):
-        return origin_updatable_map(self.apiurl, pending=pending)
+        # include_self=True to check for updates whenever the target package is
+        # updated. This will catch needed follow-up change_devel and handle
+        # updates blocked by frequency control.
+        return origin_updatable_map(self.apiurl, pending=pending, include_self=not pending)
 
     def update_consider(self, origins, origin_project, package):
         if origin_project not in origins:

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -124,14 +124,14 @@ class TestCase(unittest.TestCase):
         try:
             env = os.environ
             env['OSC_CONFIG'] = OSCRC
-            self.output = subprocess.check_output(args, stderr=subprocess.STDOUT, env=env)
+            self.output = subprocess.check_output(args, stderr=subprocess.STDOUT, text=True, env=env)
         except subprocess.CalledProcessError as e:
             print(e.output)
             raise e
         print(self.output) # For debugging assertion failures.
 
     def assertOutput(self, text):
-        self.assertTrue(bytes(text, 'utf-8') in self.output, '[MISSING] ' + text)
+        self.assertTrue(text in self.output, '[MISSING] ' + text)
 
     def assertReview(self, rid, **kwargs):
         request = get_request(self.apiurl, rid)

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -210,8 +210,24 @@ class StagingWorkflow(object):
     def setup_remote_config(self):
         self.create_target()
         self.create_attribute_type('OSRT', 'Config', 1)
-        attribute_value_save(APIURL, self.project, 'Config', 'overridden-by-local = remote-nope\n'
-                                                        'remote-only = remote-indeed\n')
+
+        config = {
+            'overridden-by-local': 'remote-nope',
+            'remote-only': 'remote-indeed',
+        }
+        self.remote_config_set(config, replace_all=True)
+
+    def remote_config_set(self, config, replace_all=False):
+        if not replace_all:
+            config_existing = Config.get(self.apiurl, self.project)
+            config_existing.update(config)
+            config = config_existing
+
+        config_lines = []
+        for key, value in config.items():
+            config_lines.append(f'{key} = {value}')
+
+        attribute_value_save(APIURL, self.project, 'Config', '\n'.join(config_lines))
 
     def create_group(self, name, users=[]):
 

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -23,6 +23,7 @@ from osclib.conf import Config
 from osclib.freeze_command import FreezeCommand
 from osclib.stagingapi import StagingAPI
 from osclib.core import attribute_value_save
+from osclib.core import request_state_change
 from osclib.memoize import memoize_session_reset
 
 try:
@@ -440,10 +441,8 @@ class Request(object):
     def revoke(self):
         if self.revoked: return
         self.revoked = True
-        url = osc.core.makeurl(APIURL, ['request', self.reqid], { 'newstate': 'revoked',
-                                                                  'cmd': 'changestate' })
         try:
-            osc.core.http_POST(url)
+            request_state_change(APIURL, self.reqid, state)
         except HTTPError:
             # may fail if already accepted/declined in tests
             pass

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -453,7 +453,12 @@ class Request(object):
 
     def revoke(self):
         if self.revoked: return
+        self.change_state('revoked')
         self.revoked = True
+
+    def change_state(self, state):
+        print(f'changing request state of {self.reqid} to {state}')
+
         try:
             request_state_change(APIURL, self.reqid, state)
         except HTTPError as e:

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -158,6 +158,13 @@ class TestCase(unittest.TestCase):
         if comment:
             self.assertEqual(review.comment, comment)
 
+    def randomString(self, prefix='', length=None):
+        if prefix and not prefix.endswith('_'):
+            prefix += '_'
+        if not length:
+            length = random.randint(10, 30)
+        return prefix + ''.join([random.choice(string.ascii_letters) for i in range(length)])
+
 
 class StagingWorkflow(object):
     def __init__(self, project=PROJECT):

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -302,8 +302,10 @@ class StagingWorkflow(object):
                                       project_links=project_links)
         return self.projects[name]
 
-    def submit_package(self, package=None):
-        request = Request(source_package=package, target_project=self.project)
+    def submit_package(self, package=None, project=None):
+        if not project:
+            project = self.project
+        request = Request(source_package=package, target_project=project)
         self.requests.append(request)
         return request
 

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -66,6 +66,7 @@ class TestCase(unittest.TestCase):
                 '[general]',
                 'apiurl = http://api:3000',
                 'cookiejar = {}'.format(OSCCOOKIEJAR),
+                'osrt.cache.disable = true',
                 '[http://api:3000]',
                 'user = {}'.format(userid),
                 'pass = opensuse',

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -50,6 +50,7 @@ class TestCase(unittest.TestCase):
             # Avoid stale cookiejar since local OBS may be completely reset.
             os.remove(OSCCOOKIEJAR)
 
+        self.users = []
         self.osc_user('Admin')
         self.apiurl = conf.config['apiurl']
         self.assertOBS()
@@ -76,11 +77,16 @@ class TestCase(unittest.TestCase):
 
     def osc_user(self, userid):
         print(f'setting osc user to {userid}')
+        self.users.append(userid)
         self.oscrc(userid)
 
         # Rather than modify userid and email, just re-parse entire config and
         # reset authentication by clearing opener to avoid edge-cases.
         self.oscParse()
+
+    def osc_user_pop(self):
+        self.users.pop()
+        self.osc_user(self.users.pop())
 
     def oscParse(self):
         # Otherwise, will stick to first user for a given apiurl.

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -55,6 +55,10 @@ class TestCase(unittest.TestCase):
         self.apiurl = conf.config['apiurl']
         self.assertOBS()
 
+    def tearDown(self):
+        # Ensure admin user so that tearDown cleanup succeeds.
+        self.osc_user('Admin')
+
     def assertOBS(self):
         url = makeurl(self.apiurl, ['about'])
         root = ET.parse(http_GET(url)).getroot()

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -143,9 +143,20 @@ class TestCase(unittest.TestCase):
             for key, value in kwargs.items():
                 if hasattr(review, key) and getattr(review, key) == value[0]:
                     self.assertEqual(review.state, value[1], '{}={} not {}'.format(key, value[0], value[1]))
-                    return
+                    return review
 
         self.fail('{} not found'.format(kwargs))
+
+    def assertReviewBot(self, request_id, user, before, after, comment=None):
+        self.assertReview(request_id, by_user=(user, before))
+
+        self.osc_user(user)
+        self.execute_script(['id', request_id])
+        self.osc_user_pop()
+
+        review = self.assertReview(request_id, by_user=(user, after))
+        if comment:
+            self.assertEqual(review.comment, comment)
 
 
 class StagingWorkflow(object):

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -75,6 +75,7 @@ class TestCase(unittest.TestCase):
             ]))
 
     def osc_user(self, userid):
+        print(f'setting osc user to {userid}')
         self.oscrc(userid)
 
         # Rather than modify userid and email, just re-parse entire config and

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -90,6 +90,7 @@ class TestCase(unittest.TestCase):
         conf.get_config(override_conffile=OSCRC,
                         override_no_keyring=True,
                         override_no_gnome_keyring=True)
+        os.environ['OSC_CONFIG'] = OSCRC
 
     def execute_script(self, args):
         if self.script:
@@ -159,6 +160,8 @@ class StagingWorkflow(object):
         osc.core.conf.get_config(override_conffile=oscrc,
                                  override_no_keyring=True,
                                  override_no_gnome_keyring=True)
+        os.environ['OSC_CONFIG'] = oscrc
+
         if os.environ.get('OSC_DEBUG'):
             osc.core.conf.config['debug'] = 1
 

--- a/tests/devel_project_tests.py
+++ b/tests/devel_project_tests.py
@@ -6,6 +6,7 @@ class TestDevelProject(OBSLocal.TestCase):
     script_debug_osc = False
 
     def setUp(self):
+        super().setUp()
         self.wf = OBSLocal.StagingWorkflow()
         spa = self.wf.create_project('server:php:applications')
         OBSLocal.Package('drush', project=spa)
@@ -15,6 +16,7 @@ class TestDevelProject(OBSLocal.TestCase):
         self.wf.api.pseudometa_file_ensure('devel_projects', 'server:php:applications')
 
     def tearDown(self):
+        super().tearDown()
         self.osc_user('Admin')
         del self.wf
 

--- a/tests/origin_tests.py
+++ b/tests/origin_tests.py
@@ -1,0 +1,121 @@
+from osc.core import change_review_state
+from osc.core import copy_pac as copy_package
+from osc.core import get_request
+from osclib.comments import CommentAPI
+from osclib.core import attribute_value_save
+from osclib.core import devel_project_get
+from osclib.core import request_create_change_devel
+from osclib.core import request_state_change
+from osclib.memoize import memoize_session_reset
+from osclib.origin import config_load
+from osclib.origin import config_origin_generator
+from osclib.origin import config_origin_list
+from osclib.origin import NAME
+from osclib.origin import origin_annotation_load
+from osclib.origin import origin_find
+from osclib.origin import origin_update
+import yaml
+from . import OBSLocal
+
+class TestOrigin(OBSLocal.TestCase):
+    script = './origin-manager.py'
+    script_debug_osc = False
+
+    def setUp(self):
+        super().setUp()
+
+        self.target_project = self.randomString('target')
+        self.wf = OBSLocal.StagingWorkflow(self.target_project)
+
+        self.wf.create_attribute_type('OSRT', 'OriginConfig', 1)
+
+        self.bot_user = self.randomString('bot')
+        self.wf.create_user(self.bot_user)
+
+        self.review_user = self.randomString('reviewer')
+        self.wf.create_user(self.review_user)
+
+        self.review_group = self.randomString('group')
+        self.wf.create_group(self.review_group, [self.review_user])
+
+        self.wf.create_project(self.target_project, reviewer={'users': [self.bot_user]})
+
+    def tearDown(self):
+        super().tearDown()
+        del self.wf
+
+    def remote_config_set_age_minimum(self, minimum=0):
+        self.wf.remote_config_set({'originmanager-request-age-min': minimum})
+
+    def origin_config_write(self, origins, extra={}):
+        config = {
+            'origins': origins,
+            'review-user': self.bot_user,
+            'fallback-group': self.review_group,
+        }
+        config.update(extra)
+        config = yaml.dump(config, default_flow_style=False)
+        attribute_value_save(self.wf.apiurl, self.target_project, 'OriginConfig', config)
+
+    def assertComment(self, request_id, comment):
+        comments_actual = CommentAPI(self.wf.api.apiurl).get_comments(request_id=request_id)
+        comment_actual = next(iter(comments_actual.values()))
+        self.assertEqual(comment_actual['who'], self.bot_user)
+        self.assertEqual(comment_actual['comment'], '\n\n'.join(comment))
+
+    def assertAnnotation(self, request_id, annotation):
+        request = get_request(self.wf.apiurl, request_id)
+        annotation_actual = origin_annotation_load(request, request.actions[0], self.bot_user)
+
+        self.assertTrue(type(annotation_actual) is dict)
+        self.assertEqual(annotation_actual, annotation)
+
+    def accept_fallback_review(self, request_id):
+        self.osc_user(self.review_user)
+        change_review_state(apiurl=self.wf.apiurl,
+                            reqid=request_id, newstate='accepted',
+                            by_group=self.review_group, message='approved')
+        self.osc_user_pop()
+
+    def testRequestMinAge(self):
+        self.origin_config_write([])
+
+        request = self.wf.create_submit_request(self.randomString('devel'), self.randomString('package'))
+        self.assertReviewBot(request.reqid, self.bot_user, 'new', 'new')
+        self.assertOutput(f'skipping {request.reqid} of age')
+        self.assertOutput(f'since it is younger than 1800s')
+
+    def test_config(self):
+        attribute_value_save(self.wf.apiurl, self.target_project, 'OriginConfig', 'origins: []')
+        config = config_load(self.wf.apiurl, self.wf.project)
+        self.assertEqual(config['unknown_origin_wait'], False)
+        self.assertEqual(config['review-user'], NAME)
+
+        memoize_session_reset()
+        self.origin_config_write([{'fakeProject': {}}, {'*~': {}}])
+        config = config_load(self.wf.apiurl, self.wf.project)
+        self.assertEqual(config_origin_list(config), ['fakeProject', 'fakeProject~'])
+        for _, values in config_origin_generator(config['origins']):
+            self.assertEqual(values['automatic_updates'], True)
+
+    def test_no_config(self):
+        request = self.wf.create_submit_request(self.randomString('devel'), self.randomString('package'))
+        self.assertReviewBot(request.reqid, self.bot_user, 'new', 'accepted', 'skipping since no OSRT:OriginConfig')
+
+    def test_not_allowed_origin(self):
+        self.remote_config_set_age_minimum()
+        self.origin_config_write([{'fakeProject': {}}], {'unknown_origin_wait': True})
+
+        request = self.wf.create_submit_request(self.randomString('devel'), self.randomString('package'))
+        self.assertReviewBot(request.reqid, self.bot_user, 'new', 'new')
+
+        comment = [
+            '<!-- OriginManager state=seen result=None -->',
+            'Source not found in allowed origins:',
+            '- fakeProject',
+        ]
+        self.assertComment(request.reqid, comment)
+
+        self.origin_config_write([{'fakeProject': {}}], {'unknown_origin_wait': False})
+        self.assertReviewBot(request.reqid, self.bot_user, 'new', 'declined', 'review failed')
+        self.assertComment(request.reqid, comment)


### PR DESCRIPTION
- 55fe5fecf5a32ae6641840f383c4c68c93bef948:
    tests/origin_tests: provide split product origin tests.

- 0e0d53f06afd35eb2e125af24f41683fbb62f18c:
    tests/origin_tests: provide devel origin tests.

- 1ba38741e02eb0650ca682afadfe91e8df7ab27e:
    tests/origin_tests: provide harness and basic tests.

- 816ddac3869c64d0577597c4739d095831ca4ede:
    tests/OBSLocal: provide randomString() for ensuring tools not name dependent.

- 68352c72a2f8c2b34533700abb6c0584742bbcda:
    tests/OBSLocal: provide assertReviewBot() for review script workflows.

- e821cee8ec87c07aa9ad5101522be9cae9d0e6ed:
    tests/OBSLocal: submit_package(): provide optional project argument.
    
    Generating submit requests beyond only against the target project is
    important during testing.

- 227df6aad7efc5330187864831c48cdcac816dab:
    tests/OBSLocal: StagingWorkflow: provide and utilize remote_config_set().

- 3f374602ef1e4b1a1e490a5cdd778d7ac5d0d178:
    tests/OBSLocal: Request: extract change_state() from revoke.
    
    Changing request state is an import part of testing beyond just revoking.

- 92c30ac937d9b4e2e5b7fd67e7512c0fb2c6a488:
    tests/OBSLocal: tearDown(): ensure user is Admin before cleanup.
    
    Without this all cleanup fails which can cause leakage between test runs
    that utilize the same entity names.

- 9eee7ac2a777eaedd926157604b0696732ad6c5e:
    tests/OBSLocal: StagingWorkflow: stop hiding valid errors.
    
    Makes for debugging issues quite a pain.

- 38ee3f2286f35feb73ec06eb7d3edb0982b8fd6e:
    tests/OBSLocal: correct python 3 port attempt for subprocess output handling.
    
    Newlines are lost in previous port which makes output nearly useless.

- 712d16a1fda267353e4a22d3cc3ef97cf2609b75:
    tests/OBSLocal: provide osc_user_pop() to make user switching cleaner.

- 53c3ddc86dcb91243aa0bae7b4a9b9aadb15c63e:
    tests/OBSLocal: osc_user(): indicate when switching user.

- 4d383f77c3fd6dcac86f7c5b02cacab1d8d58def:
    tests/OBSLocal: disable request cache during testing.

- c70e8d1a5ba20f2eadd76d8821ee0d4a0dbed2e3:
    osclib/origin_listener: ultilize origin_updatable_map() include_self option.
    
    Useful for trigger follow-up change_devel requests are suppressed updates.

- 9282a0f2532101be95b7f392c0aeab699f0051e1:
    osclib/origin: origin_updatable_map(): provide include_self option.

- 626cb22ae685e1a2ba1616855365fe528835bfd4:
    osclib/origin: origin_update() generate change_devel requests.
    
    As a follow-up to new packages accepted from a specific devel generate
    a change_devel request automatically. Such requests should be approved
    automatically since they are a workaround to not being able to set devel
    during source submission.

- a708a610dffca40358104c8f2c5e56fef97df76a:
    origin-manager: handle change_devel request review.

- b06917ee2fff1a8974a441efeecc106e80a5e27c:
    origin-manager: when appropriate simulate devel project during source change review.

- 1e678cfadbba136e1b6e8d95bbb9ad7dc8d4330a:
    origin-manager: provide devel_project_simulate_check().
    
    Handles decided when and what to simulate the devel project as when
    reviewing a source change request.

- 805e5e9ce8e4e8ff1f21de74fc6d9eb4b58ac320:
    origin-manager: provide devel_project_simulate_check_command().
    
    Handles ingest of change_devel commands.

- 1dd502d9e81309d0c064d000205142eb38659eb3:
    origin-manager: provide and utilize origin_maintainer_review_ensure().
    
    Instead of ensure devel owner using owner search which is incorrect in
    many cases including for new packages add a review for origin maintainers.

- 0ccea1032a0d07df055a1a2e6deb23c3003223e6:
    osclib/origin: policy_input_calculate(): handle change from None origin.

- 09c806f9b1b2a250d79eefde820755b39a04bbeb:
    osclib/origin: allow for identical source if origin changed.
    
    Enables change_devel reviews were the source does not change, but the
    effective origin will change changed by the request.

- f7a7247e8776cdd3c30c5e557283baf43fff4e0e:
    osclib/origin: provide and utilize origin_devel_projects().
    
    Incorporate meta devel, request devel, and whitelist devel into one
    function.

- 8ce56dc0692a85ac15e46a87a132767b9e955f22:
    osclib/origin: provide origin_devel_project() and utlize.
    
    Handles incorporating simulated devel, pseudo devel from requests, and
    meta devel project into one function.

- a26e865e9cde02214c254550682df38d9fb03d9b:
    osclib/origin: provide origin_devel_project_requests().
    
    Determines psuedo devel projects based on pending requests.

- 3114e29849df105c73a6b523b86767d838027dfd:
    osclib/origin: provide devel_project_simulate enterable.

- 8406117d1ce2417b99faf5c008bd8dc134377fb2:
    osclib/origin: require origin key in origin_annotation_load().
    
    Alternatively, this can validate something like "ok: not handled".

- 870d3018bd983ff2b50ea7ffa3c34772d85f6476:
    osclib/origin: provide origin_workaround_strip().

- cd9f1ef33d403bc8451e7bf4ff0b34e562a9bbea:
    osclib/core: provide request_state_change() and utilize.

- 1f1a944e8b9af05e37ad0ec14207cef18bf144d7:
    osclib/core: provide request_create_change_devel() RequestFuture.

- a080170be08842ad3390e32900837a8fb9247b80:
    osclib/core: provide package_role_expand() to expand package role to users.

- 3d5eff0c71164310677cc5cbbf3a01837861cf0f:
    osclib/core: provide project_role_expand() to expand project role to users.

- d5b7fb08220c5538085b9b4eb2fb70c66ae93398:
    osclib/core: provide meta_role_expand() to expand a role to users given meta.

- 1b412ed709baa0546f7ffb59ed578d8eec09557f:
    osclib/core: break apart request_age() to provide request_created().

- 680e5eb4151dd8c29a1feb268f4a443deabcad55:
    osclib/cache: provide osrt.cache.disable config option to disable cache.
    
    Necessary for writing involved tests since the assumptions made by the
    cache are violated and thus cause problems.

- 8e64a6b514a08273baec48aab1a6dd388b6f1a5d:
    dist/ci/flake-extra: include origin_listener in product check.

- 2c0191ef1eeeeb06771ce3aa64ef7b312d8cbe97:
    ReviewBot: include request description in search for comment commands.

- 7cb4113c717aa6305217dadda93454693c2c742b:
    ReviewBot: rework override check to operate on actions.
    
    In multi-action workflows the override check should be performed by
    action so that different groups of users can override for different
    actions. Additionally, abstracting the request_commands() method provides
    a flexible base for additional commands to be added by ReviewBots.

- 1136631cf350c77db9c5003f8bfaa462e49f46f0:
    osclib/comments: provide request description as comment.
    
    Useful for operating on request descriptions inline with comments.

Some note worthy highlights for users:

- Comment commands are now supported in request description. That means release manager (and any requester for `change_devel` commands) can add relevant override commands when creating requests that they know will require overrides (or follow-up to requests that already did).
- A new `change_devel` command is supported by origin manager review bot that allows a source change request to be considered as coming from a specific devel project as if it's meta data was marked as such. By default the source project is simulated as the devel project, but the first argument can be any project. The normal evaluation process is performed so if they sources are not found in simulated devel project the review will still fail, but otherwise appropriate reviews will be added. Additionally, a change_devel request will automatically be generated for a package once accepted (if the origin is not otherwise found - such as for new package submissions).
- change_devel requests are reviewed by origin manager and will add reviews based on the new devel origin being requested. Automatically generated requests from origin-manager will skip human review since they are only generated when a source change request was already human reviewed with such a change devel annotation.
- comment override commands are now evaluated on a per-action basis so the appropriate user pools can override different portions of the review.
- The `devel-whitelist` config is supported to handle workflows like Factory where a devel project is desired to be pre-approved before a bulk submission, but otherwise requests can be approved individually. Additionally, once a request has been approved for a specific devel it will be included in devel project lists used elsewhere before the request has been accepted.
- The _maintainer_ review added by origin manager no longer utilizes owner search which was problematic for new packages and special cases within Leap with devel overrides. Instead reviews are added for the origin package which is the desired review.

Fixes #2183.
Fixes #1663.
Fixes #1703.
Fixes #2205.