### PR TITLE
osclib/origin: origin_update_pending() utilize project_remote_prefixed().

### DIFF
--- a/osclib/core.py
+++ b/osclib/core.py
@@ -726,6 +726,17 @@ def project_remote_apiurl(apiurl, project):
 
     return apiurl, project
 
+def project_remote_prefixed(apiurl, apiurl_remote, project):
+    if apiurl_remote == apiurl:
+        return project
+
+    remotes = project_remote_list(apiurl)
+    for remote, remote_apiurl in remotes.items():
+        if remote_apiurl == apiurl_remote:
+            return remote + ':' + project
+
+    raise Exception('remote APIURL interconnect not configured for{}'.format(apiurl_remote))
+
 def review_find_last(request, user, states=['all']):
     for review in reversed(request.reviews):
         if review.by_user == user and ('all' in states or review.state in states):

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -12,6 +12,7 @@ from osclib.core import package_source_hash_history
 from osclib.core import package_version
 from osclib.core import project_attributes_list
 from osclib.core import project_remote_apiurl
+from osclib.core import project_remote_prefixed
 from osclib.core import request_action_key
 from osclib.core import request_action_list
 from osclib.core import request_action_list_source
@@ -687,7 +688,8 @@ def origin_update_pending(apiurl, origin_project, package, target_project):
     for request, action in sorted(request_actions, key=lambda i: i[0].reqid, reverse=True):
         identifier = request_remote_identifier(apiurl, apiurl_remote, request.reqid)
         message = 'Newer pending source available from package origin. See {}.'.format(identifier)
-        return request_create_submit(apiurl, action.src_project, action.src_package,
+        src_project = project_remote_prefixed(apiurl, apiurl_remote, action.src_project)
+        return request_create_submit(apiurl, src_project, action.src_package,
                                      target_project, package, message=message, revision=action.src_rev)
 
     return False


### PR DESCRIPTION
- 8cdd505beabba174a60b756e0af93615202f7330:
    osclib/origin: origin_update_pending() utilize project_remote_prefixed().
    
    Correctly prefix the remote project with the interconnect when creating
    a submit request.

- fd94254601d8336779acf64193e6a94bef390058:
    osclib/core: provide project_remote_prefixed().

Fixes submission of pending updates from a remote origin. Meaning SLE can submit pending Factory updates if the switch is enabled.