### PR TITLE
osclib/origin: provide automatic update mode controls.

### DIFF
--- a/dist/ci/docker-compose-test.sh
+++ b/dist/ci/docker-compose-test.sh
@@ -17,6 +17,7 @@ for file in tests/*_tests.py; do
   if test -f /code/travis.settings; then
     COVER_ARGS="--with-coverage --cover-package=. --cover-inclusive"
   fi
+  echo "running tests from $file..."
   run_as_tester nosetests $COVER_ARGS -c .noserc -s $file
 done
 

--- a/dist/obs/OSRT:OriginUpdateDelay.xml
+++ b/dist/obs/OSRT:OriginUpdateDelay.xml
@@ -1,0 +1,5 @@
+<definition name="OSRT:OriginUpdateDelay" namespace="OSRT">
+  <description>OriginManager update delay frequency in seconds (minimum time since source change)</description>
+  <count>1</count>
+  <modifiable_by role="maintainer"/>
+</definition>

--- a/dist/obs/OSRT:OriginUpdateFrequency.xml
+++ b/dist/obs/OSRT:OriginUpdateFrequency.xml
@@ -1,0 +1,5 @@
+<definition name="OSRT:OriginUpdateFrequency" namespace="OSRT">
+  <description>OriginManager update frequency in seconds (minimum time since last request)</description>
+  <count>1</count>
+  <modifiable_by role="maintainer"/>
+</definition>

--- a/dist/obs/OSRT:OriginUpdateSupersede.xml
+++ b/dist/obs/OSRT:OriginUpdateSupersede.xml
@@ -1,0 +1,5 @@
+<definition name="OSRT:OSRT:OriginUpdateSupersede" namespace="OSRT">
+  <description>OriginManager allowed to supersede existing requests (true or false)</description>
+  <count>1</count>
+  <modifiable_by role="maintainer"/>
+</definition>

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -968,7 +968,7 @@ def request_action_simple_list(apiurl, project, package, states, request_type):
     # Disable including source project in get_request_list() query.
     before = conf.config['include_request_from_project']
     conf.config['include_request_from_project'] = False
-    requests = get_request_list(apiurl, project, package, None, states, request_type)
+    requests = get_request_list(apiurl, project, package, None, states, request_type, withfullhistory=True)
     conf.config['include_request_from_project'] = before
 
     for request in requests:

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -361,8 +361,9 @@ def package_list_kind_filtered(apiurl, project, kinds_allowed=['source']):
 
         yield package
 
-def attribute_value_load(apiurl, project, name, namespace='OSRT'):
-    url = makeurl(apiurl, ['source', project, '_attribute', namespace + ':' + name])
+def attribute_value_load(apiurl, project, name, namespace='OSRT', package=None):
+    path = list(filter(None, ['source', project, package, '_attribute', namespace + ':' + name]))
+    url = makeurl(apiurl, path)
 
     try:
         root = ETL.parse(http_GET(url)).getroot()
@@ -389,7 +390,7 @@ def attribute_value_load(apiurl, project, name, namespace='OSRT'):
 #   `api -T $xml /attribute/OSRT/$NEWATTRIBUTE/_meta`
 #
 # Remember to create for both OBS and IBS as necessary.
-def attribute_value_save(apiurl, project, name, value, namespace='OSRT'):
+def attribute_value_save(apiurl, project, name, value, namespace='OSRT', package=None):
     root = ET.Element('attributes')
 
     attribute = ET.SubElement(root, 'attribute')
@@ -399,7 +400,7 @@ def attribute_value_save(apiurl, project, name, value, namespace='OSRT'):
     ET.SubElement(attribute, 'value').text = value
 
     # The OBS API of attributes is super strange, POST to update.
-    url = makeurl(apiurl, ['source', project, '_attribute'])
+    url = makeurl(apiurl, list(filter(None, ['source', project, package, '_attribute'])))
     http_POST(url, data=ET.tostring(root))
 
 @memoize(session=True)

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -13,6 +13,7 @@ from osc.core import get_binarylist
 from osc.core import get_commitlog
 from osc.core import get_dependson
 from osc.core import get_request_list
+from osc.core import http_DELETE
 from osc.core import http_GET
 from osc.core import http_POST
 from osc.core import http_PUT
@@ -402,6 +403,10 @@ def attribute_value_save(apiurl, project, name, value, namespace='OSRT', package
     # The OBS API of attributes is super strange, POST to update.
     url = makeurl(apiurl, list(filter(None, ['source', project, package, '_attribute'])))
     http_POST(url, data=ET.tostring(root))
+
+def attribute_value_delete(apiurl, project, name, namespace='OSRT', package=None):
+    http_DELETE(makeurl(
+        apiurl, list(filter(None, ['source', project, package, '_attribute', namespace + ':' + name]))))
 
 @memoize(session=True)
 def _repository_path_expand(apiurl, project, repo):

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -999,7 +999,7 @@ def request_action_list_source(apiurl, project, package, states=['new', 'review'
 
 def request_create_submit(apiurl, source_project, source_package,
                           target_project, target_package=None, message=None, revision=None,
-                          ignore_if_any_request=False):
+                          ignore_if_any_request=False, supersede=True):
     """
     ignore_if_any_request: ignore source changes and do not submit if any prior requests
     """
@@ -1016,6 +1016,8 @@ def request_create_submit(apiurl, source_project, source_package,
     for request, action in request_action_list(
         apiurl, target_project, target_package, REQUEST_STATES_MINUS_ACCEPTED, ['submit']):
         if ignore_if_any_request:
+            return False
+        if not supersede and request.state.name in ('new', 'review'):
             return False
 
         source_hash_pending = package_source_hash(

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -999,7 +999,7 @@ def request_action_list_source(apiurl, project, package, states=['new', 'review'
 
 def request_create_submit(apiurl, source_project, source_package,
                           target_project, target_package=None, message=None, revision=None,
-                          ignore_if_any_request=False, supersede=True):
+                          ignore_if_any_request=False, supersede=True, frequency=None):
     """
     ignore_if_any_request: ignore source changes and do not submit if any prior requests
     """
@@ -1018,6 +1018,8 @@ def request_create_submit(apiurl, source_project, source_package,
         if ignore_if_any_request:
             return False
         if not supersede and request.state.name in ('new', 'review'):
+            return False
+        if frequency and request_age(request).total_seconds() < frequency:
             return False
 
         source_hash_pending = package_source_hash(

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 from collections import OrderedDict
 from datetime import datetime
+from datetime import timezone
 from dateutil.parser import parse as date_parse
 import re
 import socket
@@ -525,6 +526,14 @@ def project_meta_revision(apiurl, project):
     root = ET.fromstringlist(get_commitlog(
         apiurl, project, '_project', None, format='xml', meta=True))
     return int(root.find('logentry').get('revision'))
+
+def package_source_changed(apiurl, project, package):
+    url = makeurl(apiurl, ['source', project, package, '_history'], {'limit': 1})
+    root = ETL.parse(http_GET(url)).getroot()
+    return datetime.fromtimestamp(int(root.find('revision/time').text), timezone.utc).replace(tzinfo=None)
+
+def package_source_age(apiurl, project, package):
+    return datetime.utcnow() - package_source_changed(apiurl, project, package)
 
 def entity_exists(apiurl, project, package=None):
     try:

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -158,7 +158,7 @@ class TestCase(unittest.TestCase):
         if prefix and not prefix.endswith('_'):
             prefix += '_'
         if not length:
-            length = random.randint(10, 30)
+            length = 2
         return prefix + ''.join([random.choice(string.ascii_letters) for i in range(length)])
 
 

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -480,6 +480,9 @@ class Request(object):
                                  dst_project=self.target_project)
         self.revoked = False
 
+        print('created submit request {}/{} -> {}'.format(
+            self.source_package.project.name, self.source_package.name, self.target_project))
+
     def __del__(self):
         self.revoke()
 


### PR DESCRIPTION
- ba103f3609f8b56583f721bd156763678f5ef1ec:
    osclib/origin: provide automatic update mode controls.

- 35dab9824a1067ba6962e167968689cfda194ecb:
    osclib/core: request_create_submit(): provide frequency option.

- 5087480d7bff406244e8d09a951e028d19238e72:
    osclib/core: request_create_submit(): provide supersede flag.

- fbeccb34ecbeecbf68612ee2aea92c3cb19cbb88:
    osclib/core: request_action_simple_list(): include full history.
    
    Without this the requests are not nearly as useful when processing.

- 6bdd1a014d122e4eaa90e1c923f0f234b327ae8c:
    osclib/core: provide package_source_{changed,age}() functions.

- 34e21ad23034416aece231d09b0f1088c7ff856f:
    osclib/core: provide attribute_value_delete().

- b894ceae509461bf82c83bde39155d52aa974894:
    osclib/core: support package in attribute_value_{load,save}() functions.

Based on requests from devel package maintainers for Leap, likely want to default to a delay and frequency cap for `<devel>` origin. @lnussel thoughts? (for now I configured a one hour delay and daily frequency for both Leap and Factory devel projects)

Fixes #2182.
Fixes #942.