### PR TITLE
osclib/core: package_kind(): require releasename to differ from package for maintenance_update.

### DIFF
--- a/osclib/core.py
+++ b/osclib/core.py
@@ -550,7 +550,7 @@ def package_kind(apiurl, project, package):
 
         raise e
 
-    if root.find('releasename') is not None:
+    if root.find('releasename') is not None and root.find('releasename').text != package:
         return 'maintenance_update'
 
     # Some multispec subpackages do not have bcntsynctag, so check link.


### PR DESCRIPTION
When releasename does not differ it is essentially the same as no
releasename at all, but since OBS allows this and some source packages
contain such a value need to make check more specific.

Fixes #2294.