### PR TITLE
web/origin-manager: paginate request history.

### DIFF
--- a/web/origin-manager/main.js
+++ b/web/origin-manager/main.js
@@ -240,6 +240,8 @@ function history_table_init(selector) {
         initialSort: [
             { column: 'request', dir: 'desc' },
         ],
+        pagination: 'local',
+        paginationSize: 15,
         rowClick: history_select_hash,
         selectable: 1,
         tooltips: true,


### PR DESCRIPTION
Otherwise, packages that are frequently updated (such as openSUSE-release-tools) overflow the page with so many request entries.

# before

![image](https://user-images.githubusercontent.com/22943929/68337178-8d648380-00a5-11ea-947e-33cc8106ff7a.png)

# after

![image](https://user-images.githubusercontent.com/22943929/68337128-76be2c80-00a5-11ea-8134-9a655d3829bd.png)