### PR TITLE
origin-manager: add psuedo maintenance_incident review to mirror staging workflow and provide pending_submission_allowed_reviews along with not to facilitate desired filtering

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -120,6 +120,8 @@ DEFAULT = {
         'repo_checker-arch-whitelist': 'x86_64',
         'repo_checker-no-filter': 'True',
         'repo_checker-package-comment-devel': 'True',
+        'review-install-check': 'maintenance-installcheck',
+        'review-openqa': 'qam-openqa',
     },
     r'openSUSE:(?P<project>Backports:(?P<version>[^:]+))$': {
         'staging': 'openSUSE:%(project)s:Staging',

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -911,7 +911,15 @@ def request_action_list_maintenance_incident(apiurl, project, package, states=['
         # Before being assigned to an incident.
         xpath_project = xpath_join(xpath_project, 'action/target/@project="{}"'.format(
             maintenance_project))
-        xpath_project = xpath_join(xpath_project, 'action/source/@package="{}"'.format(package), op='and', inner=True)
+
+        xpath_project_package = ''
+        xpath_project_package = xpath_join(
+            xpath_project_package, 'action/source/@package="{}"'.format(package))
+        xpath_project_package = xpath_join(
+            xpath_project_package, 'action/source/@package="{}"'.format(
+                package_repository), op='or', inner=True)
+
+        xpath_project = xpath_join(xpath_project, f'({xpath_project_package})', op='and', inner=True)
 
         xpath = xpath_join(xpath, xpath_project, op='or', nexpr_parentheses=True)
         xpath_project = ''
@@ -941,7 +949,8 @@ def request_action_list_maintenance_incident(apiurl, project, package, states=['
 
         for action in request.actions:
             if action.type == 'maintenance_incident' and action.tgt_releaseproject == project and (
-                (action.tgt_package is None and action.src_package == package) or
+                (action.tgt_package is None and
+                    (action.src_package == package or action.src_package == package_repository)) or
                 (action.tgt_package == package_repository)):
                 yield request, action
                 break

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -759,11 +759,19 @@ def review_find_last(request, user, states=['all']):
 
     return None
 
-def reviews_remaining(request):
+def reviews_remaining(request, incident_psuedo=False):
     reviews = []
     for review in request.reviews:
         if review.state != 'accepted':
             reviews.append(review_short(review))
+
+    if incident_psuedo:
+        # Add review in the same style as the staging review used for non
+        # maintenance projects to allow for the same wait on review.
+        for action in request.actions:
+            if action.type == 'maintenance_incident':
+                reviews.append('maintenance_incident')
+                break
 
     return reviews
 

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -51,7 +51,11 @@ POLICY_DEFAULTS = {
     'pending_submission_allow': False,
     'pending_submission_consider': False,
     'pending_submission_allowed_reviews': [
+        # Non-maintenance projects:
         '<config_source:staging>*',
+        # Maintenance projects:
+        '<config_source:review-install-check>',
+        '<config_source:review-openqa>',
     ],
     # Submit pending requests with a set of allowed reviews, but still wait for
     # the above reviews before being accepted.

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -525,16 +525,26 @@ def policy_input_evaluate_reviews_not_allowed(policy, inputs):
 def reviews_filter_allowed(reviews_remaining, allowed_reviews):
     reviews_not_allowed = []
     for review_remaining in reviews_remaining:
-        allowed = False
+        allowed = None
+        not_rule = False
         for review_allowed in allowed_reviews:
+            result = True
+            if review_allowed.startswith('!'):
+                not_rule = True
+                review_allowed = review_allowed[1:]
+                result = False
+
             if review_allowed.endswith('*') and review_remaining.startswith(review_allowed[:-1]):
-                allowed = True
+                allowed = result
                 break
             if review_remaining == review_allowed:
-                allowed = True
+                allowed = result
                 break
 
-        if not allowed:
+        # If not the allowed case then add the review to not allowed list.
+        # Allowed if either matches an allow rule or does not match anything
+        # when at least one not rule is present.
+        if not (allowed or (not_rule and allowed is None)):
             reviews_not_allowed.append(review_remaining)
 
     return reviews_not_allowed

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -52,7 +52,6 @@ POLICY_DEFAULTS = {
     'pending_submission_consider': False,
     'pending_submission_allowed_reviews': [
         '<config_source:staging>*',
-        '<config_source:repo-checker>',
     ],
     # Submit pending requests with a set of allowed reviews, but still wait for
     # the above reviews before being accepted.

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -519,10 +519,14 @@ def policy_input_evaluate(policy, inputs):
     return result
 
 def policy_input_evaluate_reviews_not_allowed(policy, inputs):
+    return reviews_filter_allowed(inputs['pending_submission'].reviews_remaining,
+                                  policy['pending_submission_allowed_reviews'])
+
+def reviews_filter_allowed(reviews_remaining, allowed_reviews):
     reviews_not_allowed = []
-    for review_remaining in inputs['pending_submission'].reviews_remaining:
+    for review_remaining in reviews_remaining:
         allowed = False
-        for review_allowed in policy['pending_submission_allowed_reviews']:
+        for review_allowed in allowed_reviews:
             if review_allowed.endswith('*') and review_remaining.startswith(review_allowed[:-1]):
                 allowed = True
                 break

--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -277,7 +277,7 @@ def project_source_pending(apiurl, project, package, source_hash):
         if source_hash_consider == source_hash:
             return PendingRequestInfo(
                 request_remote_identifier(apiurl, apiurl_remote, request.reqid),
-                reviews_remaining(request))
+                reviews_remaining(request, True))
 
     return False
 


### PR DESCRIPTION
- c6e093d8d01a229485721d85c20d468c503e348b:
    osclib/core: request_action_list_maintenance_incident(): support another form.
    
    When at last one thought all the variations of the data format were
    handled OBS decided to provide another. :((((

- a3b1d627b4a2b188ff2185c5a45f2b8da283cc9a:
    osclib/conf: configure maintenance staging review options for origin-manager.

- dc9147be974200d8798b0ab7bbb29ab862314841:
    osclib/origin: add maintenance staging equivalent reviews to pending_submission_allowed_reviews.

- 6826524d07b501da9bcf6cbbb85e0951b25bee45:
    osclib/origin: drop repo-checker from pending_submission_allowed_reviews.
    
    No longer utilized and the config option has been removed from project
    configs so the rule is dropped when evaluated anyway.

- e2334dae3db471cbe61651db17bf94ac58d551a0:
    osclib/origin: provide pending_submission_allowed_reviews_update option.

- 538b39ae3cfdcfa4a2769e04bcf4beb9bbe94aa9:
    osclib/origin: reviews_filter_allowed(): support negation rules.

- 13be4f2ef1c5bfeedfb997d056b0e3a1ce349f6e:
    osclib/origin: provide reviews_filter_allowed().
    
    Split out inner logic from policy_input_evaluate_reviews_not_allowed() to
    allow for other users.

- 4bbdfc675e919698776d6fd952a5ccb69088822c:
    osclib/origin: project_source_pending(): include psuedo incident review.

- c8cba5d2a1c260de6723daa8d5f8c91eb0244ffb:
    osclib/core: reviews_remaining(): provide incident_psuedo option.

@lnussel You can re-enable `pending_submission_allow` for `Leap:15.1:Update` if desired as it will only consider release requests by default, but still have to deal with #2146. It will still match submissions against incidents and wait for them to be accepted.

Fixes #2147.