### PR TITLE
osclib/origin: origin_annotation_dump(): include pending information.

### DIFF
--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -319,7 +319,14 @@ def origin_find_fallback(apiurl, target_project, package, source_hash, user):
     return None
 
 def origin_annotation_dump(origin_info_new, origin_info_old, override=False, raw=False):
-    data = {'origin': str(origin_info_new.project) if origin_info_new else 'None'}
+    data = {}
+    if origin_info_new is None:
+        data['origin'] = str(origin_info_new)
+    else:
+        data['origin'] = str(origin_info_new.project)
+        if origin_info_new.pending:
+            data['pending'] = origin_info_new.pending.identifier
+
     if origin_info_old and origin_info_new.project != origin_info_old.project:
         data['origin_old'] = str(origin_info_old.project)
 


### PR DESCRIPTION
Fixes #2151.