### PR TITLE
origin-manager: indicate the decision may be overridden via command.

### DIFF
--- a/origin-manager.py
+++ b/origin-manager.py
@@ -169,6 +169,9 @@ class OriginManager(ReviewBot.ReviewBot):
         return False, None
 
     def policy_result_handle(self, project, package, origin_info_new, origin_info_old, result):
+        if result.wait and not result.accept:
+            result.comments.append(f'Decision may be overridden via `@{self.review_user} override`.')
+
         self.policy_result_reviews_add(project, package, result.reviews, origin_info_new, origin_info_old)
         self.policy_result_comment_add(project, package, result.comments)
 

--- a/tests/origin_tests.py
+++ b/tests/origin_tests.py
@@ -142,11 +142,13 @@ class TestOrigin(OBSLocal.TestCase):
             '<!-- OriginManager state=seen result=None -->',
             'Source not found in allowed origins:',
             '- fakeProject',
+            f'Decision may be overridden via `@{self.bot_user} override`.',
         ]
         self.assertComment(request.reqid, comment)
 
         self.origin_config_write([{'fakeProject': {}}], {'unknown_origin_wait': False})
         self.assertReviewBot(request.reqid, self.bot_user, 'new', 'declined', 'review failed')
+        comment.pop()
         self.assertComment(request.reqid, comment)
 
     def test_devel_only(self):
@@ -176,6 +178,7 @@ class TestOrigin(OBSLocal.TestCase):
                 '<!-- OriginManager state=seen result=None -->',
                 'Source not found in allowed origins:',
                 f'- {self.product_project}',
+                f'Decision may be overridden via `@{self.bot_user} override`.',
             ]
             self.assertComment(request.reqid, comment)
 


### PR DESCRIPTION
Fixes #2228.