### PR TITLE
osclib/origin: origin_history(): include non-annotated requests.

### DIFF
--- a/osclib/origin.py
+++ b/osclib/origin.py
@@ -599,11 +599,10 @@ def origin_history(apiurl, target_project, package, user):
     request_actions = request_action_list_source(apiurl, target_project, package, states=['all'])
     for request, action in sorted(request_actions, key=lambda i: i[0].reqid, reverse=True):
         annotation = origin_annotation_load(request, action, user)
-        if not annotation:
-            continue
-
         history.append({
-            'origin': annotation.get('origin', 'None'),
+            # Not completely accurate, but more useful to have non-annotated
+            # entries than to exclude them.
+            'origin': annotation['origin'] if annotation else action.src_project,
             'request': request.reqid,
             'state': request.state.name,
             'source_project': action.src_project,


### PR DESCRIPTION
Otherwise, requests that are declined quickly (likely by bot) are not
shown in history which can be confusing when viewing in web interface. A
package may show as being one revision behind and one would wonder why
not update request when in fact a request could have been made and
declined.

Fixes #2245.