### PR TITLE
dist/obs/attribute-update: provide script for updating attribute definitions.

### DIFF
--- a/dist/obs/attribute-update
+++ b/dist/obs/attribute-update
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ $# -ne 2 ] ; then
+  echo "usage: $(basename "$0") <APIURL> <group>"
+  echo
+  echo "  ./attribute-update obs factory-staging"
+  echo "  ./attribute-update ibs sle-staging-managers"
+  exit 1
+fi
+
+for file in *.xml ; do
+  read -p "update $(basename "$file")? [y/n]: " response
+  if [ "$response" != "y" ] ; then
+    continue
+  fi
+
+  temp="/tmp/$(basename "$file")"
+  sed "5i<modifiable_by group='$2'/>" "$file" > "$temp"
+  path="$(basename "$file" | sed 's|:|/|' | sed 's|.xml||')"
+  echo "PUT /attribute/$path/_meta"
+  osc -A "$1" api -X PUT -T "$temp" "/attribute/$path/_meta"
+  rm "$temp"
+done


### PR DESCRIPTION
Utilized to deploy the new origin manager attributes to both OBS and IBS.