### PR TITLE
Disable splitter info until we find a better place to store it

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -562,10 +562,11 @@ def do_staging(self, subcmd, opts, *args):
                     request_ids = map(str, info['requests'].keys())
                     target_project = api.prj_from_short(info['staging'])
 
-                    if 'merge' not in info:
-                        # Assume that the original splitter_info is desireable
-                        # and that this staging is simply manual followup.
-                        api.set_splitter_info_in_prj_pseudometa(target_project, info['group'], info['strategy'])
+                    # TODO: Find better place for splitter info
+                    # if 'merge' not in info:
+                    #    Assume that the original splitter_info is desireable
+                    #    and that this staging is simply manual followup.
+                    #    api.set_splitter_info_in_prj_pseudometa(target_project, info['group'], info['strategy'])
 
                     SelectCommand(api, target_project) \
                         .perform(request_ids, no_freeze=opts.no_freeze)

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -72,6 +72,9 @@ class RequestSplitter(object):
         if required:
             self.filter_add(xpath)
 
+    def is_staging_mergeable(self, staging):
+        return self.stagings[staging]['status'].find('staged_requests/request') is not None
+
     def filter_only(self):
         ret = []
         for request in self.requests:
@@ -175,18 +178,16 @@ class RequestSplitter(object):
             return '00'
         return '__'.join(key)
 
-    def is_staging_mergeable(self, status, pseudometa):
-        return len(pseudometa['requests']) > 0 and 'splitter_info' in pseudometa
-
-    def should_staging_merge(self, status, pseudometa, bootstrapped):
-        if (not bootstrapped and
-            pseudometa['splitter_info']['strategy']['name'] in ('devel', 'super') and
-            status['overall_state'] not in ('acceptable', 'review')):
+    def should_staging_merge(self, staging):
+        staging = self.stagings[staging]
+        if (not staging['bootstrapped'] and
+            staging['splitter_info']['strategy']['name'] in ('devel', 'super') and
+            staging['status'].get('state') not in ('acceptable', 'review')):
             # Simplistic attempt to allow for followup requests to be staged
             # after age max has been passed while still stopping when ready.
             return True
 
-        if 'activated' not in pseudometa['splitter_info']:
+        if 'activated' not in staging['splitter_info']:
             # No information on the age of the staging.
             return False
 
@@ -194,17 +195,15 @@ class RequestSplitter(object):
         # created shortly after. This method removes the need to wait to create
         # a larger staging at once while not ending up with lots of tiny
         # stagings. As such this handles both high and low request backlogs.
-        activated = dateutil.parser.parse(pseudometa['splitter_info']['activated'])
+        activated = dateutil.parser.parse(staging['splitter_info']['activated'])
         delta = datetime.utcnow() - activated
         return delta.total_seconds() <= self.staging_age_max
 
-    def staging_status_load(self, project):
-        status = self.api.project_status(project)
-        return status, self.api.load_prj_pseudometa(status['description'])
-
-    def is_staging_considerable(self, project, pseudometa):
-        return (len(pseudometa['requests']) == 0 and
-                self.api.prj_frozen_enough(project))
+    def is_staging_considerable(self, staging):
+        staging = self.stagings[staging]
+        if staging['status'].find('staged_requests/request') is not None:
+            return False
+        return self.api.prj_frozen_enough(staging['project'])
 
     def stagings_load(self, stagings):
         self.stagings = {}
@@ -227,25 +226,25 @@ class RequestSplitter(object):
 
         for staging in stagings:
             project = self.api.prj_from_short(staging)
-            status, pseudometa = self.staging_status_load(project)
+            status = self.api.project_status(project)
             bootstrapped = self.api.is_staging_bootstrapped(project)
 
             # Store information about staging.
             self.stagings[staging] = {
                 'project': project,
                 'bootstrapped': bootstrapped,
-                'status': status,
-                'pseudometa': pseudometa,
+                # TODO: find better place for splitter info
+                'splitter_info': { 'strategy': { 'name': 'none' } },
+                'status': status
             }
 
             # Decide if staging of interested.
-            if self.is_staging_mergeable(status, pseudometa) and (
-               should_always or self.should_staging_merge(status, pseudometa, bootstrapped)):
-                if pseudometa['splitter_info']['strategy']['name'] == 'none':
+            if self.is_staging_mergeable(staging) and (should_always or self.should_staging_merge(staging)):
+                if self.stagings[staging]['splitter_info']['strategy']['name'] == 'none':
                     self.stagings_mergeable_none.append(staging)
                 else:
                     self.stagings_mergeable.append(staging)
-            elif self.is_staging_considerable(project, pseudometa):
+            elif self.is_staging_considerable(staging):
                 self.stagings_considerable.append(staging)
 
         # Allow both considered and remaining to be accessible after proposal.
@@ -358,8 +357,9 @@ class RequestSplitter(object):
             if group not in groups:
                 del self.grouped[group]
 
-    def merge_staging(self, staging, pseudometa):
-        splitter_info = pseudometa['splitter_info']
+    def merge_staging(self, staging):
+        staging = self.stagings[staging]
+        splitter_info = staging['splitter_info']
         self.strategy_from_splitter_info(splitter_info)
 
         if not self.stagings[staging]['bootstrapped']:
@@ -376,8 +376,7 @@ class RequestSplitter(object):
     def merge(self, strategy_none=False):
         stagings = self.stagings_mergeable_none if strategy_none else self.stagings_mergeable
         for staging in sorted(stagings):
-            self.merge_staging(staging, self.stagings[staging]['pseudometa'])
-
+            self.merge_staging(staging)
 
 class Strategy(object):
     def __init__(self, **kwargs):

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -620,26 +620,6 @@ class StagingAPI(object):
         meta = show_project_meta(self.apiurl, project, rev=revision)
         return ET.fromstringlist(meta)
 
-    def load_prj_pseudometa(self, description_text):
-        try:
-            data = yaml.safe_load(description_text)
-            if isinstance(data, str) or data is None:
-                data = {}
-        except (TypeError, AttributeError):
-            data = {}
-        # make sure we have a requests field
-        data['requests'] = data.get('requests', [])
-        return data
-
-    def set_splitter_info_in_prj_pseudometa(self, project, group, strategy_info):
-        data = self.get_prj_pseudometa(project)
-        data['splitter_info'] = {
-            'group': group,
-            'strategy': strategy_info,
-            'activated': str(datetime.utcnow()),
-        }
-        self.set_prj_pseudometa(project, data)
-
     def get_request_id_for_package(self, project, package):
         """
         Query the request id from meta


### PR DESCRIPTION
This leads to staging-bot preferring none strategy for all and this is a problem,
so this is WIP