### PR TITLE
findfileconflicts: Ignore kernel installed certificates in /etc/uefi/…

### DIFF
--- a/findfileconflicts
+++ b/findfileconflicts
@@ -355,7 +355,7 @@ for my $tc (sort keys %tocheck) {
 	}
 	# got one!
 	$f =~ /^(\d+)\/(.*)/;
-	push @con, "$dirs[$1]$2$info";
+	push @con, "$dirs[$1]$2$info" unless "$dirs[$1]$2" =~ m{/etc/uefi/certs/.*crt};
       }
       next unless @con;
       my @sp1 = split(' ', $p1);


### PR DESCRIPTION
…certs

The file names are generated out of the sha1sum of the file content. Thus we
know if the file has the same name, it has the same content as well. Multiple
packages are allowed to own the same file with the same content. This is already
proven functional by the kernel being flavor:multiversion - the kernel can
be installed in multiple versions already (which the checked never would have
caught file conflicts for: we only check against current packages in the distro)

Fixes issue #2350