### PR TITLE
Staging accept: build-disable the images repository

### DIFF
--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -110,6 +110,7 @@ class AcceptCommand(object):
         for project in staging_packages.keys():
             u = self.api.makeurl(['staging', self.api.project, 'staging_projects', project, 'accept'], opts)
             http_POST(u)
+            self.api.switch_flag_in_prj(project, flag='build', state='disable', repository='images')
 
         for req in other_new:
             print(f"Accepting request {req['id']}: {req['package']}")


### PR DESCRIPTION
With the current pipelines, we enable build of the images repository
once everything in /standard is build-succeeded and repo-checker passed.

Let's go the last mile and disable images when we check in the staging.

This should save some OBS build power (not building ISO images before the
stagings are actually ready) and also some openQA (not testing ISO images
before stagings settle)

I can foresee that sometimes an RM would still want to have preliminary
testing done - in which case the images repo can be manually build enabled
(or the pipeline be triggered to go beyond repo-checker, as it likely also
needs a recalculation of the content)