### PR TITLE
Notify the obs_rsync plugin already when the scheduler is finished

### DIFF
--- a/gocd/rabbit-openqa.py
+++ b/gocd/rabbit-openqa.py
@@ -209,6 +209,8 @@ class Listener(PubSubConsumer):
     def on_published_repo(self, payload):
         for p in self.projects:
             p.check_published_repo(str(payload['project']), str(payload['repo']), str(payload['buildid']))
+
+    def on_finished_repo(self, payload):
         # notify openQA to sync the projects - the plugin will check itself it
         # the project is to be synced. For now we notify about every 'images' repo
         if payload['repo'] == 'images':
@@ -226,6 +228,8 @@ class Listener(PubSubConsumer):
         self.acknowledge_message(method.delivery_tag)
         if method.routing_key == '{}.obs.repo.published'.format(amqp_prefix):
             self.on_published_repo(json.loads(body))
+        elif method.routing_key == '{}.obs.repo.build_finished'.format(amqp_prefix):
+            self.on_finished_repo(json.loads(body))
         elif re.search(r'.openqa.', method.routing_key):
             self.on_openqa_job(json.loads(body).get('ISO'))
         else:


### PR DESCRIPTION
openqa will keep polling the repository for ready to sync, waiting
for published event is a problem for ToTest repositories that aren't
published. openqa will start syncing when it becomes 'unpublished'

CC @andrii-suse