### PR TITLE
Staging accept: No longer set the version in .product files on accept

### DIFF
--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -237,29 +237,13 @@ class AcceptCommand(object):
 
         project = self.api.project
         curr_version = date.today().strftime('%Y%m%d')
-        update_version_attr = False
-        url = self.api.makeurl(['source', project], {'view': 'productlist'})
 
-        products = ET.parse(http_GET(url)).getroot()
-        for product in products.findall('product'):
-            product_name = product.get('name') + '.product'
-            product_pkg = product.get('originpackage')
-            product_spec = source_file_load(self.api.apiurl, project, product_pkg, product_name)
-            new_product = re.sub(r'<version>\d{8}</version>', '<version>%s</version>' % curr_version, product_spec)
-
-            if product_spec != new_product:
-                update_version_attr = True
-                url = self.api.makeurl(['source', project, product_pkg, product_name])
-                http_PUT(url + '?comment=Update+version', data=new_product)
-
-        if update_version_attr:
-            self.update_version_attribute(project, curr_version)
+        self.update_version_attribute(project, curr_version)
 
         ports_prjs = ['PowerPC', 'ARM', 'zSystems' ]
-
         for ports in ports_prjs:
             project = self.api.project + ':' + ports
-            if self.api.item_exists(project) and update_version_attr:
+            if self.api.item_exists(project):
                 self.update_version_attribute(project, curr_version)
 
     def sync_buildfailures(self):

--- a/tests/accept_tests.py
+++ b/tests/accept_tests.py
@@ -24,6 +24,7 @@ class TestAccept(unittest.TestCase):
         self.winerq = wf.create_submit_request('devel:wine', 'wine', text='Hallo World')
         self.assertEqual(True, SelectCommand(wf.api, self.prj).perform(['wine']))
         self.comments = self.c_api.get_comments(project_name=self.prj)
+        wf.create_attribute_type('OSRT', 'ProductVersion', 1)
         return wf
 
     def test_accept_comments(self):


### PR DESCRIPTION
In the past, we had a dashboard reading the version of the current source from the .product file.
Not immediately updating this version after a checkin would have been confusing as the dashboard would
have shown incorrect/outdated information.

the new dashboard (https://factory-dashboard.opensuse.org) reads the source version directly from the
attribute, so this mis-match is eliminated.

The .product files will be updated by pkglistgen in due time.