### PR TITLE
Release FTP repos before ISOs

### DIFF
--- a/ttm/releaser.py
+++ b/ttm/releaser.py
@@ -191,12 +191,12 @@ class ToTestReleaser(ToTestManager):
                                   target_repository=self.project.totest_container_repo)
 
         if len(self.project.main_products):
+            for product in self.project.ftp_products:
+                self.release_package(self.project.name, product, repository=self.project.product_repo)
+
             for cd in self.project.main_products:
                 self.release_package(self.project.name, cd, set_release=set_release,
                                       repository=self.project.product_repo)
-
-            for product in self.project.ftp_products:
-                self.release_package(self.project.name, product, repository=self.project.product_repo)
 
         for cd in self.project.livecd_products:
             self.release_package('%s:Live' %


### PR DESCRIPTION
It takes a long time to sync the repos but ISOs are very quick. This lead
to the problem that openQA already started syncing the build while the
repo was synced up. As the repository is set to unpublished in between
the calls, openQA has no chance to see that more is to come.

So if we release the slow products first, openqa has a better chance to
catch up.