### PR TITLE
Make images release to TEST generic

### DIFF
--- a/gocd/sp2.target.gocd.yaml
+++ b/gocd/sp2.target.gocd.yaml
@@ -81,22 +81,8 @@ pipelines:
         - staging-bot
         tasks:
         - script: |-
-            for product in kiwi-templates-JeOS \
-                SLES15-SP2-BYOS SLES15-SP2-HPC-BYOS \
-                SLES15-SP2-SAP SLES15-SP2-SAP-BYOS \
-                SLED-15-SP2-Vagrant SLES-15-SP2-Vagrant \
-                SLES15-SP2-CHOST-BYOS SLES15-SP2-on-demand \
-                SLES15-SP2-Azure SLES15-SP2-Azure-BYOS \
-                SLES15-SP2-Azure-Priority SLES15-SP2-Azure-Standard \
-                SLES15-SP2-Azure-HPC \
-                SLES15-SP2-EC2-ECS-HVM SLES15-SP2-EC2-HVM \
-                SLES15-SP2-EC2-HVM-BYOS SLES15-SP2-GCE SLES15-SP2-GCE-BYOS \
-                SLES15-SP2-SAP-Azure SLES15-SP2-SAP-Azure-BYOS \
-                SLES15-SP2-SAP-Azure-LI-BYOS \
-                SLES15-SP2-SAP-Azure-VLI-BYOS \
-                SLES15-SP2-SAP-EC2-HVM SLES15-SP2-SAP-EC2-HVM-BYOS \
-                SLES15-SP2-OCI-BYOS SLES15-SP2-SAP-OCI-BYOS \
-                SLES15-SP2-SAP-GCE SLES15-SP2-SAP-GCE-BYOS 000product; do
+            PRODUCTS=$(osc -A https://api.suse.de ls SUSE:SLE-15-SP2:GA | grep "^SLE" | grep -v release)
+            for product in kiwi-templates-JeOS 000product $PRODUCTS; do
               osc -A https://api.suse.de release SUSE:SLE-15-SP2:GA $product
             done
 


### PR DESCRIPTION
As image names have a pattern in 15-SP2 (SLE*), change the script that
release to TEST to use this image name pattern instead of list all
images.This will avoid frequently updates in script cause by new image
package submissions.