### PR TITLE
Replace declined requests

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -464,7 +464,7 @@ class StagingAPI(object):
             if stage_info and stage_info['rq_id'] != request_id:
                 request_old = get_request(self.apiurl, str(stage_info['rq_id'])).to_xml()
                 request_new = request
-                replace_old = request_old.find('state').get('name') in ['revoked', 'superseded']
+                replace_old = request_old.find('state').get('name') in ['revoked', 'superseded', 'declined']
 
                 if (request_new.find('action').get('type') == 'delete' and
                     request_old.find('action').get('type') == 'delete'):


### PR DESCRIPTION
A common workflow is:
* pkg is being marked for deletion by repo-checker [botdel]
* User comes to the rescue and fixes the package, Submits the fix
* Commonly, the delreq is being declined (by factory-maintainer)
* factory-auto declines SR, as pkg now has a delreq and subreq pending
* factory-auto does not consider the 'declined' request as replacable
  and complains that it should be revoked (or superseded). Since the
  del req was created by repo-checker, 'nobody' has the credentials to
  revoke the request. The user, not having a role in the old SR, has
  no permission to supersede

So let's just accept a delete request in statet 'declined' as something
  that can be replaced by a submit request for the same package.