### PR TITLE
Allow overriding the prefix for setrelease

### DIFF
--- a/ttm/releaser.py
+++ b/ttm/releaser.py
@@ -214,7 +214,7 @@ class ToTestReleaser(ToTestManager):
         if not self.project.set_snapshot_number:
             snapshot = None
         if snapshot:
-            release = 'Snapshot%s' % snapshot
+            release = self.project.snapshot_number_prefix + snapshot
             self.logger.info('Updating snapshot %s' % snapshot)
         else:
             release = None

--- a/ttm/totest.py
+++ b/ttm/totest.py
@@ -27,6 +27,7 @@ class ToTest(object):
         self.do_not_release = False
         self.need_same_build_number = False
         self.set_snapshot_number = False
+        self.snapshot_number_prefix = "Snapshot"
         self.take_source_from_product = False
         self.arch = 'x86_64'
         self.openqa_server = None


### PR DESCRIPTION
Currently if set_snapshot_number is true, it uses "Snapshot" as prefix.
In some cases it's necessary to use a different one. This can now be configured
using the "snapshot_number_prefix" option.

Currently needed for 15.2 Images, which do not have a special publish script anymore, so plain `Repotype: staticlinks` has to work, which requires the `BuildX.Y` pattern.