### PR TITLE
Split the work done in rabbit-openqa into smaller chunks

### DIFF
--- a/gocd/rabbit-repoid.py
+++ b/gocd/rabbit-repoid.py
@@ -80,10 +80,11 @@ class Listener(PubSubConsumer):
 
     def check_some_repos(self):
         count = 0
-        limit = 25
+        limit = 15
         while len(self.repositories_to_check):
             project, repository = self.repositories_to_check.pop()
             self.logger.debug(f"Check repo {project}/{repository}")
+            self.update_repo(project, repository)
             count += 1
             if count >= limit:
                 return

--- a/tests/fixtures/staging-meta-for-bootstrap-copy.xml
+++ b/tests/fixtures/staging-meta-for-bootstrap-copy.xml
@@ -18,12 +18,12 @@
        <arch>i586</arch>
        <arch>x86_64</arch>
   </repository>
-  <repository linkedbuild="all" name="standard" rebuild="direct">
+  <repository name="standard" linkedbuild="all" rebuild="direct">
     <path project="openSUSE:Factory:Staging:A" repository="bootstrap_copy"/>
     <arch>i586</arch>
     <arch>x86_64</arch>
   </repository>
-  <repository linkedbuild="all" name="images">
+  <repository name="images" linkedbuild="all">
     <path project="openSUSE:Factory:Staging:A" repository="standard"/>
     <arch>x86_64</arch>
   </repository>


### PR DESCRIPTION
As the rabbitmq heartbeart interval is a hard limit, we need to make sure
we're not overloading the time in between