### PR TITLE
dist: drop bogus python-enum34 dependency

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -58,10 +58,6 @@ Requires:       python3-pycurl
 Requires:       python3-python-dateutil
 Requires:       python3-pyxdg
 Requires:       python3-requests
-# ttm/manager.py
-%if %{without python3}
-Requires:       python-enum34
-%endif
 
 # bs_mirrorfull
 Requires:       perl-Net-SSLeay


### PR DESCRIPTION
The entire codebase has moved to python3; pulling in this one python2 package makese no sense.
The guard with %if %{without python3} does not work as intended, as there is no %bcond_without statement
in the .spec file, thus assuming 'without' unless overriden by any other rules.