### PR TITLE
Fix crash in project-installcheck if there are no packages in the pra

### DIFF
--- a/project-installcheck.py
+++ b/project-installcheck.py
@@ -151,7 +151,8 @@ class RepoChecker():
             target_packages = []
             with open(os.path.join(dir, 'catalog.yml')) as file:
                 catalog = yaml.safe_load(file)
-                target_packages = catalog.get(directories[0], [])
+                if catalog is not None:
+                    target_packages = catalog.get(directories[0], [])
 
             parsed = parsed_installcheck([pfile] + primaryxmls, arch, target_packages, [])
             for package in parsed:


### PR DESCRIPTION
Fix crash of the run added by https://github.com/openSUSE/openSUSE-release-tools/pull/2438