### PR TITLE
skip SUSE:Channel files harder

### DIFF
--- a/legal-auto.py
+++ b/legal-auto.py
@@ -230,7 +230,7 @@ class LegalAuto(ReviewBot.ReviewBot):
             for l in si.findall('linked'):
                 if l.get('project') == 'SUSE:Channels':
                     self.logger.info("SKIP {}, it links to {}".format(package, l.get('project')))
-                    skip  = True
+                    skip = True
                     break
                 lpackage = l.get('package')
                 # strip sle11's .imported_ suffix

--- a/legal-auto.py
+++ b/legal-auto.py
@@ -216,6 +216,7 @@ class LegalAuto(ReviewBot.ReviewBot):
                 continue
             # skip packages that have _channel inside
             if si.find('filename').text == '_channel':
+                self.logger.info("SKIP {}".format(si.find('filename').text))
                 continue
             # handle maintenance links - we only want the latest
             match = re.match(r'(\S+)\.\d+$', package)
@@ -227,6 +228,10 @@ class LegalAuto(ReviewBot.ReviewBot):
                 continue
             skip = False
             for l in si.findall('linked'):
+                if l.get('project') == 'SUSE:Channels':
+                    self.logger.info("SKIP {}, it links to {}".format(package, l.get('project')))
+                    skip  = True
+                    break
                 lpackage = l.get('package')
                 # strip sle11's .imported_ suffix
                 lpackage = re.sub(r'\.imported_\d+$', '', lpackage)


### PR DESCRIPTION
isc api /source/home:osalvador:branches:Devel:Kernel:SLE12-SP2-LTSS:Submit/?view=info

shows

  <sourceinfo package="SLE-SERVER_12-SP2-LTSS_x86_64" rev="3" vrev="113" srcmd5="8b9a4eef8f161a41c96b89c7163091a9" lsrcmd5="55f550c22886d610c2e386c727f30817" verifymd5="66e022e70e6e94f85f494918960fc0cb">
      <error>bad build configuration, no build type defined or detected</error>
      <linked project="SUSE:Channels" package="SLE-SERVER_12-SP2-LTSS_x86_64"/>
 </sourceinfo>