### PR TITLE
Fix osc.core.repository_path_expand

### DIFF
--- a/tests/origin_tests.py
+++ b/tests/origin_tests.py
@@ -113,7 +113,7 @@ class TestOrigin(OBSLocal.TestCase):
         request = self.wf.create_submit_request(self.randomString('devel'), self.randomString('package'))
         self.assertReviewBot(request.reqid, self.bot_user, 'new', 'new')
         self.assertOutput(f'skipping {request.reqid} of age')
-        self.assertOutput(f'since it is younger than 1800s')
+        self.assertOutput('since it is younger than 1800s')
 
     def test_config(self):
         attribute_value_save(self.wf.apiurl, self.target_project, 'OriginConfig', 'origins: []')


### PR DESCRIPTION
The algorithm was wrong, it didn't add non-recursively entered paths to the
list. The correct algorithm even allows for a simpler implementation.

This causes false negatives (or even positives) during installcheck, especially impacting the rebuild triggers against `openSUSE:Tumbleweed/standard`, which was omitted due to the bug and so glibc was missing.