### PR TITLE
factory-auto: add opensuse-review-team on submits to NonFree

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -61,6 +61,7 @@ DEFAULT = {
         'staging': 'openSUSE:%(project)s:Staging',
         'staging-group': 'factory-staging',
         'onlyadi': 'True',
+        'review-team': 'opensuse-review-team',
     },
     r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+))$': {
         'staging': 'openSUSE:%(project)s:Staging',


### PR DESCRIPTION
Packages submitted to openSUSE:*:NonFree did not end up on the queue
of the opensuse-review-team