### PR TITLE
metrics/grafana/openqa: Add openSUSE Leap 15.1 and 15.2

### DIFF
--- a/metrics/grafana/access.json
+++ b/metrics/grafana/access.json
@@ -31,6 +31,22 @@
       "type": "datasource",
       "pluginId": "influxdb",
       "pluginName": "InfluxDB"
+    },
+    {
+      "name": "openSUSE:Leap:15.1",
+      "label": "openSUSE:Leap:15.1",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    },
+    {
+      "name": "openSUSE:Leap:15.2",
+      "label": "openSUSE:Leap:15.2",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
     }
   ],
   "__requires": [
@@ -109,6 +125,30 @@
         "iconColor": "rgba(255, 96, 96, 1)",
         "limit": 100,
         "name": "15.0 Schedule",
+        "query": "select description from release_schedule where $timeFilter",
+        "showIn": 0,
+        "tags": [],
+        "type": "tags"
+      },
+      {
+        "datasource": "openSUSE:Leap:15.1",
+        "enable": false,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "15.1 Schedule",
+        "query": "select description from release_schedule where $timeFilter",
+        "showIn": 0,
+        "tags": [],
+        "type": "tags"
+      },
+      {
+        "datasource": "openSUSE:Leap:15.2",
+        "enable": false,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "15.2 Schedule",
         "query": "select description from release_schedule where $timeFilter",
         "showIn": 0,
         "tags": [],

--- a/metrics/grafana/provisioning/datasources.yaml
+++ b/metrics/grafana/provisioning/datasources.yaml
@@ -7,6 +7,18 @@ datasources:
   access: proxy
   database: openSUSE:Factory
 
+- name: openSUSE:Leap:15.2
+  type: influxdb
+  url: http://localhost:8086
+  access: proxy
+  database: openSUSE:Leap:15.2
+
+- name: openSUSE:Leap:15.1
+  type: influxdb
+  url: http://localhost:8086
+  access: proxy
+  database: openSUSE:Leap:15.1
+
 - name: openSUSE:Leap:15.0
   type: influxdb
   url: http://localhost:8086


### PR DESCRIPTION
Not sure if there are further changes necessary, e.g. internal changes
to influxdb or whatever data source should provide the data.