### PR TITLE
TTM: Ignore arch check for multibuild containers

### DIFF
--- a/ttm/releaser.py
+++ b/ttm/releaser.py
@@ -172,6 +172,9 @@ class ToTestReleaser(ToTestManager):
                     multibuildcontainer = packagename.split(':')[0]
                     if multibuildcontainer in product_archs:
                         released_archs = product_archs[multibuildcontainer]
+                        # Ignore the arch check for multibuild containers,
+                        # as it might not build for the same archs as all flavors.
+                        continue
 
                 if released_archs is None:
                     self.logger.error("%s is built for %s, but not mentioned as product" % (


### PR DESCRIPTION
`openSUSE:Factory:ARM`'s ttm config has

```
JeOS:
- armv7hl
```

and doesn't mention any of the multibuild flavors to avoid the build success check.
Adding the missing arches to the multibuild container would cause the build check to fail as plain `JeOS` only builds for `armv7hl`.