### PR TITLE
pkglistgen: add Leap 15.2 MicroOS back to pipeline

### DIFF
--- a/gocd/pkglistgen.opensuse.gocd.yaml
+++ b/gocd/pkglistgen.opensuse.gocd.yaml
@@ -83,6 +83,27 @@ pipelines:
             tasks:
              - script: python3 ./pkglistgen.py --apiurl https://api.opensuse.org handle_update_repos openSUSE:Factory:RISCV
   Pkglistgen.openSUSE_Leap:
+    group: Leap.15.2.pkglistgen
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    timer:
+      spec: 0 10 * ? * *
+      only_on_changes: false
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    stages:
+    - pkglistgen:
+        approval:
+          type: manual
+        jobs:
+          openSUSE_Leap_15.2_MicroOS:
+            resources:
+            - repo-checker
+            tasks:
+              - script: python3 ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Leap:15.2:MicroOS -s target
+  Pkglistgen.openSUSE_Jump:
     group: Leap.jump.pkglistgen
     lock_behavior: unlockWhenFinished
     environment_variables:
@@ -103,7 +124,7 @@ pipelines:
             - repo-checker
             tasks:
             - script: python3 ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Jump:15.2 -s target
-  Update.Repos.Leap:
+  Update.Repos.Jump:
     group: Leap.jump.pkglistgen
     lock_behavior: unlockWhenFinished
     environment_variables:

--- a/gocd/pkglistgen.opensuse.gocd.yaml.erb
+++ b/gocd/pkglistgen.opensuse.gocd.yaml.erb
@@ -54,6 +54,35 @@ pipelines:
              - script: python3 ./pkglistgen.py --apiurl https://api.opensuse.org handle_update_repos <%= project %>
 <% end -%>
   Pkglistgen.openSUSE_Leap:
+    group: Leap.15.2.pkglistgen
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    timer:
+      spec: 0 10 * ? * *
+      only_on_changes: false
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    stages:
+    - pkglistgen:
+        approval:
+          type: manual
+        jobs:
+  <% ['openSUSE:Leap:15.2:MicroOS'].each do |project|
+    project=project.split('/')
+    name=project[0].gsub(':', '_')
+    if project.size > 1
+      options=" -s #{project[1]}"
+      name = name + "_#{project[1]}"
+    end -%>
+        <%= name %>:
+            resources:
+            - repo-checker
+            tasks:
+            - script: python3 ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p <%= project[0] %><%= options %>
+  <% end -%>
+  Pkglistgen.openSUSE_Jump:
     group: Leap.jump.pkglistgen
     lock_behavior: unlockWhenFinished
     environment_variables:
@@ -82,7 +111,7 @@ pipelines:
             tasks:
             - script: python3 ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p <%= project[0] %><%= options %>
   <% end -%>
-Update.Repos.Leap:
+Update.Repos.Jump:
     group: Leap.jump.pkglistgen
     lock_behavior: unlockWhenFinished
     environment_variables:


### PR DESCRIPTION
Leap 15.2 MicroOS is still ongoing, add pkglsitgen service for Leap 15.2 MicroOS back, this change also renamed old Leap pipeline to Jump.