### PR TITLE
Migrate metrics scripts to Python 3

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -391,7 +391,7 @@ def dashboard_at(api, filename, datetime=None, revision=None):
     elif filename in ('config'):
         if content:
             # TODO re-use from osclib.conf.
-            from ConfigParser import ConfigParser
+            from configparser import ConfigParser
             import io
 
             cp = ConfigParser()

--- a/metrics.py
+++ b/metrics.py
@@ -548,9 +548,9 @@ def main(args):
     if args.wipe_cache:
         Cache.delete_all()
     if args.heavy_cache:
-        Cache.PATTERNS[r'/search/request'] = sys.maxint
-        Cache.PATTERNS[r'/source/[^/]+/{}/_history'.format(package)] = sys.maxint
-    Cache.PATTERNS[r'/source/[^/]+/{}/[^/]+\?rev=.*'.format(package)] = sys.maxint
+        Cache.PATTERNS[r'/search/request'] = sys.maxsize
+        Cache.PATTERNS[r'/source/[^/]+/{}/_history'.format(package)] = sys.maxsize
+    Cache.PATTERNS[r'/source/[^/]+/{}/[^/]+\?rev=.*'.format(package)] = sys.maxsize
     Cache.init('metrics')
 
     Config(apiurl, args.project)

--- a/metrics.py
+++ b/metrics.py
@@ -396,7 +396,7 @@ def dashboard_at(api, filename, datetime=None, revision=None):
 
             cp = ConfigParser()
             config = '[remote]\n' + content
-            cp.readfp(io.BytesIO(config))
+            cp.read_string(config)
             return dict(cp.items('remote'))
         return {}
 


### PR DESCRIPTION
sys.maxint has been removed in Python 3.1.

https://docs.python.org/3.1/whatsnew/3.0.html#integers