### PR TITLE
check_source.pl: One .changes file per package is enough

### DIFF
--- a/check_source.pl
+++ b/check_source.pl
@@ -75,17 +75,17 @@ my $changes_updated = 0;
 for my $spec (@specs) {
     $changes = $spec;
     $changes =~ s/\.spec$/.changes/;
-    if (!-f "$dir/$changes") {
-        print "$changes is missing. A package containing FooBar.spec needs to have a FooBar.changes file with a format created by `osc vc`.\n";
-        $ret = 1;
+
+    # new or deleted .changes files also count
+    if ((-f "$old/$changes") != (-f "$dir/$changes")) {
+        $changes_updated = 1;
+        last;
     }
-    if (-f "$old/$changes") {
+    elsif ((-f "$old/$changes") && (-f "$dir/$changes")) {
         if (system(("cmp", "-s", "$old/$changes", "$dir/$changes"))) {
             $changes_updated = 1;
+            last;
         }
-    }
-    else { # a new file is an update too
-        $changes_updated = 1;
     }
 }
 


### PR DESCRIPTION
It's actually fine to have a single .changes file for multiple .spec files
in the same package, OBS picks that automatically. Relax the check to only
require a single .changes file for the package name.

Many multi-spec packages currently just duplicate the changes files anyway,
which can be avoided.