### PR TITLE
Also add required checks to adi stagings after adding architectures

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1078,6 +1078,9 @@ class StagingAPI(object):
         meta = ET.tostring(meta)
         http_PUT(self.project_meta_url(project), data=meta)
 
+        for required_check in self.cstaging_required_checks_adi.split():
+            self.add_required_check(project, required_check)
+
     def prj_from_letter(self, letter):
         if ':' in letter:  # not a letter
             return letter


### PR DESCRIPTION
Otherwise the newly added archs don't have any required checks assigned.

Seems to work: https://build.opensuse.org/staging_workflows/openSUSE:Factory/staging_projects/openSUSE:Factory:Staging:adi:29