### PR TITLE
Calculate the i586 DVD as i686 package set

### DIFF
--- a/pkglistgen/tool.py
+++ b/pkglistgen/tool.py
@@ -189,7 +189,11 @@ class PkgListGen(ToolBase.ToolBase):
 
     def prepare_pool(self, arch, ignore_conflicts):
         pool = solv.Pool()
-        pool.setarch(arch)
+        # the i586 DVD is really a i686 one
+        if arch == 'i586':
+            pool.setarch('i686')
+        else:
+            pool.setarch(arch)
 
         self.lockjobs[arch] = []
         solvables = set()


### PR DESCRIPTION
mozjs is now i686 exclusive and GNOME and KDE depends on it