### PR TITLE
Switch to python3 shebang

### DIFF
--- a/abichecker/abichecker-web.py
+++ b/abichecker/abichecker-web.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os
 import sys

--- a/abichecker/abichecker_common.py
+++ b/abichecker/abichecker_common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from xdg.BaseDirectory import save_cache_path, save_data_path
 

--- a/abichecker/abichecker_dbmodel.py
+++ b/abichecker/abichecker_dbmodel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os
 import sys

--- a/biarchtool.py
+++ b/biarchtool.py
@@ -1,14 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from xml.etree import cElementTree as ET
 import sys
 import cmdln
 import logging
-try:
-    from urllib.error import HTTPError
-except ImportError:
-    # python 2.x
-    from urllib2 import HTTPError
+from urllib.error import HTTPError
 import osc.core
 
 import ToolBase

--- a/deptool.py
+++ b/deptool.py
@@ -1,6 +1,4 @@
-#!/usr/bin/python
-
-from __future__ import print_function
+#!/usr/bin/python3
 
 from pprint import pprint
 import os

--- a/dist/ci/osc-credentials
+++ b/dist/ci/osc-credentials
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 try:
     from osc import conf

--- a/obs_clone.py
+++ b/obs_clone.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from copy import deepcopy
 from lxml import etree as ET
@@ -10,12 +10,7 @@ from osc.core import http_PUT
 from osc.core import makeurl
 from osc.core import show_upstream_rev
 from osclib.core import project_pseudometa_package
-
-try:
-    from urllib.error import HTTPError
-except ImportError:
-    # python 2.x
-    from urllib2 import HTTPError
+from urllib.error import HTTPError
 
 import argparse
 import osc.conf

--- a/status.py
+++ b/status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import argparse
 from datetime import datetime

--- a/sync-rebuild.py
+++ b/sync-rebuild.py
@@ -1,6 +1,4 @@
-#!/usr/bin/python
-
-from __future__ import print_function
+#!/usr/bin/python3
 
 import sys
 import os

--- a/unmaintained.py
+++ b/unmaintained.py
@@ -1,6 +1,4 @@
-#!/usr/bin/python
-
-from __future__ import print_function
+#!/usr/bin/python3
 
 import argparse
 from lxml import etree as ET

--- a/update_crawler.py
+++ b/update_crawler.py
@@ -1,17 +1,11 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import argparse
 import itertools
 import logging
 import sys
-
-try:
-    from urllib.error import HTTPError
-except ImportError:
-    # python 2.x
-    from urllib2 import HTTPError
-
 import time
+from urllib.error import HTTPError
 from xml.etree import cElementTree as ET
 
 import osc.conf


### PR DESCRIPTION
With the python shebang remaining as Python 2, switch the scripts to
using Python 3. This also allows us to clean up some imports.