### PR TITLE
Fix repo state error handling in pkglistgen

### DIFF
--- a/pkglistgen/tool.py
+++ b/pkglistgen/tool.py
@@ -330,10 +330,11 @@ class PkgListGen(ToolBase.ToolBase):
                 if not os.path.exists(d):
                     os.makedirs(d)
 
-                try:
-                    # Fetch state before mirroring in-case it changes during download.
-                    state = repository_arch_state(self.apiurl, project, repo, arch)
-                except HTTPError:
+                # Fetch state before mirroring in-case it changes during download.
+                state = repository_arch_state(self.apiurl, project, repo, arch)
+
+                if state is None:
+                    # Repo might not have this architecture
                     continue
 
                 # Would be preferable to include hash in name, but cumbersome to handle without


### PR DESCRIPTION
repository_arch_state doesn't raise HTTPError for 404 any more, but that's what
pkglistgen uses to skip that repo/arch. Handle None as replacement instead.