### PR TITLE
adi: stage Non-Ring delete requests in adi projects

### DIFF
--- a/osclib/adi_command.py
+++ b/osclib/adi_command.py
@@ -84,7 +84,7 @@ class AdiCommand:
                 requests.append(rf.load_request(p))
 
         splitter = RequestSplitter(self.api, requests, in_ring=False)
-        splitter.filter_add('./action[@type="submit"]')
+        splitter.filter_add('./action[@type="submit" or @type="delete"]')
         if len(wanted_requests):
             splitter.filter_add_requests([str(p) for p in wanted_requests])
             # wanted_requests forces all requests into a single group.

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -131,9 +131,6 @@ class RequestSplitter(object):
         ring = self.ring_get(target_package)
         if ring:
             target.set('ring', ring)
-        elif not self.api.conlyadi and request_type == 'delete':
-            # Delete requests should always be considered in a ring.
-            target.set('ring', 'delete')
 
         request_id = int(request.get('id'))
         if request_id in self.requests_ignored:


### PR DESCRIPTION
This is now acceptable as the installcheck bot verifies that we
cannot remove binaries we still care for.

Fixes https://github.com/openSUSE/openSUSE-release-tools/issues/2440