### PR TITLE
pkglistgen: ignore bootstrap_copy repo

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -42,6 +42,7 @@ DEFAULT = {
         'repo_checker-package-comment-devel': 'True',
         'pkglistgen-product-family-include': 'openSUSE:Leap:N',
         'pkglistgen-locales-from': 'openSUSE.product.in',
+        'pkglistgen-ignore_repos': 'bootstrap_copy',
         'mail-list': 'opensuse-factory@opensuse.org',
         'mail-maintainer': 'Dominique Leuenberger <dimstar@suse.de>',
         'mail-noreply': 'noreply@opensuse.org',
@@ -96,6 +97,7 @@ DEFAULT = {
         'pkglistgen-archs': 'x86_64',
         'pkglistgen-scopes': 'target rings staging',
         'pkglistgen-locales-from': 'openSUSE.product',
+        'pkglistgen-ignore_repos': 'bootstrap_copy',
         'pkglistgen-delete-kiwis-rings': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
         'pkglistgen-delete-kiwis-staging': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
         'mail-list': 'opensuse-factory@opensuse.org',
@@ -158,6 +160,7 @@ DEFAULT = {
         'pkglistgen-archs': 'x86_64 aarch64 ppc64le s390x',
         'pkglistgen-scopes': 'target',
         'pkglistgen-locales-from': 'openSUSE.product',
+        'pkglistgen-ignore_repos': 'bootstrap_copy',
     },
     # Allows devel projects to utilize tools that require config, but not
     # complete StagingAPI support.

--- a/pkglistgen/tool.py
+++ b/pkglistgen/tool.py
@@ -578,7 +578,8 @@ class PkgListGen(ToolBase.ToolBase):
                                 project, scope, force, no_checkout,
                                 only_release_packages, stop_after_solve):
         self.all_architectures = target_config.get('pkglistgen-archs').split(' ')
-        self.repos = self.expand_repos(project, main_repo)
+        ignore_repos = set(target_config.get('pkglistgen-ignore_repos').split(' '))
+        self.repos = [ r for r in self.expand_repos(project, main_repo) if r[0] != project or r[1] not in ignore_repos ]
         print('[{}] {}/{}: update and solve'.format(scope, project, main_repo))
 
         group = target_config.get('pkglistgen-group', '000package-groups')


### PR DESCRIPTION
Never use the bootstrap_copy repo for package solving. Staging content
might be very different so don't confuse the solver.