### PR TITLE
Revert pkglistgen: ignore bootstrap_copy repo

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -42,7 +42,6 @@ DEFAULT = {
         'repo_checker-package-comment-devel': 'True',
         'pkglistgen-product-family-include': 'openSUSE:Leap:N',
         'pkglistgen-locales-from': 'openSUSE.product.in',
-        'pkglistgen-ignore_repos': 'bootstrap_copy',
         'mail-list': 'opensuse-factory@opensuse.org',
         'mail-maintainer': 'Dominique Leuenberger <dimstar@suse.de>',
         'mail-noreply': 'noreply@opensuse.org',
@@ -97,7 +96,6 @@ DEFAULT = {
         'pkglistgen-archs': 'x86_64',
         'pkglistgen-scopes': 'target rings staging',
         'pkglistgen-locales-from': 'openSUSE.product',
-        'pkglistgen-ignore_repos': 'bootstrap_copy',
         'pkglistgen-delete-kiwis-rings': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
         'pkglistgen-delete-kiwis-staging': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
         'mail-list': 'opensuse-factory@opensuse.org',
@@ -160,7 +158,6 @@ DEFAULT = {
         'pkglistgen-archs': 'x86_64 aarch64 ppc64le s390x',
         'pkglistgen-scopes': 'target',
         'pkglistgen-locales-from': 'openSUSE.product',
-        'pkglistgen-ignore_repos': 'bootstrap_copy',
     },
     # Allows devel projects to utilize tools that require config, but not
     # complete StagingAPI support.

--- a/pkglistgen/tool.py
+++ b/pkglistgen/tool.py
@@ -596,8 +596,7 @@ class PkgListGen(ToolBase.ToolBase):
                                 project, scope, force, no_checkout,
                                 only_release_packages, stop_after_solve):
         self.all_architectures = target_config.get('pkglistgen-archs').split(' ')
-        ignore_repos = set(target_config.get('pkglistgen-ignore_repos', '').split(' '))
-        self.repos = [ r for r in self.expand_repos(project, main_repo) if r[0] != project or r[1] not in ignore_repos ]
+        self.repos = self.expand_repos(project, main_repo)
         print('[{}] {}/{}: update and solve'.format(scope, project, main_repo))
 
         group = target_config.get('pkglistgen-group', '000package-groups')


### PR DESCRIPTION
#2539 broke quite a bit, including blocking all Factory Ring 1 stagings, so I think it's best we just revert it now before revisiting whati t was trying to fix