### PR TITLE
gocd: Drop obsolete projects, fix whitespace

### DIFF
--- a/gocd/microos-stagings.gocd.yaml
+++ b/gocd/microos-stagings.gocd.yaml
@@ -94,7 +94,6 @@ pipelines:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
 
-  
   MicroOS.Staging.B:
     environment_variables:
       STAGING_PROJECT: SUSE:SLE-15-SP3:Update:Products:MicroOS51:Staging:B
@@ -157,5 +156,3 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-
-  

--- a/gocd/microos-stagings.gocd.yaml.erb
+++ b/gocd/microos-stagings.gocd.yaml.erb
@@ -89,5 +89,4 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-
-  <% end -%>
+<% end -%>

--- a/gocd/pkglistgen.opensuse.gocd.yaml
+++ b/gocd/pkglistgen.opensuse.gocd.yaml
@@ -82,27 +82,6 @@ pipelines:
             - repo-checker
             tasks:
              - script: python3 ./pkglistgen.py --apiurl https://api.opensuse.org handle_update_repos openSUSE:Factory:RISCV
-  Pkglistgen.openSUSE_Leap_15.2:
-    group: Leap.15.2.pkglistgen
-    lock_behavior: unlockWhenFinished
-    environment_variables:
-      OSC_CONFIG: /home/go/config/oscrc-staging-bot
-    timer:
-      spec: 0 10 * ? * *
-      only_on_changes: false
-    materials:
-      git:
-        git: https://github.com/openSUSE/openSUSE-release-tools.git
-    stages:
-    - pkglistgen:
-        approval:
-          type: manual
-        jobs:
-          openSUSE_Leap_15.2_MicroOS:
-            resources:
-            - repo-checker
-            tasks:
-              - script: python3 ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Leap:15.2:MicroOS
   Pkglistgen.openSUSE_Leap_15.3:
     group: Leap.15.3.pkglistgen
     lock_behavior: unlockWhenFinished

--- a/gocd/pkglistgen.opensuse.gocd.yaml.erb
+++ b/gocd/pkglistgen.opensuse.gocd.yaml.erb
@@ -53,35 +53,6 @@ pipelines:
             tasks:
              - script: python3 ./pkglistgen.py --apiurl https://api.opensuse.org handle_update_repos <%= project %>
 <% end -%>
-  Pkglistgen.openSUSE_Leap_15.2:
-    group: Leap.15.2.pkglistgen
-    lock_behavior: unlockWhenFinished
-    environment_variables:
-      OSC_CONFIG: /home/go/config/oscrc-staging-bot
-    timer:
-      spec: 0 10 * ? * *
-      only_on_changes: false
-    materials:
-      git:
-        git: https://github.com/openSUSE/openSUSE-release-tools.git
-    stages:
-    - pkglistgen:
-        approval:
-          type: manual
-        jobs:
-  <% ['openSUSE:Leap:15.2:MicroOS'].each do |project|
-    project=project.split('/')
-    name=project[0].gsub(':', '_')
-    if project.size > 1
-      options=" -s #{project[1]}"
-      name = name + "_#{project[1]}"
-    end -%>
-        <%= name %>:
-            resources:
-            - repo-checker
-            tasks:
-            - script: python3 ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p <%= project[0] %><%= options %>
-  <% end -%>
   Pkglistgen.openSUSE_Leap_15.3:
     group: Leap.15.3.pkglistgen
     lock_behavior: unlockWhenFinished

--- a/gocd/pkglistgen_staging.gocd.yaml.erb
+++ b/gocd/pkglistgen_staging.gocd.yaml.erb
@@ -80,4 +80,3 @@ pipelines:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
 <% end %>
-

--- a/gocd/sle15sp3-stagings.gocd.yaml
+++ b/gocd/sle15sp3-stagings.gocd.yaml
@@ -157,7 +157,6 @@ pipelines:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
 
-  
   SLE15.SP3.Staging.B:
     environment_variables:
       STAGING_PROJECT: SUSE:SLE-15-SP3:GA:Staging:B
@@ -221,7 +220,6 @@ pipelines:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
 
-  
   SLE15.SP3.Staging.C:
     environment_variables:
       STAGING_PROJECT: SUSE:SLE-15-SP3:GA:Staging:C
@@ -285,7 +283,6 @@ pipelines:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
 
-  
   SLE15.SP3.Staging.D:
     environment_variables:
       STAGING_PROJECT: SUSE:SLE-15-SP3:GA:Staging:D
@@ -349,7 +346,6 @@ pipelines:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
 
-  
   SLE15.SP3.Staging.E:
     environment_variables:
       STAGING_PROJECT: SUSE:SLE-15-SP3:GA:Staging:E
@@ -413,7 +409,6 @@ pipelines:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
 
-  
   SLE15.SP3.Staging.F:
     environment_variables:
       STAGING_PROJECT: SUSE:SLE-15-SP3:GA:Staging:F
@@ -477,7 +472,6 @@ pipelines:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
 
-  
   SLE15.SP3.Staging.G:
     environment_variables:
       STAGING_PROJECT: SUSE:SLE-15-SP3:GA:Staging:G
@@ -541,7 +535,6 @@ pipelines:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
 
-  
   SLE15.SP3.Staging.H:
     environment_variables:
       STAGING_PROJECT: SUSE:SLE-15-SP3:GA:Staging:H
@@ -605,7 +598,6 @@ pipelines:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
 
-  
   SLE15.SP3.Staging.S:
     environment_variables:
       STAGING_PROJECT: SUSE:SLE-15-SP3:GA:Staging:S
@@ -669,7 +661,6 @@ pipelines:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
 
-  
   SLE15.SP3.Staging.V:
     environment_variables:
       STAGING_PROJECT: SUSE:SLE-15-SP3:GA:Staging:V
@@ -733,7 +724,6 @@ pipelines:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
 
-  
   SLE15.SP3.Staging.Y:
     environment_variables:
       STAGING_PROJECT: SUSE:SLE-15-SP3:GA:Staging:Y
@@ -796,5 +786,3 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-
-  

--- a/gocd/sle15sp3-stagings.gocd.yaml.erb
+++ b/gocd/sle15sp3-stagings.gocd.yaml.erb
@@ -89,5 +89,4 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-
-  <% end -%>
+<% end -%>

--- a/gocd/staging.bot.gocd.yaml
+++ b/gocd/staging.bot.gocd.yaml
@@ -52,10 +52,8 @@ pipelines:
                ln -s $PWD/osclib $tempdir/.osc-plugins
                export HOME=$tempdir
 
-               osc -A https://api.opensuse.org staging -p openSUSE:Factory rebuild
                osc -A https://api.opensuse.org staging -p openSUSE:Factory list --supersede
                osc -A https://api.opensuse.org staging -p openSUSE:Factory adi --by-develproject
-               osc -A https://api.opensuse.org staging -p openSUSE:Factory select --non-interactive --merge --try-strategies
                osc -A https://api.opensuse.org staging -p openSUSE:Factory unselect --cleanup
                osc -A https://api.opensuse.org staging -p openSUSE:Factory repair --cleanup
                rm -rf $tempdir
@@ -116,4 +114,3 @@ pipelines:
                osc -A https://api.opensuse.org staging -p openSUSE:Backports:SLE-15-SP3 unselect --cleanup
                osc -A https://api.opensuse.org staging -p openSUSE:Backports:SLE-15-SP3 repair --cleanup
                rm -rf $tempdir
-

--- a/gocd/staging.bot.gocd.yaml.erb
+++ b/gocd/staging.bot.gocd.yaml.erb
@@ -54,12 +54,9 @@ pipelines:
                ln -s $PWD/osclib $tempdir/.osc-plugins
                export HOME=$tempdir
 
-               osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> rebuild
                osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> list --supersede
                osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> adi --by-develproject
-               osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> select --non-interactive --merge --try-strategies
                osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> unselect --cleanup
                osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> repair --cleanup
                rm -rf $tempdir
-
 <% end -%>

--- a/gocd/totestmanager.gocd.yaml
+++ b/gocd/totestmanager.gocd.yaml
@@ -105,48 +105,6 @@ pipelines:
         - script: |-
             install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
             scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Factory:zSystems
-  TTM.Leap_15.1_ARM_Images:
-    group: openSUSE.Checkers
-    lock_behavior: unlockWhenFinished
-    environment_variables:
-      OSC_CONFIG: /home/go/config/oscrc-totest-manager
-    materials:
-      script:
-        git: https://github.com/openSUSE/openSUSE-release-tools.git
-        destination: scripts
-    timer:
-      spec: 0 */15 * ? * *
-      only_on_changes: false
-    stages:
-    - Run:
-        approval: manual
-        resources:
-        - staging-bot
-        tasks:
-        - script: |-
-            install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
-            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.1:ARM:Images
-  TTM.Leap_15.1_Images:
-    group: openSUSE.Checkers
-    lock_behavior: unlockWhenFinished
-    environment_variables:
-      OSC_CONFIG: /home/go/config/oscrc-totest-manager
-    materials:
-      script:
-        git: https://github.com/openSUSE/openSUSE-release-tools.git
-        destination: scripts
-    timer:
-      spec: 0 */15 * ? * *
-      only_on_changes: false
-    stages:
-    - Run:
-        approval: manual
-        resources:
-        - staging-bot
-        tasks:
-        - script: |-
-            install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
-            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.1:Images
   TTM.Leap_15.2_ARM_Images:
     group: openSUSE.Checkers
     lock_behavior: unlockWhenFinished
@@ -189,27 +147,6 @@ pipelines:
         - script: |-
             install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
             scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.2:Images
-  TTM.Leap_15.2_MicroOS:
-    group: openSUSE.Checkers
-    lock_behavior: unlockWhenFinished
-    environment_variables:
-      OSC_CONFIG: /home/go/config/oscrc-totest-manager
-    materials:
-      script:
-        git: https://github.com/openSUSE/openSUSE-release-tools.git
-        destination: scripts
-    timer:
-      spec: 0 */15 * ? * *
-      only_on_changes: false
-    stages:
-    - Run:
-        approval: manual
-        resources:
-        - staging-bot
-        tasks:
-        - script: |-
-            install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
-            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.2:MicroOS
   TTM.Leap_15.2_WSL:
     group: openSUSE.Checkers
     lock_behavior: unlockWhenFinished
@@ -252,27 +189,6 @@ pipelines:
         - script: |-
             install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
             scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.3
-  TTM.Leap_15.3_ARM:
-    group: openSUSE.Checkers
-    lock_behavior: unlockWhenFinished
-    environment_variables:
-      OSC_CONFIG: /home/go/config/oscrc-totest-manager
-    materials:
-      script:
-        git: https://github.com/openSUSE/openSUSE-release-tools.git
-        destination: scripts
-    timer:
-      spec: 0 */15 * ? * *
-      only_on_changes: false
-    stages:
-    - Run:
-        approval: manual
-        resources:
-        - staging-bot
-        tasks:
-        - script: |-
-            install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
-            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.3:ARM
   TTM.Leap_15.3_Images:
     group: openSUSE.Checkers
     lock_behavior: unlockWhenFinished
@@ -294,3 +210,24 @@ pipelines:
         - script: |-
             install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
             scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.3:Images
+  TTM.Leap_15.3_ARM:
+    group: openSUSE.Checkers
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-totest-manager
+    materials:
+      script:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+        destination: scripts
+    timer:
+      spec: 0 */15 * ? * *
+      only_on_changes: false
+    stages:
+    - Run:
+        approval: manual
+        resources:
+        - staging-bot
+        tasks:
+        - script: |-
+            install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
+            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.3:ARM

--- a/gocd/totestmanager.gocd.yaml.erb
+++ b/gocd/totestmanager.gocd.yaml.erb
@@ -6,11 +6,8 @@ pipelines:
       openSUSE:Factory:PowerPC
       openSUSE:Factory:WSL
       openSUSE:Factory:zSystems
-      openSUSE:Leap:15.1:ARM:Images
-      openSUSE:Leap:15.1:Images
       openSUSE:Leap:15.2:ARM:Images
       openSUSE:Leap:15.2:Images
-      openSUSE:Leap:15.2:MicroOS
       openSUSE:Leap:15.2:WSL
       openSUSE:Leap:15.3
       openSUSE:Leap:15.3:Images


### PR DESCRIPTION
- Drop Leap:15.1:Images and Leap:15.2:MicroOS
- Some .yaml files were changed manually, adjust the .erb source
- Delete some unnecessary/duplicate whitespace