### PR TITLE
Drop the old path for releasing SP3:GA/sles15-image

### DIFF
--- a/gocd/sp3.target.gocd.yaml
+++ b/gocd/sp3.target.gocd.yaml
@@ -85,7 +85,6 @@ pipelines:
             for product in kiwi-templates-JeOS SLES-15-SP3-Vagrant sles15-image 000product $PRODUCTS; do
               osc -A https://api.suse.de release SUSE:SLE-15-SP3:GA $product
             done
-            osc -A https://api.suse.de release SUSE:SLE-15-SP3:Update:CR sles15-image
             sleep 600
             while (osc -A https://api.suse.de/ api "/build/SUSE:SLE-15-SP3:GA:TEST/_result?view=summary&repository=images" | grep "result project" | grep -v 'code="published" state="published">'); do
                 echo PENDING
@@ -104,7 +103,6 @@ pipelines:
         tasks:
         - script: |-
             osc -A https://api.suse.de release SUSE:SLE-15-SP3:GA:TEST
-            osc -A https://api.suse.de release SUSE:SLE-15-SP3:Update:CR:ToTest sles15-image -r images --target-project SUSE:SLE-15-SP3:Update:CR:PUBLISH --target-repository images
             sleep 600
             while (osc -A https://api.suse.de/ api "/build/SUSE:SLE-15-SP3:GA:PUBLISH/_result?view=summary&repository=images" | grep "result project" | grep -v 'code="published" state="published">'); do
                 echo PENDING
@@ -156,7 +154,6 @@ pipelines:
                   for product in kiwi-templates-JeOS SLES-15-SP3-Vagrant sles15-image 000product $PRODUCTS; do
                     osc -A https://api.suse.de release SUSE:SLE-15-SP3:GA $product
                   done
-                  osc -A https://api.suse.de release SUSE:SLE-15-SP3:Update:CR sles15-image
 
     - Release.Images.To.Publish:
         approval: manual


### PR DESCRIPTION
The new path is now used by QA and ~soon~ Autobuild.