### PR TITLE
Support Leap:15.3:ARM:Images as well

### DIFF
--- a/gocd/totestmanager.gocd.yaml
+++ b/gocd/totestmanager.gocd.yaml
@@ -231,3 +231,24 @@ pipelines:
         - script: |-
             install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
             scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.3:ARM
+  TTM.Leap_15.3_ARM_Images:
+    group: openSUSE.Checkers
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-totest-manager
+    materials:
+      script:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+        destination: scripts
+    timer:
+      spec: 0 */15 * ? * *
+      only_on_changes: false
+    stages:
+    - Run:
+        approval: manual
+        resources:
+        - staging-bot
+        tasks:
+        - script: |-
+            install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
+            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.3:ARM:Images

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -104,7 +104,7 @@ DEFAULT = {
         'mail-noreply': 'noreply@opensuse.org',
         'mail-release-list': 'opensuse-releaseteam@opensuse.org',
     },
-    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+)):ARM$': {
+    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+)):ARM:(Images)?$': {
         'product': 'openSUSE.product',
         'openqa': 'https://openqa.opensuse.org',
         'main-repo': 'ports',

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -52,6 +52,7 @@ class TestConfig(unittest.TestCase):
             'openSUSE:Leap:15.2:Update',
             'openSUSE:Leap:15.3',
             'openSUSE:Leap:15.3:ARM',
+            'openSUSE:Leap:15.3:ARM:Images',
             'openSUSE:Leap:15.3:NonFree',
             'openSUSE:Leap:15.3:Update',
             'openSUSE:Backports:SLE-15',


### PR DESCRIPTION
We need this to run TTM against :images and properly determine the
pseudometa package.