### PR TITLE
check_source.py: Decline if source_revision not set

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -114,6 +114,10 @@ class CheckSource(ReviewBot.ReviewBot):
             self.review_messages['declined'] = 'Only one action per request allowed'
             return False
 
+        if source_revision is None:
+            self.review_messages['declined'] = 'Submission not from a pinned source revision'
+            return False
+
         kind = package_kind(self.apiurl, target_project, target_package)
         if kind == 'meta':
             self.review_messages['accepted'] = 'Skipping all checks for meta packages'


### PR DESCRIPTION
Accepts https://build.opensuse.org/request/show/895535, but declines https://build.opensuse.org/request/show/867727.