### PR TITLE
TTM fixes for 15.3:ARM:Images

### DIFF
--- a/ttm/manager.py
+++ b/ttm/manager.py
@@ -63,7 +63,7 @@ class ToTestManager(ToolBase.ToolBase):
 
     def iso_build_version(self, project, tree, repo=None, arch=None):
         for binary in self.binaries_of_product(project, tree, repo=repo, arch=arch):
-            result = re.match(r'.*-(?:Build|Snapshot)([0-9.]+)(?:-Media.*\.iso|\.docker\.tar\.xz|\.raw\.xz|\.appx)', binary)
+            result = re.match(r'.*-(?:Build|Snapshot)([0-9.]+)(?:-Media.*\.iso|\.docker\.tar\.xz|\.tar\.xz|\.raw\.xz|\.appx)', binary)
             if result:
                 return result.group(1)
         raise NotFoundException("can't find %s iso version" % project)

--- a/ttm/publisher.py
+++ b/ttm/publisher.py
@@ -189,16 +189,16 @@ class ToTestPublisher(ToTestManager):
 
         self.send_amqp_event(current_snapshot, current_result)
 
-        if current_result == QAResult.failed:
+        if current_result == QAResult.failed and not force:
             self.update_status('failed', current_snapshot)
             return QAResult.failed
         else:
             self.update_status('failed', '')
 
-        if current_result != QAResult.passed:
+        if current_result != QAResult.passed and not force:
             return QAResult.inprogress
 
-        if current_qa_version != current_snapshot:
+        if current_qa_version != current_snapshot and not force:
             # We reached a very bad status: openQA testing is 'done', but not of the same version
             # currently in test project. This can happen when 'releasing' the
             # product failed


### PR DESCRIPTION
Make `publish --force` really publish forcibly and fix version detection of `JeOS`