### PR TITLE
Document CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/openSUSE/openSUSE-release-tools/workflows/CI/badge.svg?branch=master)](https://github.com/openSUSE/openSUSE-release-tools/actions?query=branch%3Amaster)
-[![Coverage Status](https://coveralls.io/repos/github/openSUSE/openSUSE-release-tools/badge.svg?branch=master)](https://coveralls.io/github/openSUSE/openSUSE-release-tools?branch=master)
+[![codecov](https://codecov.io/gh/openSUSE/openSUSE-release-tools/branch/master/graph/badge.svg?token=MqVygxmguE)](https://codecov.io/gh/openSUSE/openSUSE-release-tools)
 [![openSUSE Tumbleweed package](https://repology.org/badge/version-for-repo/opensuse_tumbleweed/opensuse-release-tools.svg)](https://repology.org/metapackage/opensuse-release-tools)
 
 # openSUSE-release-tools

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ It can also be useful to work against a development copy of `osc` either to util
     # to utilize the wrapper for working on osc plugins from osrt checkout
     $(realpath ./osc)/../osc-wrapper.py --version
 
-Using [Docker Compose](https://docs.docker.com/compose/), a containerized OBS can be started via one command. The default credentials are `Admin` and `opensuse` on [0.0.0.0:3000](http://0.0.0.0:3000).
+Using [Docker Compose](https://docs.docker.com/compose/), a containerized OBS can be started via one command. The default credentials are `Admin` and `opensuse` on [0.0.0.0:3000](http://0.0.0.0:3000). You can change the port by setting the environment variable `OSRT_EXPOSED_OBS_PORT`.
 
     docker-compose -f dist/ci/docker-compose.yml up api
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ This repository includes all the needed files to set up and run the Continuous I
     # Run the linter
     docker-compose -f dist/ci/docker-compose.yml run flaker
 
-    # Run the test suite. It may take some time.
+    # Run the test full suite (it may take some time)...
     docker-compose -f dist/ci/docker-compose.yml run test
+
+    # .. or just run a single test (i.e., the 'tests/util_tests.py')
+    docker-compose -f dist/ci/docker-compose.yml run test run_as_tester nosetests tests/util_tests.py
 
     # We are finished. Now you can shut the containers down.
     docker-compose -f dist/ci/docker-compose.yml down

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ It can also be useful to work against a development copy of `osc` either to util
 
 A containerized OBS can be started via one command. The default credentials are `Admin` and `opensuse` on [0.0.0.0:3000](http://0.0.0.0:3000).
 
-    ./dist/ci/docker-compose-obs
+    docker-compose -f dist/ci/docker-compose.yml up api
 
 An `osc` alias is automatically configured as `local`.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ It can also be useful to work against a development copy of `osc` either to util
     # to utilize the wrapper for working on osc plugins from osrt checkout
     $(realpath ./osc)/../osc-wrapper.py --version
 
-A containerized OBS can be started via one command. The default credentials are `Admin` and `opensuse` on [0.0.0.0:3000](http://0.0.0.0:3000).
+Using [Docker Compose](https://docs.docker.com/compose/), a containerized OBS can be started via one command. The default credentials are `Admin` and `opensuse` on [0.0.0.0:3000](http://0.0.0.0:3000).
 
     docker-compose -f dist/ci/docker-compose.yml up api
 
@@ -70,3 +70,28 @@ A facsimile of `openSUSE:Factory` in the form of a subset of the related data ca
 Some tests will attempt to run against the local OBS, but not all.
 
     nosetests
+
+## Running Continuous Integration
+
+This repository includes all the needed files to set up and run the Continuous Integration test suite. The idea is to use Docker Compose to orchestrate a set of containers, including an OBS instance, and run [the tests](tests/) on top of them. Although they automatically run [on GitHub Actions](https://github.com/features/actions) (more on that later), it is easy to run them locally. The following commands must be executed from the root of the repository.
+
+
+    # Mount the current path at the /code directory on the container
+    sed -i -e "s,../..:,$PWD:," dist/ci/docker-compose.yml
+
+    # Run the linter
+    docker-compose -f dist/ci/docker-compose.yml run flaker
+
+    # Run the test suite. It may take some time.
+    docker-compose -f dist/ci/docker-compose.yml run test
+
+    # We are finished. Now you can shut the containers down.
+    docker-compose -f dist/ci/docker-compose.yml down
+
+The [docker-compose.yml](dist/ci/docker-compose.yml) mentions two container images that are built in the [openSUSE:Tools:Images](https://build.opensuse.org/project/show/openSUSE:Tools:Images) project:
+
+* `osrt-miniobs-for-ci` is the base of OBS-related services (API, caches, SMTP, and so on).
+* `osrt-testenv-tumbleweed` used to run the tests. The code and the tests are mounted in the `/code` directory of this container.
+
+As mentioned before, the main repository uses GitHub Actions to automatically run the tests when a pull request is opened or the code is pushed to the master branch. You can find the details in the
+[workflow definition](.github/workflows/ci-test.yml). Note that, in addition to the steps listed before, code coverage data is submitted to [Codecov](https://app.codecov.io/gh/openSUSE/openSUSE-release-tools).

--- a/dist/ci/docker-compose.yml
+++ b/dist/ci/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       - srcserver
       - repserver
       - servicedispatch
+    ports:
+      - 0.0.0.0:3000:3000
   srcserver:
     <<: *obs
     command: chroot --userspec=obsrun / /usr/lib/obs/server/bs_srcserver

--- a/dist/ci/docker-compose.yml
+++ b/dist/ci/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - repserver
       - servicedispatch
     ports:
-      - 0.0.0.0:3000:3000
+      - "0.0.0.0:${OSRT_EXPOSED_OBS_PORT:-3000}:3000"
   srcserver:
     <<: *obs
     command: chroot --userspec=obsrun / /usr/lib/obs/server/bs_srcserver


### PR DESCRIPTION
* Add a section to the README explaining how to use Docker Compose to run integration tests.
* Expose OBS port in the Docker Compose `api` service so it can replace the `./dist/ci/docker-compose-obs` script.
* Replace Coveralls badge with Codecov one (see [GitHub's action workflow definition](https://github.com/openSUSE/openSUSE-release-tools/blob/9c0e048aac399557c8aa0be725adec972629e670/.github/workflows/ci-test.yml#L26-L27)).