### PR TITLE
osclib/conf.py: Don't use same config for openSUSE:Leap:15.3:ARM and :Images

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -105,7 +105,7 @@ DEFAULT = {
         'mail-noreply': 'noreply@opensuse.org',
         'mail-release-list': 'opensuse-releaseteam@opensuse.org',
     },
-    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+)):ARM(:Images)?$': {
+    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+)):ARM$': {
         'product': 'openSUSE.product',
         'openqa': 'https://openqa.opensuse.org',
         'main-repo': 'ports',


### PR DESCRIPTION
Otherwise they both try to write into the same pseudometa.