### PR TITLE
Rename DVD-Backports to DVD-Backports-Incidents

### DIFF
--- a/data/apimap.json
+++ b/data/apimap.json
@@ -11,7 +11,7 @@
   },
   "openSUSE:Backports:SLE-15-SP3:Update" : {
     "version": "15.3",
-    "flavor": "DVD-Backports",
+    "flavor": "DVD-Backports-Incidents",
     "distri": "opensuse"
   }
 }

--- a/data/incidents.json
+++ b/data/incidents.json
@@ -13,7 +13,7 @@
   },
   "openSUSE:Backports:SLE-15-SP3:Update": {
     "DISTRI": "opensuse",
-    "FLAVOR": "DVD-Backports",
+    "FLAVOR": "DVD-Backports-Incidents",
     "VERSION": "15.3",
     "ARCH": "x86_64"
   }

--- a/data/repos.json
+++ b/data/repos.json
@@ -33,7 +33,7 @@
      "openSUSE:Backports:SLE-15-SP3:Update" : {
        "settings" : {
          "OS_TEST_ISSUES" : "",
-         "FLAVOR" : "DVD-Backports",
+         "FLAVOR" : "DVD-Backports-Incidents",
          "DISTRI" : "opensuse",
          "VERSION" : "15.3",
          "ARCH" : "x86_64"


### PR DESCRIPTION
Progress ticket : https://progress.opensuse.org/issues/94810#change-423835