### PR TITLE
Preparation for switch from nosetests to pytest

### DIFF
--- a/dist/ci/testenv-tumbleweed/Dockerfile
+++ b/dist/ci/testenv-tumbleweed/Dockerfile
@@ -5,9 +5,9 @@ FROM opensuse/tumbleweed
 RUN zypper -n ar http://download.opensuse.org/repositories/openSUSE:/Tools/openSUSE_Factory/ openSUSE:Tools
 RUN zypper --gpg-auto-import-keys ref
 
-RUN zypper in -y osc python3-nose python3-httpretty python3-pyxdg python3-PyYAML \
+RUN zypper in -y osc python3-pytest python3-nose python3-httpretty python3-pyxdg python3-PyYAML \
    python3-pika python3-mock python3-cmdln python3-lxml python3-python-dateutil python3-colorama \
-   python3-influxdb python3-coverage python3-coveralls libxml2-tools curl python3-flake8 \
+   python3-influxdb python3-coverage python3-pytest-cov python3-coveralls libxml2-tools curl python3-flake8 \
    shadow vim vim-data strace git sudo patch openSUSE-release openSUSE-release-ftp \
    perl-Net-SSLeay perl-Text-Diff perl-XML-Simple perl-XML-Parser build \
    obs-service-download_files


### PR DESCRIPTION
The preparation is needed so no workaround is needed when validating
that all tests passed when switched from nosetests to pytest. Nosetests
will be removed as part of final switch change.

final pr: https://github.com/openSUSE/openSUSE-release-tools/pull/2595