### PR TITLE
Check for maintainers in the source project

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -11,6 +11,8 @@ try:
 except ImportError:
     import cElementTree as ET
 
+from lxml import etree as ETL
+
 import osc.conf
 import osc.core
 from osc.util.helper import decode_list
@@ -22,7 +24,7 @@ from osclib.core import package_kind
 from osclib.core import source_file_load
 from osclib.core import target_archs
 from osclib.core import create_add_role_request
-from osclib.core import maintainers_get
+from osc.core import show_project_meta
 from urllib.error import HTTPError
 
 import ReviewBot
@@ -348,7 +350,10 @@ class CheckSource(ReviewBot.ReviewBot):
         )
         if not self.required_maintainer: return True
 
-        maintainers = maintainers_get(self.apiurl, source_project)
+        meta = ETL.fromstringlist(show_project_meta(self.apiurl, source_project))
+        maintainers = meta.xpath('//person[@role="maintainer"]/@userid')
+        maintainers += ['group:' + g for g in meta.xpath('//group[@role="maintainer"]/@groupid')]
+
         return self.required_maintainer in maintainers
 
     @staticmethod

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -47,6 +47,7 @@ DEFAULT = {
         'mail-noreply': 'noreply@opensuse.org',
         'mail-release-list': 'opensuse-releaseteam@opensuse.org',
         'always_set_productversion_to': '',
+        'required-source-maintainer': 'group:factory-maintainers',
     },
     r'openSUSE:(?P<project>Factory):ARM$': {
         'product': 'openSUSE.product',

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -1101,7 +1101,7 @@ def create_change_devel_request(apiurl, source_project, source_package,
 def create_add_role_request(apiurl, target_project, user, role, target_package=None, message=None):
     """Create an add_role request
 
-    user -- user or group name. If it is a group, it should start with 'group:'.
+    user -- user or group name. If it is a group, it has to start with 'group:'.
     """
 
     if user.startswith('group:'):

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -1098,6 +1098,21 @@ def create_change_devel_request(apiurl, source_project, source_package,
             tgt_project=target_project, tgt_package=target_package)
     return create_request(apiurl, action, message)
 
+def create_add_role_request(apiurl, target_project, user, role, target_package=None, message=None):
+    """Create an add_role request
+
+    user -- user or group name. If it is a group, it should start with 'group:'.
+    """
+
+    if user.startswith('group:'):
+        group = user.replace('group:', '')
+        kargs = dict(group_name=group, group_role=role)
+    else:
+        kargs = dict(person_name=user, person_role=role)
+
+    action = Action('add_role', tgt_project=target_project, tgt_package=target_package, **kargs)
+    return create_request(apiurl, action, message)
+
 def create_request(apiurl, action, message=None):
     """Create a request for the given action
 

--- a/tests/check_source_tests.py
+++ b/tests/check_source_tests.py
@@ -8,7 +8,7 @@ from osc.core import get_request_list
 
 PROJECT = 'openSUSE:Factory'
 SRC_PROJECT = 'devel:Fishing'
-FIXTURES = os.path.join(os.getcwd(), 'tests/fixtures')
+FIXTURES = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'fixtures')
 REVIEW_TEAM = 'reviewers-team'
 FACTORY_MAINTAINERS = 'group:factory-maintainers'
 

--- a/tests/check_source_tests.py
+++ b/tests/check_source_tests.py
@@ -43,6 +43,7 @@ class TestCheckSource(OBSLocal.TestCase):
         del self.wf
 
     def test_no_devel_project(self):
+        """Declines the request when it does not come from a devel project"""
         req_id = self.wf.create_submit_request(SRC_PROJECT, self.randomString('package')).reqid
 
         self.assertReview(req_id, by_user=(self.bot_user, 'new'))
@@ -54,6 +55,7 @@ class TestCheckSource(OBSLocal.TestCase):
         self.assertIn('%s is not a devel project of %s' % (SRC_PROJECT, PROJECT), review.comment)
 
     def test_devel_project(self):
+        """Accepts a request coming from a devel project"""
         self._setup_devel_project()
 
         # Set up the reviewers team


### PR DESCRIPTION
* It introduces a new configuration parameter `required-source-maintainer`.
* If defined, it is expected to be a maintainer of the devel project.
* If that's not the case, the request is declined and an `add_role` request is created.

Fixes #2429 