### PR TITLE
Add an inventory

### DIFF
--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -107,9 +107,12 @@ Finds unmaintained binaries sourced from SLE.
 * Package: openSUSE-release-tools
 * Usage: ?
 
-#### sync-rebuild
+#### sync-rebuild (obsolete)
 
-Syncs openSUSE:Factory and openSUSE:Factory:Rebuild.
+Syncs openSUSE:Factory and openSUSE:Factory:Rebuild. This feature was already
+merged into the [accept
+command](https://github.com/openSUSE/openSUSE-release-tools/commit/87c891662015f14421c2315210c248e712e697c8)
+of the staging projects plug-in.
 
 * Sources: [sync-rebuild.py](sync-rebuild.py)
 * Documentation: --

--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -60,7 +60,9 @@ Generates and updates OBS products for openSUSE and SLE. It generates package li
 
 #### container_cleaner
 
-Cleans up the `maintenance_release` projects for containers
+Clean old containers from a given project like
+[openSUSE:Containers:Tumbleweed](https://build.opensuse.org/project/show/openSUSE:Containers:Tumbleweed).
+Only those containers providing binaries to the latest five versions for each architecture are kept.
 
 * Sources: [container_cleaner.py](container_cleaner.py)
 * Documentation: --

--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -45,7 +45,7 @@ Generates email diffs summaries to announce product releases.
 * Sources: [factory-package-news/announcer.py](factory-package-news/announcer.py)
 * Documentation: [factory-package-news/README.asciidoc](factory-package-news/README.asciidoc)
 * Package: openSUSE-release-tools-announcer
-* Usage: gocd
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+announcer)
 
 #### pkglistgen
 
@@ -56,7 +56,7 @@ Generates and updates OBS products for openSUSE and SLE. It generates package li
 * Sources: [pkglistgen.py](pkglistgen.py)
 * Documentation: [docs/pkglistgen.md](docs/pkglistgen.md)
 * Package: openSUSE-release-tools-pkglistgen
-* Usage: gocd
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+pkglistgen)
 
 #### container_cleaner
 
@@ -67,7 +67,7 @@ Only those containers providing binaries to the latest five versions for each ar
 * Sources: [container_cleaner.py](container_cleaner.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: gocd
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+container_cleaner)
 
 #### metrics
 
@@ -96,7 +96,7 @@ Releases distribution snapshots to openQA and publishes if the result is positiv
 * Sources: [totest-manager.py](totest-manager.py) and [ttm](ttm)
 * Documentation: [ttm/README.md](ttm/README.md)
 * Package: openSUSE-release-tools
-* Usage: gocd
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+totest-manager)
 
 #### unmaintained
 
@@ -105,9 +105,9 @@ Finds unmaintained binaries sourced from SLE.
 * Sources: [unmaintained.py](unmaintained.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: ?
+* Usage: obsolete
 
-#### sync-rebuild (obsolete)
+#### sync-rebuild
 
 Syncs openSUSE:Factory and openSUSE:Factory:Rebuild. This feature was already
 merged into the [accept
@@ -117,7 +117,7 @@ of the staging projects plug-in.
 * Sources: [sync-rebuild.py](sync-rebuild.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: ?
+* Usage: obsolete
 
 #### bugowner
 
@@ -153,7 +153,7 @@ Sends e-mails about packages failing to build for a long time.
 * Sources: [build-fail-reminder.py](build-fail-reminder.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: gocd
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+build-fail-reminder)
 
 #### checknewer
 
@@ -189,7 +189,7 @@ Create SRs for Leap.
 * Sources: [update_crawler.py](update_crawler.py) and [script](script).
 * Documentation: --
 * Package: openSUSE-release-tools-leaper
-* Usage: see [leaper](#leaper)
+* Usage: obsolete
 
 #### create_staging
 
@@ -209,7 +209,7 @@ Handles maintenance incident requests
 * Sources: [check_maintenance_incidents.py](check_maintenance_incidents.py)
 * Documentation: [docs/maintbot.asciidoc](docs/maintbot.asciidoc)
 * Package: openSUSE-release-tools-maintenance
-* Usage: gocd
+* Usage: obsolete
 
 #### leaper
 
@@ -218,7 +218,7 @@ Implements Leap-style services for non-Factory projects (whatever that means).
 * Sources: [leaper.py](leaper.py)
 * Documentation: --
 * Package: openSUSE-release-tools-leaper
-* Usage: gocd
+* Usage: obsolete
 
 #### origin-manager
 
@@ -227,7 +227,7 @@ Keeps track of from what project a package originates, submit updates, review re
 * Sources: [origin-manager.py](origin-manager.py) and [web](web)
 * Documentation: [docs/origin-manager.md](docs/origin-manager.md)
 * Package: openSUSE-release-tools-origin-manager
-* Usage: gocd
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Forigin-manager)
 
 #### staging-bot
 
@@ -236,7 +236,8 @@ Assists in management of staging projects.
 * Sources: [devel-project.py][devel-project], [staging-report.py](staging-report.py), [suppkg_rebuild.py](suppkg_rebuild.py).
 * Documentation: --
 * Package: openSUSE-release-tools-staging-bot
-* Usage: gocd
+* Usage: gocd ([staging-report.py](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+staging-report)
+[suppkg_rebuild.py](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+suppkg_rebuild), etc.)
 
 #### legal-auto
 
@@ -245,16 +246,16 @@ Makes automatic legal reviews based on the legaldb API
 * Sources: [legal-auto.py](legal-auto.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: gocd
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+legal-auto)
 
 #### check_tags_in_requests
 
-Checks that a submit request has corrrect tags specified.
+Checks that a submit request has correct tags specified.
 
 * Sources: [check_tags_in_requests.py](check_tags_in_requests.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: gocd
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+check_tags_in_requests)
 
 #### abichecker
 
@@ -263,7 +264,7 @@ Checks ABI compatibility in OBS requests.
 * Sources: [abichecker](abichecker)
 * Documentation: --
 * Package: openSUSE-release-tools-abichecker
-* Usage: gocd
+* Usage: gocd?
 
 #### check_source_in_factory
 
@@ -273,7 +274,7 @@ sources exist.
 * Sources: [check_source_in_factory.py](check_source_in_factory.py)
 * Documentation: [docs/factory-source.asciidoc](docs/factory-source.asciidoc)
 * Package: openSUSE-release-tools
-* Usage: gocd?
+* Usage: obsolete
 
 #### openqa-maintenance
 
@@ -282,7 +283,7 @@ OpenQA stuff, not sure about the details.
 * Sources: [openqa-maintenance.py](openqa-maintenance.py) and [oqamaint](oqamaint)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: gocd?
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+openqa_maintenance)
 
 #### repo-checker
 
@@ -294,7 +295,9 @@ Inspects built RPMs from staging projects.
   [findfileconflicts](findfileconflicts), [write_repo_susetags_file.pl](write_repo_susetags_file.pl)
 * Documentation: --
 * Package: openSUSE-release-tools-repo-checker
-* Usage: gocd?
+* Usage: gocd ([project-installcheck.py](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+project-installcheck), [staging-installcheck](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+staging-installcheck),
+[maintenance-installcheck.py](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+maintenance-installcheck) and
+[findfileconflicts](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+findfileconflicts))
 
 #### manager_42.py
 
@@ -303,7 +306,7 @@ Maintains `00Meta/lookup.yml`.
 * Sources: [manager_42.py](manager_42.py)
 * Documentation: --
 * Package: openSUSE-release-tools-leaper
-* Usage: Obsoleted by origin-manager?
+* Usage: obsolete (by origin-manager)
 
 ### OSC Plugins
 
@@ -315,7 +318,7 @@ review bot that assigns reviews (?).
 * Sources: [check_source.py](check_source.py) and [check_source.pl](check_source.pl)
 * Documentation: [docs/check_source.asciidoc](docs/check_source.asciidoc)
 * Package: openSUSE-release-tools-check-source
-* Usage: gocd?
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+osc-check_source)
 
 #### osc-origin.py
 
@@ -324,7 +327,7 @@ Tools for working with origin information.
 * Sources: [osc-origin.py](osc-origin.py)
 * Documentation: [docs/origin-manager.md](docs/origin-manager.md)
 * Package: openSUSE-release-tools-origin-manager
-* Usage: gocd?
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+osc-origin)
 
 #### osc-cycle.py
 

--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -1,0 +1,423 @@
+# Contents
+
+This document describes in detail the contents of this repository. It is still a *work in progress*,
+but do not hesitate to report if something is missing.
+
+## Overview
+
+The repository contains a set of tools to aid in the process of building, testing and releasing
+(open)SUSE based distributions. The [Tools](#tools) section enumerates and describes all these
+tools, including links to documentation, source code and some information about where they are used.
+
+Apart from these tools, the repository includes:
+
+* Some documenation in the [docs](docs) directory.
+* A Python module called [osclib](osclib) which includes code that is shared by several tools. They
+  are available in the `osclib` package.
+* A Docker-based [tests suite](tests). The Docker manifests and the Docker Compose files are
+  located in the [dist](dist) directory.
+* [GoCD](https://www.gocd.org) configuration files in [gocd](gocd). GoCD is an open source CI/CD
+  server that it is used to deploy the bots on OBS.
+* A set of [Tampermonkey](https://www.tampermonkey.net) scripts (see [userscript](userscript)
+  directory) to extend OBS features when using the web interface.
+* Several [systemd](systemd) units, as many of the tools (e.g., the `staging-bot`) make use of
+  them.
+
+## Tools
+
+Most of these tools are available as packages for several distributions. Check the [spec file in
+this repository](dist/package/openSUSE-release-tools.spec) or the [devel
+project](https://build.opensuse.org/package/show/openSUSE:Tools/openSUSE-release-tools) for further
+information.
+
+For the time being, we have classified them into three different groups: *command line tools*, *OBS
+bots* and *osc plugins*. Bear in mind that the information in the following list might be wrong and
+incomplete.
+
+### Command Line Tools
+
+ Usually, the executables are renamed as `osrt-NAME` (e.g., `osrt-announcer`).
+
+#### announcer
+
+Generates email diffs summaries to announce product releases.
+
+* Sources: [factory-package-news/announcer.py](factory-package-news/announcer.py)
+* Documentation: [factory-package-news/README.asciidoc](factory-package-news/README.asciidoc)
+* Package: openSUSE-release-tools-announcer
+
+#### pkglistgen
+
+Generates and updates OBS products for openSUSE and SLE. It generates package lists based on
+`000package-groups` and puts them in `000product` (resulting kiwi files) and `000release-packages`
+(release package spec files).
+
+* Sources: [pkglistgen.py](pkglistgen.py)
+* Documentation: [docs/pkglistgen.md](docs/pkglistgen.md)
+* Package: openSUSE-release-tools-pkglistgen
+* Usage: gocd
+
+#### container_cleaner
+
+Cleans up the `maintenance_release` projects for containers
+
+* Sources: [container_cleaner.py](container_cleaner.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: gocd
+
+#### metrics
+
+Generates insightful metrics from relevant OBS and annotation data, based on InfluxDB and Grafana.
+
+* Sources: [metrics.py](metrics.py)
+* Documentation: [docs/metrics.md](./docs/metrics.md)
+* Package: openSUSE-release-tools-metrics
+* Usage: ?
+
+#### metrics-access
+
+Ingests `download.opensuse.org` Apache access logs and generate metrics. It is composed of a PHP.
+script and a set of [systemd units](systemd).
+
+* Sources: [metrics/access/aggregate.php](metrics/access/aggregate.php)
+* Documentation: [docs/metrics.md](./docs/metrics.md)
+* Package: openSUSE-release-tools-metrics-access
+* Usage: ?
+
+#### totest-manager
+
+Releases distribution snapshots to openQA and publishes if the result is positive.
+
+* Sources: [totest-manager.py](totest-manager.py) and [ttm](ttm)
+* Documentation: [ttm/README.md](ttm/README.md)
+* Package: openSUSE-release-tools
+* Usage: gocd
+
+#### unmaintained
+
+Finds unmaintained binaries sourced from SLE.
+
+* Sources: [unmaintained.py](unmaintained.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ?
+
+#### sync-rebuild
+
+Syncs openSUSE:Factory and openSUSE:Factory:Rebuild.
+
+* Sources: [sync-rebuild.py](sync-rebuild.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ?
+
+#### bugowner
+
+Manages bugowner information
+
+* Sources: [bugowner.py](bugowner.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ?
+
+#### bs_mirrorfull
+
+Mirrors repositories from build service.
+
+* Souces: [bs_mirrorfull](bs_mirrorfull)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: Used by other tools like `pkglistgen` or `repocheck`
+
+#### biarchtool
+
+Manages biarch packages
+
+* Source: [biarchtool.py](biarchtool.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ?
+
+#### build-fail-reminder
+
+Sends e-mails about packages failing to build for a long time.
+
+* Sources: [build-fail-reminder.py](build-fail-reminder.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: gocd
+
+#### checknewer
+
+Checks if all packages in a repository are newer than all other repositories.
+
+* Sources: [checknewer.py](checknewer.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ?
+
+#### deptool
+
+Assists in debugging dependencies
+
+* Sources: [deptool.py](deptool.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ?
+
+#### requestfinder
+
+Allows to retrieve requests from OBS with quite elaborated queries.
+
+* Sources: [requestfinder.py](requestfinder.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ?
+
+#### update_crawler
+
+Create SRs for Leap.
+
+* Sources: [update_crawler.py](update_crawler.py) and [script](script).
+* Documentation: --
+* Package: openSUSE-release-tools-leaper
+* Usage: see [leaper](#leaper)
+
+#### create_staging
+
+Scripts and templates to create staging projects.
+
+* Sources: [staging_templates](staging_templates)
+* Documentation: --
+* Package: --
+* Usage: ?
+
+### Bots
+
+#### check_maintenance_incidents
+
+Handles maintenance incident requests
+
+* Sources: [check_maintenance_incidents.py](check_maintenance_incidents.py)
+* Documentation: [docs/maintbot.asciidoc](docs/maintbot.asciidoc)
+* Package: openSUSE-release-tools-maintenance
+* Usage: gocd
+
+#### leaper
+
+Implements Leap-style services for non-Factory projects (whatever that means).
+
+* Sources: [leaper.py](leaper.py)
+* Documentation: --
+* Package: openSUSE-release-tools-leaper
+* Usage: gocd
+
+#### origin-manager
+
+Keeps track of from what project a package originates, submit updates, review requests to detect origin changes, and enforce origin specific policies like adding appropriate reviews
+
+* Sources: [origin-manager.py](origin-manager.py) and [web](web)
+* Documentation: [docs/origin-manager.md](docs/origin-manager.md)
+* Package: openSUSE-release-tools-origin-manager
+* Usage: gocd
+
+#### staging-bot
+
+Assists in management of staging projects. It is composed of Python scripts and a few systemd
+units.
+
+* Sources: [devel-project.py][devel-project], [staging-report.py](staging-report.py), [suppkg_rebuild.py](suppkg_rebuild.py) and `osrt-staging-bot-*` [systemd units](systemd)
+* Documentation: --
+* Package: openSUSE-release-tools-staging-bot
+* Usage: gocd
+
+#### legal-auto
+
+Makes automatic legal reviews based on the legaldb API
+
+* Sources: [legal-auto.py](legal-auto.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: gocd
+
+#### check_tags_in_requests
+
+Checks that a submit request has corrrect tags specified.
+
+* Sources: [check_tags_in_requests.py](check_tags_in_requests.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: gocd
+
+#### abichecker
+
+Checks ABI compatibility in OBS requests.
+
+* Sources: [abichecker](abichecker)
+* Documentation: --
+* Package: openSUSE-release-tools-abichecker
+* Usage: gocd
+
+#### check_source_in_factory
+
+Checks if the sources of a submission are either in Factory or a request for Factory with the same
+sources exist.
+
+* Sources: [check_source_in_factory.py](check_source_in_factory.py)
+* Documentation: [docs/factory-source.asciidoc](docs/factory-source.asciidoc)
+* Package: openSUSE-release-tools
+* Usage: gocd?
+
+#### openqa-maintenance
+
+OpenQA stuff, not sure about the details.
+
+* Sources: [openqa-maintenance.py](openqa-maintenance.py) and [oqamaint](uqamaint)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: gocd?
+
+#### check_tags_in_requests.py
+
+Checks that a submit request has corrrect tags specified.
+
+* Sources: [check_tags_in_requests.py](check_tags_in_requests.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: gocd?
+
+#### repo-checker
+
+Inspects built RPMs from staging projects.
+
+* Sources: [project-installcheck.py](project-installcheck.py),
+  [staging-installcheck.py](staging-installcheck.py),
+  [maintenance-installcheck.py](maintenance-installcheck.py),
+  [findfileconflicts](findfileconflicts), [write_repo_susetags_file.pl](write_repo_susetags_file.pl)
+* Documentation: --
+* Package: openSUSE-release-tools-repo-checker
+* Usage: gocd?
+
+#### manager_42.py
+
+Maintains `00Meta/lookup.yml`.
+
+* Sources: [manager_42.py](manager_42.py)
+* Documentation: --
+* Package: openSUSE-release-tools-leaper
+* Usage: Obsoleted by origin-manager?
+
+### OSC Plugins
+
+#### osc-check_source.py
+
+Checks for usual mistakes and problems in the source packages submitted by users. Used also as
+review bot that assigns reviews (?).
+
+* Sources: [check_source.py](check_source.py) and [check_source.pl](check_source.pl)
+* Documentation: [docs/check_source.asciidoc](docs/check_source.asciidoc)
+* Package: openSUSE-release-tools-check-source
+* Usage: gocd?
+
+#### osc-origin.py
+
+Tools for working with origin information.
+
+* Sources: [osc-origin.py](osc-origin.py)
+* Documentation: [docs/origin-manager.md](docs/origin-manager.py)
+* Package: openSUSE-release-tools-origin-manager
+* Usage: gocd?
+
+#### osc-cycle.py
+
+Helps with OBS cycles visualization.
+
+* Sources: [osc-cycle.py](osc-cycle.py)
+* Documentation: --
+* Package: --
+* Usage: ???
+
+#### compare_pkglist.py
+
+Compares packages status between two projects.
+
+* Sources: [compare_pkglist.py](compare_pkglist.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ???
+
+#### staging
+
+Manages staging projects.
+
+* Sources: [osc-staging.py](osc-staging.py)
+* Documentation: [docs/staging.asciidoc](docs/staging.asciidoc) and [docs/testing.asciidoc](docs/testing.asciidoc)
+* Package: osc-plugin-staging
+* Usage: ???
+
+#### status.py
+
+Checks the status of the staging workflow bots.
+
+* Sources: [status.py](status.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ???
+
+#### fcc_submitter.py
+
+Creates SR from FactoryCandidates to openSUSE Leap project for new build succeded packages.
+
+* Sources: [fcc_submitter.py](fcc_submitter.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ???
+
+#### issue-diff.py
+
+Compares packages from a project against factory for differences in referenced issues and presents
+changes to allow whitelisting before creating Bugzilla entries.
+
+
+* Sources: [issue-diff.py](issue-diff.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ???
+
+#### obs-clone.py
+
+Clones projects and dependencies between OBS instances.
+
+* Sources: [obs_clone.py](obs_clone.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ???
+
+#### obs-operator
+
+Performs staging operations as a service instead of requiring the osc staging plugin to be utilized
+directly.
+
+* Sources: [obs_operator.py](obs_operator.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ???
+
+#### scan_baselibs.py
+
+Verifies 32bit binaries were imported properly towards a project.
+
+* Sources: [scan_baselibs.py](scan_baselibs.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ???
+
+#### k8s-secret.py
+
+Applies kubernetes secrets for OSRT tool osc configuration.
+
+* Sources: [k8s-secret.py](k8s-secret.py)
+* Documentation: --
+* Package: openSUSE-release-tools
+* Usage: ???

--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -69,6 +69,7 @@ Cleans up the `maintenance_release` projects for containers
 #### metrics
 
 Generates insightful metrics from relevant OBS and annotation data, based on InfluxDB and Grafana.
+See <https://metrics.opensuse.org/>.
 
 * Sources: [metrics.py](metrics.py)
 * Documentation: [docs/metrics.md](./docs/metrics.md)
@@ -77,7 +78,7 @@ Generates insightful metrics from relevant OBS and annotation data, based on Inf
 
 #### metrics-access
 
-Ingests `download.opensuse.org` Apache access logs and generate metrics. It is composed of a PHP.
+Ingests `download.opensuse.org` Apache access logs and generates metrics. It is composed of a PHP
 script and a set of [systemd units](systemd).
 
 * Sources: [metrics/access/aggregate.php](metrics/access/aggregate.php)
@@ -325,7 +326,7 @@ review bot that assigns reviews (?).
 Tools for working with origin information.
 
 * Sources: [osc-origin.py](osc-origin.py)
-* Documentation: [docs/origin-manager.md](docs/origin-manager.py)
+* Documentation: [docs/origin-manager.md](docs/origin-manager.md)
 * Package: openSUSE-release-tools-origin-manager
 * Usage: gocd?
 

--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -227,7 +227,7 @@ Keeps track of from what project a package originates, submit updates, review re
 * Sources: [origin-manager.py](origin-manager.py) and [web](web)
 * Documentation: [docs/origin-manager.md](docs/origin-manager.md)
 * Package: openSUSE-release-tools-origin-manager
-* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Forigin-manager)
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+origin-manager)
 
 #### staging-bot
 
@@ -283,7 +283,7 @@ OpenQA stuff, not sure about the details.
 * Sources: [openqa-maintenance.py](openqa-maintenance.py) and [oqamaint](oqamaint)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+openqa_maintenance)
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+openqa-maintenance)
 
 #### repo-checker
 
@@ -295,9 +295,7 @@ Inspects built RPMs from staging projects.
   [findfileconflicts](findfileconflicts), [write_repo_susetags_file.pl](write_repo_susetags_file.pl)
 * Documentation: --
 * Package: openSUSE-release-tools-repo-checker
-* Usage: gocd ([project-installcheck.py](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+project-installcheck), [staging-installcheck](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+staging-installcheck),
-[maintenance-installcheck.py](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+maintenance-installcheck) and
-[findfileconflicts](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+findfileconflicts))
+* Usage: gocd ([project-installcheck.py](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+project-installcheck), [staging-installcheck](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+staging-installcheck) and [maintenance-installcheck.py](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+maintenance-installcheck)
 
 #### manager_42.py
 
@@ -318,7 +316,7 @@ review bot that assigns reviews (?).
 * Sources: [check_source.py](check_source.py) and [check_source.pl](check_source.pl)
 * Documentation: [docs/check_source.asciidoc](docs/check_source.asciidoc)
 * Package: openSUSE-release-tools-check-source
-* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+osc-check_source)
+* Usage: [gocd](https://github.com/openSUSE/openSUSE-release-tools/search?q=path%3A%2Fgocd+check_source)
 
 #### osc-origin.py
 

--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -189,7 +189,7 @@ Create SRs for Leap.
 * Sources: [update_crawler.py](update_crawler.py) and [script](script).
 * Documentation: --
 * Package: openSUSE-release-tools-leaper
-* Usage: obsolete
+* Usage: obsolete (by origin-manager)
 
 #### create_staging
 
@@ -209,7 +209,7 @@ Handles maintenance incident requests
 * Sources: [check_maintenance_incidents.py](check_maintenance_incidents.py)
 * Documentation: [docs/maintbot.asciidoc](docs/maintbot.asciidoc)
 * Package: openSUSE-release-tools-maintenance
-* Usage: obsolete
+* Usage: obsolete (by origin-manager)
 
 #### leaper
 
@@ -420,4 +420,4 @@ Applies kubernetes secrets for OSRT tool osc configuration.
 * Sources: [k8s-secret.py](k8s-secret.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: ???
+* Usage: obsolete

--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -125,7 +125,7 @@ Manages bugowner information
 
 #### bs_mirrorfull
 
-Mirrors repositories from build service.
+Mirrors repositories from the build service to a local directory.
 
 * Souces: [bs_mirrorfull](bs_mirrorfull)
 * Documentation: --
@@ -177,7 +177,7 @@ Allows to retrieve requests from OBS with quite elaborated queries.
 * Package: openSUSE-release-tools
 * Usage: ?
 
-#### update_crawler (obsoleted by origin-manager)
+#### update_crawler (obsoleted by [origin-manager](#origin-manager))
 
 Create SRs for Leap.
 

--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -45,6 +45,7 @@ Generates email diffs summaries to announce product releases.
 * Sources: [factory-package-news/announcer.py](factory-package-news/announcer.py)
 * Documentation: [factory-package-news/README.asciidoc](factory-package-news/README.asciidoc)
 * Package: openSUSE-release-tools-announcer
+* Usage: gocd
 
 #### pkglistgen
 
@@ -176,7 +177,7 @@ Allows to retrieve requests from OBS with quite elaborated queries.
 * Package: openSUSE-release-tools
 * Usage: ?
 
-#### update_crawler
+#### update_crawler (obsoleted by origin-manager)
 
 Create SRs for Leap.
 
@@ -225,10 +226,9 @@ Keeps track of from what project a package originates, submit updates, review re
 
 #### staging-bot
 
-Assists in management of staging projects. It is composed of Python scripts and a few systemd
-units.
+Assists in management of staging projects.
 
-* Sources: [devel-project.py][devel-project], [staging-report.py](staging-report.py), [suppkg_rebuild.py](suppkg_rebuild.py) and `osrt-staging-bot-*` [systemd units](systemd)
+* Sources: [devel-project.py][devel-project], [staging-report.py](staging-report.py), [suppkg_rebuild.py](suppkg_rebuild.py).
 * Documentation: --
 * Package: openSUSE-release-tools-staging-bot
 * Usage: gocd
@@ -274,16 +274,7 @@ sources exist.
 
 OpenQA stuff, not sure about the details.
 
-* Sources: [openqa-maintenance.py](openqa-maintenance.py) and [oqamaint](uqamaint)
-* Documentation: --
-* Package: openSUSE-release-tools
-* Usage: gocd?
-
-#### check_tags_in_requests.py
-
-Checks that a submit request has corrrect tags specified.
-
-* Sources: [check_tags_in_requests.py](check_tags_in_requests.py)
+* Sources: [openqa-maintenance.py](openqa-maintenance.py) and [oqamaint](oqamaint)
 * Documentation: --
 * Package: openSUSE-release-tools
 * Usage: gocd?
@@ -332,7 +323,7 @@ Tools for working with origin information.
 
 #### osc-cycle.py
 
-Helps with OBS cycles visualization.
+Helps with OBS build cycles visualization. See the [openSUSE:Factory/standard example](https://build.opensuse.org/project/repository_state/openSUSE:Factory/standard).
 
 * Sources: [osc-cycle.py](osc-cycle.py)
 * Documentation: --

--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -365,7 +365,7 @@ Checks the status of the staging workflow bots.
 * Sources: [status.py](status.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: obsolete?
+* Usage: obsolete (it still checks for the status of some bots that are already retired, like leaper)
 
 #### fcc_submitter.py
 
@@ -378,7 +378,7 @@ packagers and creating SR from FactoryCandidates to the Leap project on successf
 * Sources: [fcc_submitter.py](fcc_submitter.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: ???
+* Usage: manually
 
 #### issue-diff.py
 
@@ -397,7 +397,7 @@ Clones projects and dependencies between OBS instances.
 * Sources: [obs_clone.py](obs_clone.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: obsolete
+* Usage: obsolete (initially added for testing, but it was replaced with a container-based approach)
 
 #### obs-operator
 
@@ -416,7 +416,7 @@ Verifies 32bit binaries were imported properly towards a project.
 * Sources: [scan_baselibs.py](scan_baselibs.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: obsolete
+* Usage: obsolete (after https://github.com/openSUSE/open-build-service/pull/7662 was introduced in OBS)
 
 #### k8s-secret.py
 

--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -20,7 +20,7 @@ Apart from these tools, the repository includes:
   server that is used to deploy the bots on OBS.
 * A set of [Tampermonkey](https://www.tampermonkey.net) scripts (see [userscript](userscript)
   directory) to extend OBS features when using the web interface.
-* Several [systemd](systemd) units, as many of the tools (e.g., the `staging-bot`) make use of
+* Several [systemd](systemd) units: the Metrics and OBS Operator tools make use of
   them.
 
 ## Tools

--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -336,11 +336,13 @@ Helps with OBS build cycles visualization. See the [openSUSE:Factory/standard ex
 * Sources: [osc-cycle.py](osc-cycle.py)
 * Documentation: --
 * Package: --
-* Usage: ???
+* Usage: used to debug problems. See https://github.com/openSUSE/openSUSE-release-tools/pull/992 as an example.
 
 #### compare_pkglist.py
 
-Compares packages status between two projects.
+Compares packages status between two projects. It determines which project has the newer version of a package,
+shows the diff, etc. Additionally, it is able to create a submit request from SOURCE to TARGET in case packages
+are different.
 
 * Sources: [compare_pkglist.py](compare_pkglist.py)
 * Documentation: --
@@ -354,7 +356,7 @@ Manages staging projects.
 * Sources: [osc-staging.py](osc-staging.py)
 * Documentation: [docs/staging.asciidoc](docs/staging.asciidoc) and [docs/testing.asciidoc](docs/testing.asciidoc)
 * Package: osc-plugin-staging
-* Usage: ???
+* Usage: staging projects management
 
 #### status.py
 
@@ -363,11 +365,15 @@ Checks the status of the staging workflow bots.
 * Sources: [status.py](status.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: ???
+* Usage: obsolete?
 
 #### fcc_submitter.py
 
-Creates SR from FactoryCandidates to openSUSE Leap project for new build succeded packages.
+The FactoryCandidates projects are used to determine whether a new package in Factory does build in
+the Leap version under development (see
+[openSUSE:Leap:15.2:FactoryCandidates](https://build.opensuse.org/project/show/openSUSE:Leap:15.2:FactoryCandidates)
+as example). This tool helps to manage this project by creating/updating project links for new
+packagers and creating SR from FactoryCandidates to the Leap project on successful builds.
 
 * Sources: [fcc_submitter.py](fcc_submitter.py)
 * Documentation: --
@@ -378,7 +384,6 @@ Creates SR from FactoryCandidates to openSUSE Leap project for new build succede
 
 Compares packages from a project against factory for differences in referenced issues and presents
 changes to allow whitelisting before creating Bugzilla entries.
-
 
 * Sources: [issue-diff.py](issue-diff.py)
 * Documentation: --
@@ -392,7 +397,7 @@ Clones projects and dependencies between OBS instances.
 * Sources: [obs_clone.py](obs_clone.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: ???
+* Usage: obsolete
 
 #### obs-operator
 
@@ -402,7 +407,7 @@ directly.
 * Sources: [obs_operator.py](obs_operator.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: ???
+* Usage: obsolete
 
 #### scan_baselibs.py
 
@@ -411,7 +416,7 @@ Verifies 32bit binaries were imported properly towards a project.
 * Sources: [scan_baselibs.py](scan_baselibs.py)
 * Documentation: --
 * Package: openSUSE-release-tools
-* Usage: ???
+* Usage: obsolete
 
 #### k8s-secret.py
 

--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -11,13 +11,13 @@ tools, including links to documentation, source code and some information about 
 
 Apart from these tools, the repository includes:
 
-* Some documenation in the [docs](docs) directory.
+* Some documentation in the [docs](docs) directory.
 * A Python module called [osclib](osclib) which includes code that is shared by several tools. They
   are available in the `osclib` package.
 * A Docker-based [tests suite](tests). The Docker manifests and the Docker Compose files are
   located in the [dist](dist) directory.
 * [GoCD](https://www.gocd.org) configuration files in [gocd](gocd). GoCD is an open source CI/CD
-  server that it is used to deploy the bots on OBS.
+  server that is used to deploy the bots on OBS.
 * A set of [Tampermonkey](https://www.tampermonkey.net) scripts (see [userscript](userscript)
   directory) to extend OBS features when using the web interface.
 * Several [systemd](systemd) units, as many of the tools (e.g., the `staging-bot`) make use of

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 This repository contains a set of tools to aid in the process of building, testing and releasing
 (open)SUSE based distributions and their corresponding maintenance updates. You can find more
-information in the [docs/processes.md](docs/processes.md). The [CONTENTS.md](CONTENTS.md) file
-contains a list of the tools that are included in the repository.
+information in [docs/processes.md](docs/processes.md). The [CONTENTS.md](CONTENTS.md) file contains
+a list of the tools that are included in the repository.
 
 ![Rethink release tooling presentation overview](docs/res/workflow-overview.svg)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 This repository contains a set of tools to aid in the process of building, testing and releasing
 (open)SUSE based distributions and their corresponding maintenance updates. You can find more
-information in the [docs/processes.md](docs/processes.md).
+information in the [docs/processes.md](docs/processes.md). The [CONTENTS.md](CONTENTS.md) file
+contains a list of the tools that are included in the repository.
 
 ![Rethink release tooling presentation overview](docs/res/workflow-overview.svg)
 


### PR DESCRIPTION
Extends the information [in the original inventory](https://github.com/openSUSE/openSUSE-release-tools/wiki/Inventory) and creates a document explaining the contents of the repository.

Beware that it is still a draft a quite some information is missing (and most probably wrong). So, please, feel free to correct or add the missing bits.

Thanks!