### PR TITLE
pkglistgen: Delete sources after creating the final solv files

### DIFF
--- a/pkglistgen/update_repo_handler.py
+++ b/pkglistgen/update_repo_handler.py
@@ -259,6 +259,13 @@ def update_project(apiurl, project):
 
         if os.path.exists(packages_file + '.xz'):
             print(path, 'already exists')
+
+            # Some old versions didn't do cleanup, do it now. Can be removed once everything was cleaned up
+            if not opts.get('refresh', False):
+                for file in glob.glob(os.path.join(repo_dir, '{}_*.packages.xz'.format(key))):
+                    os.unlink(file)
+                    package.delete_file(os.path.basename(file))
+
             continue
 
         solv_file = packages_file + '.solv'
@@ -286,5 +293,10 @@ def update_project(apiurl, project):
 
         package.addfile(os.path.basename(path + '.xz'))
         del pool
+
+        if not opts.get('refresh', False):
+            for file in glob.glob(os.path.join(repo_dir, '{}_*.packages.xz'.format(key))):
+                os.unlink(file)
+                package.delete_file(os.path.basename(file))
 
     package.commit('Automatic update')


### PR DESCRIPTION
When a project is switched from `refresh: true` to `refresh: false`, the
`15.1:update_123XXX.packages.xz` files are kept alongside the new "final"
`15.1:update.packages.xz`. However, the `update_and_solve` command looks at all
of those, which there can be a lot of, and takes a long time to look at
effectively redundant data.

With this commit, the old files will be deleted for projects with
`refresh: false` once the final solv file is created. This is also done for
already "finalized" projects in a separate block.

This is the first time I'm looking at this code, so I might be totally wrong here.
It looks like this is done manually for `openSUSE:Factory/000update-repos`
though.