### PR TITLE
gocd: increase the timer for fire Leap updaterepos every 3 days

### DIFF
--- a/gocd/pkglistgen.opensuse.gocd.yaml
+++ b/gocd/pkglistgen.opensuse.gocd.yaml
@@ -114,7 +114,7 @@ pipelines:
     environment_variables:
       OSC_CONFIG: /home/go/config/oscrc-staging-bot
     timer:
-      spec: 0 0 21 ? * *
+      spec: 0 0 0 */3 * *
       only_on_changes: false
     materials:
       git:

--- a/gocd/pkglistgen.opensuse.gocd.yaml.erb
+++ b/gocd/pkglistgen.opensuse.gocd.yaml.erb
@@ -89,7 +89,7 @@ pipelines:
     environment_variables:
       OSC_CONFIG: /home/go/config/oscrc-staging-bot
     timer:
-      spec: 0 0 21 ? * *
+      spec: 0 0 0 */3 * *
       only_on_changes: false
     materials:
       git:


### PR DESCRIPTION
Since Leap's ftp-tree takes more time to build, increase the timer for fire Leap updates repos every 3 days, otherwise a new change might trigger mediums rebuild then a rebuild counter sync following later.