### PR TITLE
gocd: Fix timer specification for Update.Repos.Leap

### DIFF
--- a/gocd/pkglistgen.opensuse.gocd.yaml
+++ b/gocd/pkglistgen.opensuse.gocd.yaml
@@ -114,7 +114,7 @@ pipelines:
     environment_variables:
       OSC_CONFIG: /home/go/config/oscrc-staging-bot
     timer:
-      spec: 0 0 0 */3 * *
+      spec: 0 0 0 */3 * ?
       only_on_changes: false
     materials:
       git:

--- a/gocd/pkglistgen.opensuse.gocd.yaml.erb
+++ b/gocd/pkglistgen.opensuse.gocd.yaml.erb
@@ -89,7 +89,7 @@ pipelines:
     environment_variables:
       OSC_CONFIG: /home/go/config/oscrc-staging-bot
     timer:
-      spec: 0 0 0 */3 * *
+      spec: 0 0 0 */3 * ?
       only_on_changes: false
     materials:
       git:


### PR DESCRIPTION
Currently everything is broken due to this error.

```
INVALID MERGED CONFIGURATION
Number of errors: 1+
1. Invalid cron syntax: Support for specifying both a day-of-week AND a day-of-month parameter is not implemented.;; 
- For Config Repo: https://github.com/openSUSE/openSUSE-release-tools.git at 0316d3b0d30e8a6df4b9652a1004e2ce4ed37fc5
```