### PR TITLE
Remove attributes in tests

### DIFF
--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -195,6 +195,7 @@ class StagingWorkflow(object):
         self.requests = []
         self.groups = []
         self.users = []
+        self.attributes = {}
         logging.basicConfig()
 
         # clear cache from other tests - otherwise the VCR is replayed depending
@@ -230,6 +231,10 @@ class StagingWorkflow(object):
         self.config = Config(APIURL, project)
 
     def create_attribute_type(self, namespace, name, values=None):
+        if not namespace in self.attributes: self.attributes[namespace] = []
+
+        if not name in self.attributes[namespace]: self.attributes[namespace].append(name)
+
         meta = """
         <namespace name='{}'>
             <modifiable_by user='Admin'/>
@@ -484,19 +489,55 @@ class StagingWorkflow(object):
 
     def remove(self):
         print('deleting staging workflow')
+
         for project in self.projects.values():
             project.remove()
         for request in self.requests:
             request.revoke()
         for group in self.groups:
-            url = osc.core.makeurl(APIURL, ['group', group])
-            try:
-                osc.core.http_DELETE(url)
-            except HTTPError:
-                pass
+            self.remove_group(group)
+        for namespace in self.attributes:
+            self.remove_attributes(namespace)
+
         print('done')
+
         if hasattr(self.api, '_invalidate_all'):
             self.api._invalidate_all()
+
+    def remove_group(self, group):
+        """Removes a group from the OBS instance
+
+        :param group: name of the group to remove
+        :type group: str
+        """
+        print('deleting group', group)
+        url = osc.core.makeurl(APIURL, ['group', group])
+        self._safe_delete(url)
+
+    def remove_attributes(self, namespace):
+        """Removes an attributes namespace and all the attributes it contains
+
+        :param namespace: attributes namespace to remove
+        :type namespace: str
+        """
+        for name in self.attributes[namespace]:
+            print('deleting attribute {}:{}'.format(namespace, name))
+            url = osc.core.makeurl(APIURL, ['attribute', namespace, name, '_meta'])
+            self._safe_delete(url)
+        print('deleting namespace', namespace)
+        url = osc.core.makeurl(APIURL, ['attribute', namespace, '_meta'])
+        self._safe_delete(url)
+
+    def _safe_delete(self, url):
+        """Performs a delete request to the OBS instance, ignoring possible http errors
+
+        :param url: url to use for the http delete request
+        :type url: str
+        """
+        try:
+            osc.core.http_DELETE(url)
+        except HTTPError:
+            pass
 
 class Project(object):
     """This class represents a project in the testing environment of the release tools. It usually

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -218,6 +218,8 @@ class StagingWorkflow(object):
         self.setup_remote_config()
         self.load_config()
         self.api = StagingAPI(APIURL, project)
+        # The ProductVersion is required for some actions, for example, when a request is accepted
+        self.create_attribute_type('OSRT', 'ProductVersion', 1)
 
     def load_config(self, project=None):
         """Loads the corresponding :class:`osclib.Config` object into the attribute ``config``

--- a/tests/factory_submit_request_test.py
+++ b/tests/factory_submit_request_test.py
@@ -93,8 +93,12 @@ class TestFactorySubmitRequest(OBSLocal.TestCase):
         # for the staging work
         self.assertReview(reqid, by_user=('factory-auto', 'accepted'))
         self.assertReview(reqid, by_user=('licensedigger', 'accepted'))
-        self.assertReview(reqid, by_group=('opensuse-review-team', 'new'))
+
+        # This review will be accepted when the Staging Manager puts it into a staging project
         self.assertReview(reqid, by_group=('factory-staging', 'new'))
+
+        # Review created by CheckSource bot. This review should be manually accepted.
+        self.assertReview(reqid, by_group=('opensuse-review-team', 'new'))
 
         # Let's first accept the manual review
         change_review_state(
@@ -108,7 +112,7 @@ class TestFactorySubmitRequest(OBSLocal.TestCase):
         self.assertReview(reqid, by_group=('opensuse-review-team', 'accepted'))
         self.assertReview(reqid, by_group=('factory-staging', 'new'))
 
-        # Let's put the request into the staging project
+        # The Staging Manager puts the request into a staging project
         SelectCommand(self.wf.api, STAGING_PROJECT_NAME).perform(['wine'])
 
         # The factory-staging review is now accepted and a new review associated to the
@@ -116,7 +120,7 @@ class TestFactorySubmitRequest(OBSLocal.TestCase):
         self.assertReview(reqid, by_group=('factory-staging', 'accepted'))
         self.assertReview(reqid, by_project=(STAGING_PROJECT_NAME, 'new'))
 
-        # Let's say everything looks good in the staging project and it can be accepted
+        # Let's say everything looks good in the staging project and the Staging Manager accepts it
         AcceptCommand(self.wf.api).accept_all([STAGING_PROJECT_NAME], True)
 
         # Finally, all the reviews are accepted: one for each bot, one for manual review and


### PR DESCRIPTION
## Problem

The *factory_submit_request_test* requires the attribute *ProducVersion* to exist. This is because accepting a submit request requires a *ProductVersion* to properly work. But the *factory_submit_request_test* does not fail even though it does not set a *ProductVersion* at all. This is because there are dependencies between tests.

The attributes like the *ProductVersion* are not deleted when a test finishes. So, *factory_submit_request_test* will work if a previous test creates a *ProductVersion* attribute. For example, if *accept_test* is executed before, then *factory_submit_tests* passes. Otherwise, it would fail.   


## Solution

Always ensure that a *ProductVersion* attribute is created in order to make possible other actions like accepting a submit request. And clean up all the attributes when a Staging Workflow is destroyed. This avoids dependencies between tests.
