### PR TITLE
Switch to pytest from nose

### DIFF
--- a/.noserc
+++ b/.noserc
@@ -1,2 +1,0 @@
-[nosetests]
-ignore-files=metrics_release\.py

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ install:
 check: test
 
 test:
-	# to see more add -v -d -s --nologcapture
-	$(wildcard /usr/bin/nosetests-2.*) -c .noserc
+	# to see more add -vv
+	/usr/bin/pytest
 
 package:
 	touch dist/package/$(package_name).changes

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ A facsimile of `openSUSE:Factory` in the form of a subset of the related data ca
 
 Some tests will attempt to run against the local OBS, but not all.
 
-    nosetests
+    pytest
 
 ## Running Continuous Integration
 

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -89,7 +89,7 @@ BuildArch:      noarch
 Requires:       libxml2-tools
 Requires:       python3-httpretty
 Requires:       python3-mock
-Requires:       python3-nose
+Requires:       python3-pytest
 
 %description devel
 Development requirements for openSUSE-release-tools to be used in conjunction

--- a/docs/testing.asciidoc
+++ b/docs/testing.asciidoc
@@ -4,12 +4,12 @@ Testing
 Dependencies
 ------------
 
-Test suite is using +nose+, +httpretty+ and +mock+ for testing. You need these
-three python modules installed to run tests. In openSUSE, you can do it using
-the following command as a root:
+Test suite is using +pytest+, +httpretty+ and +mock+ for testing. You need
+these three python modules installed to run tests. In openSUSE, you can do it
+using the following command as a root:
 
 --------------------------------------------------------------------------------
-zypper in python-nose python-httpretty python-mock
+zypper in python3-pytest python3-httpretty python3-mock
 --------------------------------------------------------------------------------
 
 Running tests
@@ -19,7 +19,7 @@ To run the tests, you need to be in the topmost directory of your checkout and
 run the following command there:
 
 --------------------------------------------------------------------------------
-nosetests
+pytest
 --------------------------------------------------------------------------------
 
 Structure of the suite

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files=tests/*.py


### PR DESCRIPTION
The nosetests test runner has not been touched upstream for years, and
is at best unmaintained. Switch from using it to using pytest. Also
change the docs to specify Python 3 modules.