### PR TITLE
Remove devel package and make check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,6 @@ install:
 	  $(DESTDIR)$(pkgdatadir)/metrics/grafana/provisioning/dashboards.yaml \
 	  $(DESTDIR)$(unitdir)/osrt-metrics-telegraf.service
 
-check: test
-
-test:
-	# to see more add -v -d -s --nologcapture
-	$(wildcard /usr/bin/nosetests-2.*) -c .noserc
-
 package:
 	touch dist/package/$(package_name).changes
 	tar -cJf dist/package/$(package_name)-0.tar.xz --exclude=.git* --exclude=dist/package/*.tar.xz --transform 's,^\.,$(package_name)-0,' .
@@ -45,4 +39,4 @@ package-clean:
 	rm -f dist/package/$(package_name).changes
 	rm -f dist/package/$(package_name).tar.xz
 
-.PHONY: all install test check
+.PHONY: all install

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -82,19 +82,6 @@ Tools to aid in staging and release work for openSUSE/SUSE
 The toolset consists of a variety of stand-alone scripts, review bots, osc
 plugins, and automation aids.
 
-%package devel
-Summary:        Development requirements for openSUSE-release-tools
-Group:          Development/Tools/Other
-BuildArch:      noarch
-Requires:       libxml2-tools
-Requires:       python3-httpretty
-Requires:       python3-mock
-Requires:       python3-nose
-
-%description devel
-Development requirements for openSUSE-release-tools to be used in conjunction
-with a git clone of the development repository available from %{url}.
-
 %package abichecker
 Summary:        ABI review bot
 Group:          Development/Tools/Other
@@ -448,11 +435,6 @@ exit 0
 %exclude %{_datadir}/%{source_dir}/findfileconflicts
 %exclude %{_datadir}/%{source_dir}/write_repo_susetags_file.pl
 %dir %{_sysconfdir}/openSUSE-release-tools
-
-%files devel
-%defattr(-,root,root,-)
-# Non-empty for older products.
-%doc README.md
 
 %files abichecker
 %defattr(-,root,root,-)


### PR DESCRIPTION
The devel package and the make check target are now dead code, with the
testsuite requiring other setup, which means using make is not going to
help.