### PR TITLE
miniobs: Use 15.3 repos - 15.1 is EOL

### DIFF
--- a/dist/ci/miniobs/Dockerfile
+++ b/dist/ci/miniobs/Dockerfile
@@ -1,7 +1,7 @@
 #!BuildTag: osrt_miniobs
-FROM opensuse/leap:15.1
+FROM opensuse/leap:15.3
 
-RUN zypper ar http://download.opensuse.org/repositories/OBS:/Server:/Unstable/openSUSE_15.1/ 'O:S:U'; \
+RUN zypper ar http://download.opensuse.org/repositories/OBS:/Server:/Unstable/openSUSE_15.3/ 'O:S:U'; \
     zypper --gpg-auto-import-keys refresh
 
 RUN zypper install -y obs-api obs-worker obs-server \


### PR DESCRIPTION
https://build.opensuse.org/package/show/home:coolo:branches:openSUSE:Tools:Images/osrt-miniobs-for-ci - as of writing this is still waiting for obs to finish in OSU