### PR TITLE
CI: Run Tumbleweed container as priveleged in docker

### DIFF
--- a/dist/ci/docker-compose.yml
+++ b/dist/ci/docker-compose.yml
@@ -7,6 +7,7 @@ x-testenv: &testenv
   image: registry.opensuse.org/opensuse/tools/images/containers_tumbleweed/osrt_testenv_tumbleweed:latest
   volumes:
     - "../..:/code"
+  privileged: true
 
 services:
   db:


### PR DESCRIPTION
This avoids the syscall filter breaking with new glibc