### PR TITLE
Change vagrant publisher resource to staging-bot

### DIFF
--- a/gocd/vagrant-publisher.gocd.yaml
+++ b/gocd/vagrant-publisher.gocd.yaml
@@ -15,7 +15,7 @@ pipelines:
     - Run:
         approval: manual
         resources:
-        - obs-to-vagrantcloud
+        - staging-bot
         tasks:
         - script: |
             ruby.ruby3.0 obs-to-vagrantcloud.rb --url https://download.opensuse.org/tumbleweed/appliances/boxes/Tumbleweed.x86_64.json --organization opensuse --new-box-name Tumbleweed.x86_64 --provider libvirt


### PR DESCRIPTION
resources cannot have arbitrary names, atm only the following are supported:
- monitor
- repo-checker
- staging-bot

=> use staging-bot as the publisher can take a while to run, but it will not run
   permanently so monitor is overkill