### PR TITLE
gocd: Run release package generation for stagings only once an hour

### DIFF
--- a/gocd/pkglistgen_staging.gocd.yaml
+++ b/gocd/pkglistgen_staging.gocd.yaml
@@ -6,7 +6,7 @@ pipelines:
     group: Factory.pkglistgen
     lock_behavior: unlockWhenFinished
     timer:
-      spec: 0 */10 * ? * *
+      spec: 0 0 * ? * *
       only_on_changes: false
     materials:
       scripts:

--- a/gocd/pkglistgen_staging.gocd.yaml.erb
+++ b/gocd/pkglistgen_staging.gocd.yaml.erb
@@ -6,7 +6,7 @@ pipelines:
     group: Factory.pkglistgen
     lock_behavior: unlockWhenFinished
     timer:
-      spec: 0 */10 * ? * *
+      spec: 0 0 * ? * *
       only_on_changes: false
     materials:
       scripts:

--- a/gocd/sle15sp4-stagings.gocd.yaml
+++ b/gocd/sle15sp4-stagings.gocd.yaml
@@ -7,7 +7,7 @@ pipelines:
     group: SLE15.SP4.Stagings
     lock_behavior: unlockWhenFinished
     timer:
-      spec: 0 */10 * ? * *
+      spec: 0 0 * ? * *
       only_on_changes: false
     materials:
       scripts:

--- a/gocd/sle15sp4-stagings.gocd.yaml.erb
+++ b/gocd/sle15sp4-stagings.gocd.yaml.erb
@@ -8,7 +8,7 @@ pipelines:
     group: SLE15.SP4.Stagings
     lock_behavior: unlockWhenFinished
     timer:
-      spec: 0 */10 * ? * *
+      spec: 0 0 * ? * *
       only_on_changes: false
     materials:
       scripts:


### PR DESCRIPTION
Running a job that runs 7 minutes every 10 minutes just doesn't scale
with all the projects that have been added lately