### PR TITLE
add option to use newest package for resolving dependencies

### DIFF
--- a/pkglistgen/tool.py
+++ b/pkglistgen/tool.py
@@ -225,7 +225,7 @@ class PkgListGen(ToolBase.ToolBase):
                     solvable.unset(solv.SOLVABLE_CONFLICTS)
                     solvable.unset(solv.SOLVABLE_OBSOLETES)
                 # only take the first solvable in the repo chain
-                if solvable.name in solvables:
+                if not self.use_newest_version and solvable.name in solvables:
                     self.lockjobs[arch].append(pool.Job(solv.Job.SOLVER_SOLVABLE | solv.Job.SOLVER_LOCK, solvable.id))
                 solvables.add(solvable.name)
 
@@ -575,6 +575,7 @@ class PkgListGen(ToolBase.ToolBase):
                                 project, scope, force, no_checkout,
                                 only_release_packages, stop_after_solve):
         self.all_architectures = target_config.get('pkglistgen-archs').split(' ')
+        self.use_newest_version = str2bool(target_config.get('pkglistgen-use-newest-version', 'False'))
         self.repos = self.expand_repos(project, main_repo)
         print('[{}] {}/{}: update and solve'.format(scope, project, main_repo))
 


### PR DESCRIPTION
In some cases we'd like to chose from all available repositories
for selecting the right package. in appliance builds and there
is an OBS-UseUnorderedRepos flag for enabling this behavior. Similarly
product-builds have a flag "use_newest_version" that can be set
to true. pkglistgen needs to know about these variant as well
to properly resolve package dependencies.