### PR TITLE
Fix handling missing log files

### DIFF
--- a/metrics/access/aggregate.php
+++ b/metrics/access/aggregate.php
@@ -22,12 +22,14 @@ $source_map = [
     '2014-04-14' => sprintf(LANGLEY, 2) . '/' . VHOST,
     '2017-12-04' => sprintf(LANGLEY, 3) . '/' . VHOST,
     // 2017-12-05 has bad permissions on langley and is still on origin.
+    '2021-09-05' => false,
     $begin->format('Y-m-d') => PONTIFEX . '/' . VHOST,
     'filename' => FILENAME,
   ],
   'ipv6' => [
     '2012-12-31' => false,
     '2017-12-04' => sprintf(LANGLEY, 3) . '/' . IPV6_PREFIX . VHOST,
+    '2021-09-05' => false,
     $begin->format('Y-m-d') => PONTIFEX . '/' . IPV6_PREFIX . VHOST,
     'filename' => IPV6_PREFIX . FILENAME,
   ],
@@ -408,8 +410,6 @@ function write($points)
 
   if (!$database) {
     $database = InfluxDB\Client::fromDSN('influxdb://0.0.0.0:8086/osrt_access');
-    $database->drop();
-    $database->create();
   }
 
   if (!$database->writePoints($points, Database::PRECISION_SECONDS)) die('failed to write points');

--- a/metrics/access/aggregate.php
+++ b/metrics/access/aggregate.php
@@ -164,7 +164,7 @@ function aggregate_all($period)
     $data = null;
     foreach (PROTOCOLS as $protocol) {
       $cache_file = "$CACHE_DIR/$protocol/$date_string.json";
-      if (!file_exists($cache_file)) continue;
+      if (!file_exists($cache_file) or !filesize($cache_file)) continue;
 
       error_log("[$date_string] [$protocol] load cache");
       $data_new = json_decode(file_get_contents($cache_file), true);

--- a/metrics/access/ingest.php
+++ b/metrics/access/ingest.php
@@ -61,11 +61,13 @@ error_log('found ' . number_format($total) . ' requests across ' .
 
 ksort($total_product);
 ksort($unique_product);
-echo json_encode([
-  'total' => $total,
-  'total_product' => $total_product,
-  'unique_product' => $unique_product,
-  'total_image_product' => $total_image_product,
-  'total_invalid' => $total_invalid,
-  'bytes' => $position,
-]) . "\n"; // JSON_PRETTY_PRINT for debugging.
+if ($position) {
+  echo json_encode([
+    'total' => $total,
+    'total_product' => $total_product,
+    'unique_product' => $unique_product,
+    'total_image_product' => $total_image_product,
+    'total_invalid' => $total_invalid,
+    'bytes' => $position,
+  ]) . "\n"; // JSON_PRETTY_PRINT for debugging.
+}


### PR DESCRIPTION
The logs before 2021-09-05 are not available anymore.
The change takes account of it and skips parsing older logs.
Additionally, the database is not dropped on every run.