### PR TITLE
metrics: telegraf: Fix URL for openqa.opensuse.org after machines were moved to openSUSE internal network

### DIFF
--- a/metrics/telegraf/openqa.conf
+++ b/metrics/telegraf/openqa.conf
@@ -1,4 +1,4 @@
 [[inputs.http]]
-  urls = ["https://openqa.opensuse.org/admin/influxdb/jobs"]
+  urls = ["http://openqa.opensuse.org/admin/influxdb/jobs"]
   data_format = "influx"
 


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/102975