### PR TITLE
skippkg-finder: add a supplement list for adding package to the skiplist

### DIFF
--- a/skippkg-finder.py
+++ b/skippkg-finder.py
@@ -42,6 +42,11 @@ class SkippkgFinder(object):
         # SUSE:SLE-15:Update_libcdio.12032, PROJECT-NAME_PACKAGE-NAME
         self.skiplist_ignored = set(config.get('skippkg-finder-skiplist-ignores', '').split(' '))
 
+        # supplement RPMs for skipping from the ftp-tree
+        self.skiplist_supplement_regex = set(config.get('skippkg-finder-skiplist-supplement-regex', '').split(' '))
+        # drops off RPM from a list of the supplement RPMs due to regex
+        self.skiplist_supplement_ignores = set(config.get('skippkg-finder-skiplist-supplement-ignores', '').split(' '))
+
     def is_sle_specific(self, package):
         """
         Return True if package is provided for SLE only or a SLE forking.
@@ -310,6 +315,13 @@ class SkippkgFinder(object):
                 main_filename = re.sub('-[36][24]bit', '', pkg)
                 if main_filename not in obsoleted:
                     obsoleted.remove(pkg)
+
+        for regex in self.skiplist_supplement_regex:
+            for binary in fullbinarylist:
+                result = re.match(regex, binary)
+                if result and binary not in obsoleted and\
+                        binary not in self.skiplist_supplement_ignores:
+                    obsoleted.append(binary)
 
         skip_list = ET.Element('group', {'name': 'NON_FTP_PACKAGES'})
         ET.SubElement(skip_list, 'conditional', {'name': 'drop_from_ftp'})


### PR DESCRIPTION
For the purpose of adding some package(RPM) to the skiplist, there are two option has introduced, skiplist_supplement_regex for adding package if it has matched with the regex, skiplist_supplement_ignores in order to free package from the regex rule.

A major purpose of this change is about drops off python2 base stuff from the ftp-tree, the first verification run has been done, the attribute has been updated for that, see OSRT:Config at https://build.opensuse.org/attribs/openSUSE:Leap:15.4