### PR TITLE
factory-package-news.py: Don't rely on changelogtime equality

### DIFF
--- a/factory-package-news/factory-package-news.py
+++ b/factory-package-news/factory-package-news.py
@@ -252,7 +252,7 @@ class ChangeLogger(cmdln.Cmdln):
             if len(pkgs) > 1:
                 details += "Subpackages: %s\n" % " ".join([p for p in pkgs if p != name])
             for (i2, t2) in enumerate(v2changelogs[srpm]['changelogtime']):
-                if t2 == t1:
+                if t2 <= t1:
                     break
                 details += "\n" + v2changelogs[srpm]['changelogtext'][i2]
             details += '\n'


### PR DESCRIPTION
Use an inequality check instead. That way if there's no full match (like
caused by https://github.com/openSUSE/obs-build/issues/768), it doesn't fall
back to printing the whole changelog.