### PR TITLE
Check whether the FTP trees contain OSRT:ProductVersion before releasing

### DIFF
--- a/ttm/manager.py
+++ b/ttm/manager.py
@@ -124,6 +124,9 @@ class ToTestManager(ToolBase.ToolBase):
     def get_status(self, status):
         return self.get_status_dict().get(status)
 
+    def get_product_version(self):
+        return self.api.attribute_value_load('ProductVersion')
+
     def release_package(self, project, package, set_release=None, repository=None,
                          target_project=None, target_repository=None):
         query = {'cmd': 'release'}

--- a/ttm/releaser.py
+++ b/ttm/releaser.py
@@ -229,6 +229,17 @@ class ToTestReleaser(ToTestManager):
                                            self.project.product_repo, arch):
                         return False
 
+        # The FTP tree isn't released with setrelease, so it needs to contain
+        # the product version already.
+        product_version = self.get_product_version()
+        if product_version is not None:
+            for product in self.project.ftp_products:
+                for binary in self.binaries_of_product(self.project.name, product):
+                    # The NonOSS tree doesn't include the version...
+                    if binary.endswith('.report') and 'NonOss' not in binary and product_version not in binary:
+                        self.logger.debug(f'{binary} in {product} does not include {product_version}')
+                        return False
+
         if self.project.need_same_build_number:
             # make sure all medias have the same build number
             builds = set()


### PR DESCRIPTION
Otherwise it might release a build which uses the wrong version.