### PR TITLE
Include :Staging in :adi images and containerfile repo paths

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1397,6 +1397,7 @@ class StagingAPI(object):
                <repository name="images">
                  <path project="{name}" repository="standard"/>
                  {containerfile_path}
+                 <path project="{self.cstaging}" repository="standard"/>
                  <path project="{self.project}" repository="images"/>
                  <arch>x86_64</arch>
               </repository>"""
@@ -1411,6 +1412,7 @@ class StagingAPI(object):
                <repository name="containerfile">
                  <path project="{name}" repository="standard"/>
                  {images_path}
+                 <path project="{self.cstaging}" repository="standard"/>
                  <path project="{self.project}" repository="containerfile"/>
                  <arch>x86_64</arch>
               </repository>"""


### PR DESCRIPTION
Those repos have to build against :Staging as well to get the prjconf.

Tested with https://build.opensuse.org/package/show/openSUSE:Factory:Staging:adi:62/opensuse-memcached-image