### PR TITLE
Remove --by-develproject for adi command

### DIFF
--- a/gocd/checkers.suse.gocd.yaml
+++ b/gocd/checkers.suse.gocd.yaml
@@ -131,7 +131,6 @@ pipelines:
 
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP4:GA rebuild
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP4:GA list --supersede
-               osc -A https://api.suse.de staging -p SUSE:SLE-15-SP4:GA adi --by-develproject
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP4:GA select --non-interactive --merge --try-strategies
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP4:GA unselect --cleanup
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP4:GA repair --cleanup
@@ -165,7 +164,6 @@ pipelines:
 
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP3:Update:Products:MicroOS52 rebuild
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP3:Update:Products:MicroOS52 list --supersede
-               osc -A https://api.suse.de staging -p SUSE:SLE-15-SP3:Update:Products:MicroOS52 adi --by-develproject
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP3:Update:Products:MicroOS52 select --non-interactive --merge --try-strategies
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP3:Update:Products:MicroOS52 unselect --cleanup
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP3:Update:Products:MicroOS52 repair --cleanup

--- a/gocd/checkers.suse.gocd.yaml.erb
+++ b/gocd/checkers.suse.gocd.yaml.erb
@@ -131,7 +131,6 @@ pipelines:
 
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP4:GA rebuild
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP4:GA list --supersede
-               osc -A https://api.suse.de staging -p SUSE:SLE-15-SP4:GA adi --by-develproject
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP4:GA select --non-interactive --merge --try-strategies
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP4:GA unselect --cleanup
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP4:GA repair --cleanup
@@ -165,7 +164,6 @@ pipelines:
 
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP3:Update:Products:MicroOS52 rebuild
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP3:Update:Products:MicroOS52 list --supersede
-               osc -A https://api.suse.de staging -p SUSE:SLE-15-SP3:Update:Products:MicroOS52 adi --by-develproject
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP3:Update:Products:MicroOS52 select --non-interactive --merge --try-strategies
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP3:Update:Products:MicroOS52 unselect --cleanup
                osc -A https://api.suse.de staging -p SUSE:SLE-15-SP3:Update:Products:MicroOS52 repair --cleanup

--- a/gocd/staging.bot.gocd.yaml
+++ b/gocd/staging.bot.gocd.yaml
@@ -52,7 +52,7 @@ pipelines:
                export HOME=$tempdir
 
                osc -A https://api.opensuse.org staging -p openSUSE:Factory list --supersede
-               osc -A https://api.opensuse.org staging -p openSUSE:Factory adi --by-develproject
+               osc -A https://api.opensuse.org staging -p openSUSE:Factory adi
                osc -A https://api.opensuse.org staging -p openSUSE:Factory unselect --cleanup
                osc -A https://api.opensuse.org staging -p openSUSE:Factory repair --cleanup
                rm -rf $tempdir
@@ -108,7 +108,7 @@ pipelines:
                export HOME=$tempdir
 
                osc -A https://api.opensuse.org staging -p openSUSE:Backports:SLE-15-SP4 list --supersede
-               osc -A https://api.opensuse.org staging -p openSUSE:Backports:SLE-15-SP4 adi --by-develproject
+               osc -A https://api.opensuse.org staging -p openSUSE:Backports:SLE-15-SP4 adi
                osc -A https://api.opensuse.org staging -p openSUSE:Backports:SLE-15-SP4 unselect --cleanup
                osc -A https://api.opensuse.org staging -p openSUSE:Backports:SLE-15-SP4 repair --cleanup
                rm -rf $tempdir

--- a/gocd/staging.bot.gocd.yaml.erb
+++ b/gocd/staging.bot.gocd.yaml.erb
@@ -54,7 +54,7 @@ pipelines:
                export HOME=$tempdir
 
                osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> list --supersede
-               osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> adi --by-develproject
+               osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> adi
                osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> unselect --cleanup
                osc -A https://api.opensuse.org staging -p openSUSE:<%= project %> repair --cleanup
                rm -rf $tempdir

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -86,8 +86,6 @@ def clean_args(args):
 
 @cmdln.option('--move', action='store_true',
               help='force the selection to become a move')
-@cmdln.option('--by-develproject', action='store_true',
-              help='split the requests by devel project')
 @cmdln.option('--split', action='store_true',
               help='split the requests into individual groups')
 @cmdln.option('--supersede', action='store_true',
@@ -297,7 +295,7 @@ def do_staging(self, subcmd, opts, *args):
 
     Usage:
         osc staging accept [--force] [--no-cleanup] [STAGING...]
-        osc staging adi [--move] [--by-develproject] [--split] [REQUEST...]
+        osc staging adi [--move] [--split] [REQUEST...]
         osc staging check [STAGING...]
         osc staging check_duplicate_binaries
         osc staging check_local_links
@@ -583,7 +581,7 @@ def do_staging(self, subcmd, opts, *args):
         elif cmd == 'lock':
             lock.hold(opts.message)
         elif cmd == 'adi':
-            AdiCommand(api).perform(args[1:], move=opts.move, by_dp=opts.by_develproject, split=opts.split)
+            AdiCommand(api).perform(args[1:], move=opts.move, split=opts.split)
         elif cmd == 'rebuild':
             RebuildCommand(api).perform(args[1:], opts.force)
         elif cmd == 'repair':

--- a/osclib/adi_command.py
+++ b/osclib/adi_command.py
@@ -4,15 +4,11 @@ from urllib.error import HTTPError
 from colorama import Fore
 
 from osc import oscerr
-from osc.core import get_request
-from osc.core import show_package_meta
 from osc import conf
 
-from osclib.select_command import SelectCommand
 from osclib.supersede_command import SupersedeCommand
 from osclib.request_finder import RequestFinder
 from osclib.request_splitter import RequestSplitter
-from xml.etree import cElementTree as ET
 
 class AdiCommand:
     def __init__(self, api):
@@ -73,7 +69,7 @@ class AdiCommand:
         for p in self.api.get_adi_projects():
             self.check_adi_project(p)
 
-    def create_new_adi(self, wanted_requests, by_dp=False, split=False):
+    def create_new_adi(self, wanted_requests, split=False):
         source_projects_expand = self.config.get('source_projects_expand', '').split()
         # if we don't call it, there is no invalidate function added
         requests = self.api.get_open_requests()
@@ -91,8 +87,6 @@ class AdiCommand:
         else:
             if split:
                 splitter.group_by('./@id')
-            elif by_dp:
-                splitter.group_by('./action/target/@devel_project')
             else:
                 splitter.group_by('./action/source/@project')
 
@@ -130,7 +124,7 @@ class AdiCommand:
 
                 print(line + Fore.GREEN + ' (staged in {})'.format(name) + Fore.RESET)
 
-    def perform(self, packages, move=False, by_dp=False, split=False):
+    def perform(self, packages, move=False, split=False):
         """
         Perform the list command
         """
@@ -152,4 +146,4 @@ class AdiCommand:
         else:
             self.check_adi_projects()
             if self.api.is_user_member_of(self.api.user, self.api.cstaging_group):
-                self.create_new_adi((), by_dp=by_dp, split=split)
+                self.create_new_adi((), split=split)


### PR DESCRIPTION
It's pointless by now as we have no project that uses devel projects
and would accept submissions not coming from there

Fixes #1366 (kindof)