### PR TITLE
Fix output of staging reviews

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -776,9 +776,9 @@ class StagingAPI(object):
         if review.get('by_user'):
             return review.get('by_user')
         if review.get('by_package'):
-            return '{}/{}'.format(review.get('by_project'), review.get('by_package'))
+            return 'package:{}'.format(review.get('by_package'))
         if review.get('by_project'):
-            return review.get('by_project')
+            return 'project:{}'.format(review.get('by_project'))
         raise oscerr.WrongArgs('Invalid review')
 
     def job_history_fail_count(self, history):


### PR DESCRIPTION
The staging status doesn't provide the by_project and it's not
really important here, so simplify

Before:
adi:39 review: None/ekiga for ekiga[955924]

After:
adi:39 review: package:ekiga for ekiga[955924]