### PR TITLE
skippkg_finder: fix unconditional matches if the first regex element is space

### DIFF
--- a/skippkg-finder.py
+++ b/skippkg-finder.py
@@ -313,6 +313,9 @@ class SkippkgFinder(object):
                     obsoleted.remove(pkg)
 
         for regex in self.skiplist_supplement_regex:
+            # exit if it has no regex defined
+            if not regex:
+                break
             for binary in fullbinarylist:
                 result = re.match(regex, binary)
                 if result and binary not in obsoleted and\


### PR DESCRIPTION
In case regex list has not been defined any value, the first element will be space only, this causes unconditional matched any binary name. Exit the for loop if the first element is space only.