### PR TITLE
Make frozenage less reliant on changing _frozenlinks

### DIFF
--- a/dist/obs/OSRT:FreezeTime.xml
+++ b/dist/obs/OSRT:FreezeTime.xml
@@ -1,0 +1,5 @@
+<definition name="FreezeTime" namespace="OSRT">
+  <description>Date and time of the last call of freeze (updating _frozenlinks)</description>
+  <count>1</count>
+  <modifiable_by role="maintainer"/>
+</definition>

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -1,9 +1,9 @@
 from collections import namedtuple
-from datetime import datetime
-from datetime import timezone
+from datetime import datetime, timezone
 from dateutil.parser import parse as date_parse
 import re
 import socket
+import logging
 from lxml import etree as ET
 from urllib.error import HTTPError
 
@@ -452,7 +452,12 @@ def attribute_value_save(apiurl, project, name, value, namespace='OSRT', package
 
     # The OBS API of attributes is super strange, POST to update.
     url = makeurl(apiurl, list(filter(None, ['source', project, package, '_attribute'])))
-    http_POST(url, data=ET.tostring(root))
+    try:
+        http_POST(url, data=ET.tostring(root))
+    except HTTPError as e:
+        if e.code == 404:
+            logging.error(f"Saving attribute {namespace}:{name} to {project} failed. You may need to create the type on your instance.")
+        raise e
 
 
 def attribute_value_delete(apiurl, project, name, namespace='OSRT', package=None):

--- a/osclib/freeze_command.py
+++ b/osclib/freeze_command.py
@@ -1,7 +1,9 @@
 import time
+from datetime import datetime, timezone
 from urllib.error import HTTPError
 from lxml import etree as ET
 import osc.core
+from osclib.core import attribute_value_save
 
 MAX_FROZEN_AGE = 6.5
 
@@ -197,6 +199,7 @@ class FreezeCommand(object):
 
         url = self.api.makeurl(['source', self.prj, '_project', '_frozenlinks'], {'meta': '1'})
         self.api.retried_PUT(url, ET.tostring(flink))
+        attribute_value_save(self.api.apiurl, self.prj, 'FreezeTime', datetime.now(timezone.utc).isoformat())
 
     def receive_sources(self, prj, sources, flink):
         url = self.api.makeurl(['source', prj], {'view': 'info', 'nofilename': '1'})

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -879,6 +879,12 @@ class StagingAPI(object):
         :param project: project to check
         :return age in days(float) of the last update
         """
+        freezetime = attribute_value_load(self.apiurl, project, 'FreezeTime')
+        if freezetime:
+            freezetime = datetime.fromisoformat(freezetime)
+            tz_info = freezetime.tzinfo
+            return (datetime.now(tz_info) - freezetime).total_seconds() / 3600 / 24
+        # fallback: old method
         root = ET.fromstring(self._fetch_project_meta(project))
         for entry in root.findall('entry'):
             if entry.get('name') == '_frozenlinks':

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -885,7 +885,8 @@ class StagingAPI(object):
             tz_info = freezetime.tzinfo
             return (datetime.now(tz_info) - freezetime).total_seconds() / 3600 / 24
         # fallback: old method
-        root = ET.fromstring(self._fetch_project_meta(project))
+        url = self.makeurl(['source', project, '_project'], {'meta': '1'})
+        root = ET.parse(http_GET(url))
         for entry in root.findall('entry'):
             if entry.get('name') == '_frozenlinks':
                 return (time.time() - float(entry.get('mtime'))) / 3600 / 24

--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -382,6 +382,7 @@ class StagingWorkflow(ABC):
         # First ensure the existence of both the target project and the 'Config' attribute type
         self.create_target()
         self.create_attribute_type('OSRT', 'Config', 1)
+        self.create_attribute_type('OSRT', 'FreezeTime', 1)
 
         self.remote_config_set(self.initial_config(), replace_all=True)
 


### PR DESCRIPTION
The mtime of a file in OBS is the time this content was created for the first time. As such if the target project isn't moving for a week, staging select will keep asking you to freeze - even if you just froze.

So instead of relying on OBS to tell the true mtime, set an attribute in the staging project and read from it. This also gives a way to check in the webui for the last freeze time

Fixes #2462