### PR TITLE
pkglistgen: Deprecate scope 'all'

### DIFF
--- a/gocd/pkglistgen.opensuse.gocd.yaml
+++ b/gocd/pkglistgen.opensuse.gocd.yaml
@@ -49,22 +49,22 @@ pipelines:
             - repo-checker
             tasks:
               - script: |
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:PowerPC --only-release-packages
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:PowerPC
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:PowerPC -s target --only-release-packages
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:PowerPC -s target
           openSUSE_Factory_zSystems:
             resources:
             - repo-checker
             tasks:
               - script: |
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:zSystems --only-release-packages
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:zSystems
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:zSystems -s target --only-release-packages
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:zSystems -s target
           openSUSE_Factory_RISCV:
             resources:
             - repo-checker
             tasks:
               - script: |
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:RISCV --only-release-packages
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:RISCV
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:RISCV -s target --only-release-packages
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:RISCV -s target
   Update.Repos.Factory:
     group: Factory.pkglistgen
     lock_behavior: unlockWhenFinished

--- a/gocd/pkglistgen.opensuse.gocd.yaml.erb
+++ b/gocd/pkglistgen.opensuse.gocd.yaml.erb
@@ -22,6 +22,8 @@ pipelines:
   if project.size > 1
     options=" -s #{project[1]}"
     name = name + "_#{project[1]}"
+  else
+    options=" -s target"
   end
   -%>
           <%= name %>:

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -94,7 +94,6 @@ DEFAULT = {
         # No special packages since they will pass through SLE first.
         'splitter-special-packages': '',
         'pkglistgen-archs': 'x86_64',
-        'pkglistgen-scopes': 'target rings staging',
         'pkglistgen-locales-from': 'openSUSE.product',
         'pkglistgen-delete-kiwis-rings': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
         'pkglistgen-delete-kiwis-staging': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
@@ -144,18 +143,6 @@ DEFAULT = {
         # SLE projects cannot be processed since the repo cannot be mirrored.
         'repo_checker-project-skip': 'True',
         '_priority': '101',
-    },
-    r'openSUSE:(?P<project>Jump:(?P<version>[\d.]+))$': {
-        'product': 'openSUSE.product',
-        'openqa': 'https://openqa.opensuse.org',
-        'lock-ns': 'openSUSE',
-        'main-repo': 'standard',
-        'pseudometa_package': 'openSUSE:%(project)s:Staging/dashboard',
-        'download-baseurl': 'http://download.opensuse.org/distribution/leap/%(version)s/',
-        'download-baseurl-update': 'http://download.opensuse.org/update/leap/%(version)s/',
-        'pkglistgen-archs': 'x86_64 aarch64 ppc64le s390x',
-        'pkglistgen-scopes': 'target',
-        'pkglistgen-locales-from': 'openSUSE.product',
     },
     # Allows devel projects to utilize tools that require config, but not
     # complete StagingAPI support.

--- a/pkglistgen/cli.py
+++ b/pkglistgen/cli.py
@@ -5,6 +5,8 @@
 import cmdln
 import os
 import re
+
+from outcome import Value
 import ToolBase
 import traceback
 import logging
@@ -17,7 +19,7 @@ from pkglistgen.update_repo_handler import update_project
 
 
 class CommandLineInterface(ToolBase.CommandLineInterface):
-    SCOPES = ['all', 'target', 'rings', 'staging']
+    SCOPES = ['target', 'rings', 'staging']
 
     def __init__(self, *args, **kwargs):
         ToolBase.CommandLineInterface.__init__(self, args, kwargs)
@@ -64,8 +66,9 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
             opts.project = match.group(1)
         elif not opts.project:
             raise ValueError('project is required')
-        elif not opts.scope:
-            opts.scope = ['all']
+
+        if not opts.scope:
+            raise Value('--scope or --staging required')
 
         apiurl = conf.config['apiurl']
         Config(apiurl, opts.project)
@@ -84,10 +87,6 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
             os.environ['OBS_NAME'] = 'build.suse.de'
         if apiurl.find('opensuse.org') > 0:
             os.environ['OBS_NAME'] = 'build.opensuse.org'
-
-        # special case for all
-        if opts.scope == ['all']:
-            opts.scope = target_config.get('pkglistgen-scopes', 'target').split(' ')
 
         self.error_occured = False
 


### PR DESCRIPTION
Within gocd we run each job on its own worker and don't rely on builtin loop. So no need to care for a remote config