### PR TITLE
staging-installcheck: Don't exit 1 if there is a problem found

### DIFF
--- a/staging-installcheck.py
+++ b/staging-installcheck.py
@@ -379,4 +379,4 @@ if __name__ == '__main__':
                 result = staging_report.staging(staging) and result
 
     if not result:
-        sys.exit(1)
+        logging.error("Found problem")


### PR DESCRIPTION
The installcheck did it's job, so exit 1 is just a wrong red flag on the
botmaster dashboard