### PR TITLE
pkglistgen: Only solve one project at a time

### DIFF
--- a/gocd/pkglistgen.opensuse.gocd.yaml
+++ b/gocd/pkglistgen.opensuse.gocd.yaml
@@ -23,13 +23,13 @@ pipelines:
               - script: |
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s target --only-release-packages
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s target
-          openSUSE_Factory_rings:
+          openSUSE_Factory_ring1:
             resources:
             - repo-checker
             tasks:
               - script: |
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s rings --only-release-packages
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s rings
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s ring1 --only-release-packages
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s ring1
           openSUSE_Factory_ARM_target:
             resources:
             - repo-checker
@@ -37,13 +37,13 @@ pipelines:
               - script: |
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s target --only-release-packages
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s target
-          openSUSE_Factory_ARM_rings:
+          openSUSE_Factory_ARM_ring1:
             resources:
             - repo-checker
             tasks:
               - script: |
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s rings --only-release-packages
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s rings
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s ring1 --only-release-packages
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s ring1
           openSUSE_Factory_PowerPC:
             resources:
             - repo-checker

--- a/gocd/pkglistgen.opensuse.gocd.yaml.erb
+++ b/gocd/pkglistgen.opensuse.gocd.yaml.erb
@@ -16,7 +16,7 @@ pipelines:
         approval:
           type: manual
         jobs:
-<% ['openSUSE:Factory/target', 'openSUSE:Factory/rings', 'openSUSE:Factory:ARM/target', 'openSUSE:Factory:ARM/rings', 'openSUSE:Factory:PowerPC', 'openSUSE:Factory:zSystems', 'openSUSE:Factory:RISCV'].each do |project|
+<% ['openSUSE:Factory/target', 'openSUSE:Factory/ring1', 'openSUSE:Factory:ARM/target', 'openSUSE:Factory:ARM/ring1', 'openSUSE:Factory:PowerPC', 'openSUSE:Factory:zSystems', 'openSUSE:Factory:RISCV'].each do |project|
   project=project.split('/')
   name=project[0].gsub(':', '_')
   if project.size > 1


### PR DESCRIPTION
As we deprecated 'all' we can just as well rely on only one project
given (which is also what we do in gocd) to ease error reporting.

The old method of running all projects in a loop stemed from the
old pkglistgen not having a scheduler so we relied on serial execution.