### PR TITLE
gocd: Fix rare failure to push to notifications repo

### DIFF
--- a/gocd/notify-obs_rsync.py
+++ b/gocd/notify-obs_rsync.py
@@ -58,6 +58,11 @@ if __name__ == '__main__':
 
     openqa = OpenQA_Client(server=args.openqa)
 
+    # make sure we avoid a race between gocd polling the notifications repo and
+    # scheduling a notify job because of other changes. In that case gocd schedules
+    # a new job on outdated notifications repo and we can't push
+    subprocess.run(f'cd {args.to} && git pull')
+
     interesting_repos = dict()
     list = openqa.openqa_request('GET', 'obs_rsync')
     for repopair in list:


### PR DESCRIPTION
These failures are healed automatically, so it's purely to avoid
extra mails for breaking pipelines