### PR TITLE
gocd: Create release packages as early as possible

### DIFF
--- a/gocd/pkglistgen.opensuse.gocd.yaml
+++ b/gocd/pkglistgen.opensuse.gocd.yaml
@@ -21,49 +21,49 @@ pipelines:
             - repo-checker
             tasks:
               - script: |
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s target --only-release-packages
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s target --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s target
           openSUSE_Factory_ring1:
             resources:
             - repo-checker
             tasks:
               - script: |
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s ring1 --only-release-packages
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s ring1 --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s ring1
           openSUSE_Factory_ARM_target:
             resources:
             - repo-checker
             tasks:
               - script: |
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s target --only-release-packages
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s target --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s target
           openSUSE_Factory_ARM_ring1:
             resources:
             - repo-checker
             tasks:
               - script: |
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s ring1 --only-release-packages
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s ring1 --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s ring1
           openSUSE_Factory_PowerPC:
             resources:
             - repo-checker
             tasks:
               - script: |
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:PowerPC -s target --only-release-packages
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:PowerPC -s target --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:PowerPC -s target
           openSUSE_Factory_zSystems:
             resources:
             - repo-checker
             tasks:
               - script: |
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:zSystems -s target --only-release-packages
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:zSystems -s target --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:zSystems -s target
           openSUSE_Factory_RISCV:
             resources:
             - repo-checker
             tasks:
               - script: |
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:RISCV -s target --only-release-packages
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:RISCV -s target --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:RISCV -s target
   Update.Repos.Factory:
     group: Factory.pkglistgen

--- a/gocd/pkglistgen.opensuse.gocd.yaml.erb
+++ b/gocd/pkglistgen.opensuse.gocd.yaml.erb
@@ -31,7 +31,7 @@ pipelines:
             - repo-checker
             tasks:
               - script: |
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p <%= project[0] %><%= options %> --only-release-packages
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p <%= project[0] %><%= options %> --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p <%= project[0] %><%= options %>
 <% end -%>
   Update.Repos.Factory:


### PR DESCRIPTION
There is no reason to wait for the rest to build to generate release
packages, they don't depend on other packages