### PR TITLE
Rename the pkglistgen config for ring1 as well

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -95,7 +95,7 @@ DEFAULT = {
         'splitter-special-packages': '',
         'pkglistgen-archs': 'x86_64',
         'pkglistgen-locales-from': 'openSUSE.product',
-        'pkglistgen-delete-kiwis-rings': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
+        'pkglistgen-delete-kiwis-ring1': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
         'pkglistgen-delete-kiwis-staging': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
         'mail-list': 'factory@lists.opensuse.org',
         'mail-maintainer': 'Ludwig Nussel <ludwig.nussel@suse.de>',


### PR DESCRIPTION
It's a little suprising fallout from 1870e989a4d7a1f846dc06895402dc1395b34c11,
but we don't have package lists in "rings" anymore, but only in one
ring.