### PR TITLE
Disable images repo on accepting stagings

### DIFF
--- a/gocd/pkglistgen_staging.gocd.yaml
+++ b/gocd/pkglistgen_staging.gocd.yaml
@@ -187,6 +187,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.B":
     environment_variables:
@@ -247,6 +252,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.C":
     environment_variables:
@@ -307,6 +317,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.D":
     environment_variables:
@@ -367,6 +382,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.E":
     environment_variables:
@@ -427,6 +447,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.F":
     environment_variables:
@@ -487,6 +512,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.G":
     environment_variables:
@@ -547,6 +577,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.H":
     environment_variables:
@@ -607,6 +642,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.I":
     environment_variables:
@@ -667,6 +707,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.J":
     environment_variables:
@@ -727,6 +772,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.K":
     environment_variables:
@@ -787,6 +837,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.L":
     environment_variables:
@@ -847,6 +902,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.M":
     environment_variables:
@@ -907,6 +967,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.N":
     environment_variables:
@@ -967,6 +1032,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.O":
     environment_variables:
@@ -1027,6 +1097,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   "Factory.Staging.Gcc7":
     environment_variables:
@@ -1087,4 +1162,9 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 

--- a/gocd/pkglistgen_staging.gocd.yaml.erb
+++ b/gocd/pkglistgen_staging.gocd.yaml.erb
@@ -85,4 +85,9 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 <% end %>

--- a/gocd/sle15sp4-stagings.gocd.yaml
+++ b/gocd/sle15sp4-stagings.gocd.yaml
@@ -156,6 +156,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   SLE15.SP4.Staging.B:
     environment_variables:
@@ -219,6 +224,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   SLE15.SP4.Staging.C:
     environment_variables:
@@ -282,6 +292,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   SLE15.SP4.Staging.D:
     environment_variables:
@@ -345,6 +360,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   SLE15.SP4.Staging.E:
     environment_variables:
@@ -408,6 +428,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   SLE15.SP4.Staging.F:
     environment_variables:
@@ -471,6 +496,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   SLE15.SP4.Staging.G:
     environment_variables:
@@ -534,6 +564,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   SLE15.SP4.Staging.H:
     environment_variables:
@@ -597,6 +632,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   SLE15.SP4.Staging.S:
     environment_variables:
@@ -660,6 +700,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   SLE15.SP4.Staging.V:
     environment_variables:
@@ -723,6 +768,11 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   SLE15.SP4.Staging.Y:
     environment_variables:
@@ -786,3 +836,8 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success

--- a/gocd/sle15sp4-stagings.gocd.yaml.erb
+++ b/gocd/sle15sp4-stagings.gocd.yaml.erb
@@ -89,4 +89,9 @@ pipelines:
        tasks:
          - script: |-
              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
+             export PYTHONPATH=$PWD/scripts
+             while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
+               sleep 60
+             done
+             ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 <% end -%>

--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -110,6 +110,7 @@ class AcceptCommand(object):
         for project in staging_packages.keys():
             u = self.api.makeurl(['staging', self.api.project, 'staging_projects', project, 'accept'], opts)
             http_POST(u)
+            self.api.switch_flag_in_prj(project, flag='build', state='disable', repository='images')
 
         for req in other_new:
             print(f"Accepting request {req['id']}: {req['package']}")


### PR DESCRIPTION
Following up from @DimStar77's https://github.com/openSUSE/openSUSE-release-tools/pull/2382

Building and testing staging products that aren't ready yet is wasteful and confusing.