### PR TITLE
Do not decline requests with download_files errors

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -228,7 +228,11 @@ class CheckSource(ReviewBot.ReviewBot):
             return False
 
         if not self.check_urls('_old', target_package, specs):
-            return False
+            osc.core.change_review_state(apiurl=self.apiurl,
+                                         reqid=self.request.reqid, newstate='new',
+                                         by_group=self.review_group,
+                                         by_user=self.review_user, message=self.review_messages['new'])
+            return None
 
         shutil.rmtree(dir)
         self.review_messages['accepted'] = 'Check script succeeded'
@@ -563,7 +567,6 @@ class CheckSource(ReviewBot.ReviewBot):
             with open(specfn) as rf:
                 for line in rf:
                     m = re.match(r'(Source[0-9]*\s*):\s*(.*)$', line)
-                    print(line, m)
                     if m and m.group(2) in oldsources:
                         wf.write(m.group(1) + ":" + os.path.basename(m.group(2)) + "\n")
                         continue
@@ -579,7 +582,7 @@ class CheckSource(ReviewBot.ReviewBot):
             res = subprocess.run(["/usr/lib/obs/service/download_files", "--enforceupstream",
                                   "yes", "--enforcelocal", "yes", "--outdir", tmpdir], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             if res.returncode:
-                self.review_messages['declined'] = "Source URLs are not valid. Try `osc service runall download_files`.\n" + \
+                self.review_messages['new'] = "Source URLs are not valid. Try `osc service runall download_files`.\n" + \
                     res.stdout.decode('utf-8')
                 os.chdir(oldcwd)
                 return False

--- a/tests/check_source_tests.py
+++ b/tests/check_source_tests.py
@@ -368,7 +368,7 @@ class TestCheckSource(OBSLocal.TestCase):
 
     @pytest.mark.usefixtures("default_config")
     def test_source_urls(self):
-        """Declines invalid source URLs"""
+        """Soft-Declines invalid source URLs"""
         self._setup_devel_project(devel_files='blowfish-with-urls')
 
         req_id = self.wf.create_submit_request(self.devel_package.project,
@@ -379,7 +379,8 @@ class TestCheckSource(OBSLocal.TestCase):
         self.review_bot.set_request_ids([req_id])
         self.review_bot.check_requests()
 
-        review = self.assertReview(req_id, by_user=(self.bot_user, 'declined'))
+        # not declined but not accepted either
+        review = self.assertReview(req_id, by_user=(self.bot_user, 'new'))
         self.assertIn("Source URLs are not valid. Try `osc service runall download_files`.\nblowfish-1.tar.gz", review.comment)
 
     @pytest.mark.usefixtures("default_config")


### PR DESCRIPTION
The URLs might suffer from flaky networks, so just block the request
from accepted for now (and extend the review comment to make it
discoverable why factory-auto didn't approve)

Fixes #2666