### PR TITLE
project-installcheck: Store when we first saw unresolvable and failed results

### DIFF
--- a/staging-installcheck.py
+++ b/staging-installcheck.py
@@ -346,15 +346,6 @@ class InstallChecker(object):
         self.logger.info('cycle check: passed')
         return CheckResult(True, None)
 
-    def project_pseudometa_file_name(self, project, repository):
-        filename = 'repo_checker'
-
-        main_repo = Config.get(self.api.apiurl, project).get('main-repo')
-        if not main_repo:
-            filename += '.' + repository
-
-        return filename
-
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
@DimStar77 wants to have unresolvable packages be part of the build fail reminder, but for that we need to store the first time we saw the unresolvable.

(I guess we could do the same also for failures and work around issues in the project status route)