### PR TITLE
Force i586 in adi projects

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1431,12 +1431,16 @@ class StagingAPI(object):
           {repository}
             <path project="{self.cstaging}" repository="standard"/>
             <path project="{self.project}" repository="standard"/>
-            <arch>x86_64</arch>
           </repository>
           {images_repo}
           {containerfile_repo}
         </project>"""
 
+        root = ET.fromstring(meta)
+        repository = root.find('.//repository[@name="standard"]')
+        for arch in self.cstaging_archs:
+            a = ET.SubElement(repository, 'arch')
+            a.text = arch
         url = make_meta_url('prj', name, self.apiurl)
         http_PUT(url, data=meta)
         # put twice because on first put, the API adds useless maintainer


### PR DESCRIPTION
This replaces #1304 with a more brute force approach to fix not only 32bit libs but all failures we see on i586. We waste so much energy retrying failed builds, it's really not worth it not trying i586 on adi.