### PR TITLE
Recreate the database on each run

### DIFF
--- a/metrics/access/aggregate.php
+++ b/metrics/access/aggregate.php
@@ -443,6 +443,8 @@ function write($points)
 
   if (!$database) {
     $database = InfluxDB\Client::fromDSN('influxdb://0.0.0.0:8086/osrt_access');
+    $database->drop();
+    $database->create();
   }
 
   if (!$database->writePoints($points, Database::PRECISION_SECONDS)) die('failed to write points');


### PR DESCRIPTION
The purpose is to drop the last measurement on uncompleted aggregation
period.