### PR TITLE
Use consistent URL for openSUSE-release-tools.git

### DIFF
--- a/gocd/update.osrt.gocd.yaml
+++ b/gocd/update.osrt.gocd.yaml
@@ -13,7 +13,7 @@ pipelines:
       only_on_changes: false
     materials:
       git:
-        git: https://github.com/openSUSE/opensuse-release-tools.git
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
     stages:
     - obs-deploy:
         resources:

--- a/gocd/vagrant-publisher.gocd.yaml
+++ b/gocd/vagrant-publisher.gocd.yaml
@@ -7,7 +7,7 @@ pipelines:
       ATLAS_TOKEN: '{{SECRET:[opensuse.secrets][ATLAS_TOKEN]}}'
     materials:
       git:
-        git: https://github.com/openSUSE/opensuse-release-tools.git
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
     timer:
       spec: 0 0 0 ? * *
       only_on_changes: false

--- a/gocd/vagrant-publisher.gocd.yaml.erb
+++ b/gocd/vagrant-publisher.gocd.yaml.erb
@@ -7,7 +7,7 @@ pipelines:
       ATLAS_TOKEN: '{{SECRET:[opensuse.secrets][ATLAS_TOKEN]}}'
     materials:
       git:
-        git: https://github.com/openSUSE/opensuse-release-tools.git
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
     timer:
       spec: 0 0 0 ? * *
       only_on_changes: false


### PR DESCRIPTION
Otherwise it's treated as different material by GoCD