### PR TITLE
package: require git-scm-bridge by osrt-check-source

### DIFF
--- a/dist/ci/testenv-tumbleweed/Dockerfile
+++ b/dist/ci/testenv-tumbleweed/Dockerfile
@@ -10,7 +10,7 @@ RUN zypper in -y osc python3-pytest python3-httpretty python3-pyxdg python3-PyYA
    python3-influxdb python3-pytest-cov libxml2-tools curl python3-flake8 \
    shadow vim vim-data strace git sudo patch openSUSE-release openSUSE-release-ftp \
    perl-Net-SSLeay perl-Text-Diff perl-XML-Simple perl-XML-Parser build \
-   obs-service-download_files obs-service-format_spec_file
+   obs-service-download_files obs-service-format_spec_file obs-scm-bridge
 RUN useradd tester -d /code/tests/home
 
 COPY run_as_tester /usr/bin

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -103,6 +103,7 @@ OBS product release announcer for generating email diffs summaries.
 %package check-source
 Summary:        Check source review bot
 Group:          Development/Tools/Other
+Requires:       obs-scm-bridge
 Requires:       obs-service-download_files
 Requires:       obs-service-source_validator
 Requires:       osclib = %{version}


### PR DESCRIPTION
The bridge is required for git-managed sources being submitted
to Factory in order to check out the code

Fixes issue #2820
