### PR TITLE
Trigger aarch64 updates jobs

### DIFF
--- a/data/incidents.json
+++ b/data/incidents.json
@@ -15,7 +15,7 @@
      "DISTRI": "opensuse",
      "FLAVOR": "DVD-Incidents",
      "VERSION": "15.4",
-     "ARCH": "x86_64"
+     "ARCH": ["x86_64", "aarch64"]
   },
   "openSUSE:Backports:SLE-15-SP4:Update": {
     "DISTRI": "opensuse",


### PR DESCRIPTION
Motivation: [[qe-core] Increase the coverage of test scenarios in Leap Maintainance - Proposal for tests from SLES to be added to leap](https://progress.opensuse.org/issues/113297)