### PR TITLE
Fix cache handling with osc from git master

### DIFF
--- a/osclib/cache.py
+++ b/osclib/cache.py
@@ -10,7 +10,7 @@ from urllib.parse import urlsplit, SplitResult
 from io import BytesIO
 
 from osc import conf
-from osc.core import urlopen
+from urllib.request import urlopen
 from osclib.cache_manager import CacheManager
 from osclib.conf import str2bool
 from osclib.util import rmtree_nfs_safe


### PR DESCRIPTION
osc master no longer wraps urlopen, so use the underlying function