### PR TITLE
project-installcheck: Don't record unresolvables/fails during building

### DIFF
--- a/project-installcheck.py
+++ b/project-installcheck.py
@@ -233,7 +233,7 @@ class RepoChecker():
             buildresult[p.get('package')] = p.get('code')
 
         repo_state = root.find('result').get('state')
-        if repo_state in ['published', 'unpublished', 'building']:
+        if repo_state in ['published', 'unpublished']:
             self.check_buildstate(oldstate, buildresult, 'unresolvable')
             self.check_buildstate(oldstate, buildresult, 'failed')
 


### PR DESCRIPTION
While the project is building, the unresolvables may be temporarily but
more important packages that failed before, can become blocked and then
fail again. But we don't want to remove it from 'failed' because it had
an interim state of blocked

Fixes #2838