### PR TITLE
Use HTTP GET for /search/request/id API endpoint

### DIFF
--- a/legal-auto.py
+++ b/legal-auto.py
@@ -187,8 +187,7 @@ class LegalAuto(ReviewBot.ReviewBot):
             match += ' and (' + ' or '.join(sorted(batch)) + ')'
             url = osc.core.makeurl(
                 self.apiurl, ['search', 'request', 'id'], {'match': match})
-            # prefer POST because of the length
-            root = ET.parse(osc.core.http_POST(url)).getroot()
+            root = ET.parse(osc.core.http_GET(url)).getroot()
             for request in root.findall('request'):
                 self.delete_from_db(request.get('id'))
 


### PR DESCRIPTION
This API endpoint is currently accepting the GET and POST methods, but the POST method will be deprecated soon. After looking at the logs from build.opensuse.org, I noticed that the `licensedigger` user is heavily relying on this endpoint with the POST method. Using the GET method is also fine as noted by the W3C in [URIs, Addressability, and the use of HTTP GET and POST](https://www.w3.org/2001/tag/doc/whenToUseGet-20030922#ephemeral), under the section _5.2 Ephemeral Limitations_:

> **URIs cannot be longer than 256 characters**
> This was a limitation in some server implementations, and while
servers continue to have limitations to prevent denial-of-service
attacks, they are generally at least 4000 characters, and they evolve as
the legitimate uses of application developers evolve.

According to the logs, all calls to the /search/request/id API endpoint coming from this code, with the query string included, are well under 4000 characters long.

[1]: https://www.w3.org/2001/tag/doc/whenToUseGet-20030922#ephemeral