### PR TITLE
Set timeout on the suse checkers

### DIFF
--- a/gocd/checkers.suse.gocd.yaml
+++ b/gocd/checkers.suse.gocd.yaml
@@ -270,7 +270,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 30
+            timeout: 60
             resources:
             - staging-bot
             tasks:

--- a/gocd/checkers.suse.gocd.yaml
+++ b/gocd/checkers.suse.gocd.yaml
@@ -16,6 +16,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -36,6 +37,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -73,6 +75,7 @@ pipelines:
       OSC_CONFIG: /home/go/config/oscrc-repo-checker
     stages:
     - Run:
+        timeout: 30
         approval: manual
         jobs:
           SLE-Micro:
@@ -93,6 +96,7 @@ pipelines:
       only_on_changes: false
     stages:
     - Run:
+        timeout: 30
         approval: manual
         resources:
           - staging-bot
@@ -114,6 +118,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -146,6 +151,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -179,6 +185,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -199,6 +206,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -219,6 +227,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -239,6 +248,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -260,6 +270,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:

--- a/gocd/checkers.suse.gocd.yaml.erb
+++ b/gocd/checkers.suse.gocd.yaml.erb
@@ -270,7 +270,7 @@ pipelines:
           type: manual
         jobs:
           Run:
-            timeout: 30
+            timeout: 60
             resources:
             - staging-bot
             tasks:

--- a/gocd/checkers.suse.gocd.yaml.erb
+++ b/gocd/checkers.suse.gocd.yaml.erb
@@ -16,6 +16,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -36,6 +37,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -73,6 +75,7 @@ pipelines:
       OSC_CONFIG: /home/go/config/oscrc-repo-checker
     stages:
     - Run:
+        timeout: 30
         approval: manual
         jobs:
           SLE-Micro:
@@ -93,6 +96,7 @@ pipelines:
       only_on_changes: false
     stages:
     - Run:
+        timeout: 30
         approval: manual
         resources:
           - staging-bot
@@ -114,6 +118,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -146,6 +151,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -179,6 +185,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -199,6 +206,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -219,6 +227,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -239,6 +248,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:
@@ -260,6 +270,7 @@ pipelines:
           type: manual
         jobs:
           Run:
+            timeout: 30
             resources:
             - staging-bot
             tasks:


### PR DESCRIPTION
This prevents the short-living checkers from not making any progress
due to an endless hanging job