### PR TITLE
Handle Conflicts removing files

### DIFF
--- a/git-importer.py
+++ b/git-importer.py
@@ -329,7 +329,7 @@ class Git:
                 # to the commit directly.
                 first_commit = True
 
-        if self.repo.index.conflicts:
+        if not merged and self.repo.index.conflicts:
             for conflict in self.repo.index.conflicts:
                 logging.info(f"CONFLICT {conflict[1].path}")
 
@@ -983,7 +983,7 @@ class Importer:
                 merged=True,
             )
 
-        assert commit
+        assert commit and commit != "CONFLICT"
         logging.info(f"Merge with {submitted_revision.commit} into {commit}")
         revision.commit = commit
 


### PR DESCRIPTION
This affects 62 packages (example vte accepting request 81553)

The conflict is real as O:F revision 52 ran "autobuild autoformatter", which wasn't merged in devel project and then vte2.spec was removed on submitting 81553, which lead to a conflict. But the code passed "CONFLICT" as merge commit if the 2nd call to .merge didn't resolve