### PR TITLE
Fix CONFLICT logging

### DIFF
--- a/git-importer.py
+++ b/git-importer.py
@@ -331,7 +331,11 @@ class Git:
 
         if not merged and self.repo.index.conflicts:
             for conflict in self.repo.index.conflicts:
-                logging.info(f"CONFLICT {conflict[1].path}")
+                if conflict[0]:
+                    path = conflict[0].path
+                else:
+                    path = conflict[1].path
+                logging.info(f"CONFLICT {path}")
 
             if clean_on_conflict:
                 for path, _ in self.repo.status().items():


### PR DESCRIPTION
In unitest-cpp is a revision where the devel project got broken, so the MERGE conflict has no input for .changes - so the conflicts[1] is empty

("The first is the common ancestor, the second is the “ours” side of the conflict,
  and the third is the “theirs” side. These elements may be None depending on which
  sides exist for the particular conflict.)

See https://build.opensuse.org/request/show/999689 for the commit that restores the devel project and being puzzled