### PR TITLE
WIP: Save staging summary in attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 .docker-tmp/
 .bash_history
 osc
+.venv
+.vscode
+.idea

--- a/dist/obs/OSRT:StagingSummary.xml
+++ b/dist/obs/OSRT:StagingSummary.xml
@@ -1,0 +1,5 @@
+<definition name="StagingSummary" namespace="OSRT">
+  <description>Contains the last state of the staged packages</description>
+  <count>1</count>
+  <modifiable_by role="maintainer"/>
+</definition>

--- a/docs/pkglistgen.md
+++ b/docs/pkglistgen.md
@@ -1,25 +1,25 @@
 # Package List Generator
 
-pkglistgen.py is a self contained script to generate and update OBS products for openSUSE and SLE. 
+pkglistgen.py is a self contained script to generate and update OBS products for openSUSE and SLE.
 It works on the products and its staging projects and ports.
 
 The main input is a package named 000package-groups and it will update the content of other packages
 from that. For that it will read [YAML](https://en.wikipedia.org/wiki/YAML) input from e.g. 000package-groups/groups.yml and generate .group files into 000product. The rest of 000package-groups is copied into 000product as well and it runs the OBS product converter service (See [OBS Documentation](https://en.opensuse.org/openSUSE:Build_Service_product_definition) for details)
-The generated release spec files are split into 000release-packages to avoid needless rebuilds. 
+The generated release spec files are split into 000release-packages to avoid needless rebuilds.
 
 ## Input
 
-The package list generator reads several files. The most important are group*.yml (tradionally only groups.yml) within 000package-groups.
+The package list generator reads several files. The most important are group*.yml (traditionally only groups.yml) within 000package-groups.
 
 ### supportstatus.txt
 The file lists the packages and their support level. It's only necessary to list packages here that have a different level than the default level specificied in the groups. The format is plain text: <package name> <level> - the level is handed over 1:1 to KIWI file. Currently used values are: unsupported, l2 and l3
- 
+
 ### group*.yml
 The file is a list of package lists and the special hash 'OUTPUT'. OUTPUT contains an entry for every group file that needs to be written out. The group name of it needs to exist as package list as well. OUTPUT also contains flags for the groups.
 
 We currently support:
  * default-support
- Sets the support level in case there is no explicitly entry in [supportstatus.txt](#supportstatus.txt), defaults to 'unsupported'
+ Sets the support level in case there is no explicitly entry in [supportstatus.txt](#supportstatustxt), defaults to 'unsupported'
  * recommends
  If the solver should take recommends into account when solving the package list, defaults to false.
  * includes
@@ -31,7 +31,7 @@ We currently support:
 
 Be aware that group names must not contain a '-'.
 
-You can also adapt the solving on a package level by putting a hash into the package list. Normally the package name is a string, in case it's a hash the key needs to be the package name and the value is a list of following modifiers: 
+You can also adapt the solving on a package level by putting a hash into the package list. Normally the package name is a string, in case it's a hash the key needs to be the package name and the value is a list of following modifiers:
 
  * recommended
  Evaluate also 'Recommends' in package to determine dependencies. Otherwise only 'required' are considered. Used mainly for patterns in SLE. It can not be combined with platforms, For architecture specific recommends, use patterns.
@@ -46,7 +46,7 @@ You can also adapt the solving on a package level by putting a hash into the pac
  * required
  If the package is missing or is uninstallable, don't leave a comment but put the error as package entry for OBS to create unresolvable error to avoid building a DVD
 
-Note that you can write yaml lists in 2 ways. You can put the modifier lists as multiple lines starting with -, but it's recommended to put them as [M1,M2] behind the package name. See the difference between pkg4 and pkg5 in the example. 
+Note that you can write yaml lists in 2 ways. You can put the modifier lists as multiple lines starting with -, but it's recommended to put them as [M1,M2] behind the package name. See the difference between pkg4 and pkg5 in the example.
 
 #### Example:
 
@@ -68,30 +68,30 @@ OUTPUT:
   - group3:
     includes:
     - list2
-    
+
 group1:
   - pkg1
-  
+
 group2:
   - pkg2: [locked]
   - pkg3
-  
+
 group3:
   - pkg4: [x86_64]
-  
+
 list1:
   - pkg5:
     - x86_64
-  
+
 list2:
   - pkg6: [recommended]
-``` 
+```
 
-## Overlap calculcation
- TODO 
+## Overlap calculation
+ TODO
 
 ## Handling in staging workflow
-If 000package-groups contains a file named summary-staging.txt, the bot will trigger a diff mode on staging projects. 
+If 000package-groups contains a file named summary-staging.txt, the bot will trigger a diff mode on staging projects.
 It will create an equal summary-staging.txt in 000product and create a comment with a human readable diff in the staging
 project. This comment can be replied to. If the reply starts with 'approve', staging accept will apply the diff to this
 txt file. If the reply starts with 'ignore', the bot will continue with the pipeline and do nothing on staging accept.

--- a/migration/summary_file_to_attribute.py
+++ b/migration/summary_file_to_attribute.py
@@ -1,0 +1,126 @@
+#!/bin/python3
+
+"""
+This script should migrate summary-staging.txt files to the new OSRT:StagingSummary attribute.
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+from urllib.error import HTTPError
+
+from osclib import core
+
+# CLI script with one or more projects as an argument
+parser = argparse.ArgumentParser(
+    description="This script should migrate summary-staging.txt files to the new OSRT:StagingSummary attribute."
+)
+parser.add_argument(
+    "--apiurl",
+    "-A",
+    dest="apiurl",
+    action="store_const",
+    help="URL of the API from the Open Build Service instance.",
+    type=str,
+)
+parser.add_argument(
+    "--project",
+    "-p",
+    dest="projects",
+    action="store_const",
+    help="Whitespace delimited list of projects.",
+    type=str,
+)
+parser.add_argument(
+    "--export-summary",
+    "-e",
+    dest="export_summary",
+    action="store_const",
+    help="In case you want the summary at the end exported as a JSON add this flag.",
+    type=pathlib.Path,
+)
+
+project_key_valid = "valid"
+project_key_not_existing = "missing"
+project_key_missing_package_groups = "missing_package_groups"
+project_key_missing_summary_staging = "missing_summary_staging"
+project_key_success = "success"
+projects = {
+    project_key_valid: [],
+    project_key_not_existing: [],
+    project_key_missing_package_groups: [],
+    project_key_missing_summary_staging: [],
+    project_key_success: [],
+}
+summary_files_content = {}
+
+# Parse projects and check their existence
+args = parser.parse_args()
+project_list = args.projects.split()
+
+for project in project_list:
+    if core.entity_exists(args.apiurl, project):
+        projects[project_key_valid].append(project)
+    else:
+        projects[project_key_not_existing].append(project)
+
+# Check for existence of 000package-groups package
+for project in projects[project_key_valid]:
+    if not core.entity_exists(args.apiurl, project, "000package-groups"):
+        projects[project_key_missing_package_groups].append(project)
+
+for project in projects[project_key_missing_package_groups]:
+    project[project_key_valid].remove(project)
+
+# Check for existence of summary-staging.txt
+for project in projects[project_key_valid]:
+    summary_staging_txt = core.source_file_load(
+        args.apiurl, project, "000package-groups", "summary-staging.txt"
+    )
+    if summary_staging_txt is None:
+        projects[project_key_missing_summary_staging].append(project)
+
+for project in projects[project_key_missing_summary_staging]:
+    project[project_key_valid].remove(project)
+
+attribute_exists = True
+for project, content in projects[project_key_valid]:
+    try:
+        core.attribute_value_save(args.apiurl, project, "StagingSummary", content)
+        projects[project_key_success].append(project)
+    except HTTPError as e:
+        if e.code == 404:
+            # Attribute doesn't exist, thus we don't need to save all non-existent attributes
+            attribute_exists = False
+            break
+        raise e
+
+# Print summary
+print("Summary of the execution:")
+print("")
+print(f"\tThe script recognized the following projects: {', '.join(project_list)}")
+print(f"\tThe following projects were valid: {', '.join(projects[project_key_valid])}")
+print(
+    f"\tThe following projects were missing: {', '.join(projects[project_key_not_existing])}"
+)
+print(
+    "\tThe following projects were missing the 000package-groups: "
+    f"{', '.join(projects[project_key_missing_package_groups])}"
+)
+print(
+    "\tThe following projects were missing the staging summary: "
+    f"{', '.join(projects[project_key_missing_summary_staging])}"
+)
+print(
+    f"\tThe following projects were successfully converted: {', '.join(projects[project_key_success])}"
+)
+
+if args.export_summary:
+    if not args.export_summary.parent.exists():
+        print("Directory to save JSON in did not exist.")
+        sys.exit(1)
+    with open(args.export_summary, mode="wt", encoding="utf-8") as json_fd:
+        json_fd.write(json.dumps(projects, indent=2))
+    print("")
+    print(f'Above summary can be found addtionally at: "{args.export_summary}"')

--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -1,6 +1,7 @@
 import time
 import re
 from urllib.error import HTTPError
+from typing import List
 
 from lxml import etree as ET
 
@@ -80,7 +81,15 @@ class AcceptCommand(object):
             to_request[package] = {'id': id, 'bugowner': m.group(1)}
             return
 
-    def accept_all(self, projects, force=False, cleanup=True):
+    def accept_all(self, projects: List[str], force=False, cleanup=True):
+        """
+        Accept all staging projects that are either given or acceptable.
+
+        :param projects: The list of staging letters that are to be accepted. If this is an empty list then the method
+                         will search for all green staging projects and accept them.
+        :param force: This option is not allowed to be combined without giving an explicit list of projects.
+        :param cleanup: Delete the packages from staging after they are accepted.
+        """
         accept_all_green = len(projects) == 0
         if accept_all_green:
             print('Accepting all acceptable projects')
@@ -98,6 +107,7 @@ class AcceptCommand(object):
         for prj in projects:
             project = self.api.prj_from_letter(prj)
 
+            # If the following line completes without error we can be sure that the project is existing.
             status = self.api.project_status(project)
             if status.get('state') != 'acceptable':
                 if accept_all_green:
@@ -177,7 +187,13 @@ class AcceptCommand(object):
 
         return True
 
-    def cleanup(self, project):
+    def cleanup(self, project: str):
+        """
+        Deletes all packages in a given project.
+
+        The key "nocleanup_packages" in the osc config will cause that the listed packages will be excluded from
+        deletion.
+        """
         if not self.api.item_exists(project):
             return
 

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -6,6 +6,7 @@ import socket
 import logging
 from lxml import etree as ET
 from urllib.error import HTTPError
+from typing import Optional
 
 from osc.core import create_submit_request
 from osc.core import get_binarylist
@@ -413,7 +414,7 @@ def package_list_kind_filtered(apiurl, project, kinds_allowed=['source']):
         yield package
 
 
-def attribute_value_load(apiurl, project, name, namespace='OSRT', package=None):
+def attribute_value_load(apiurl: str, project: str, name: str, namespace='OSRT', package: Optional[str] = None):
     path = list(filter(None, ['source', project, package, '_attribute', namespace + ':' + name]))
     url = makeurl(apiurl, path)
 
@@ -444,7 +445,14 @@ def attribute_value_load(apiurl, project, name, namespace='OSRT', package=None):
 # Remember to create for both OBS and IBS as necessary.
 
 
-def attribute_value_save(apiurl, project, name, value, namespace='OSRT', package=None):
+def attribute_value_save(
+    apiurl: str,
+    project: str,
+    name: str,
+    value: str,
+    namespace='OSRT',
+    package: Optional[str] = None
+):
     root = ET.Element('attributes')
 
     attribute = ET.SubElement(root, 'attribute')
@@ -463,13 +471,13 @@ def attribute_value_save(apiurl, project, name, value, namespace='OSRT', package
         raise e
 
 
-def attribute_value_delete(apiurl, project, name, namespace='OSRT', package=None):
+def attribute_value_delete(apiurl: str, project: str, name: str, namespace='OSRT', package: Optional[str] = None):
     http_DELETE(makeurl(
         apiurl, list(filter(None, ['source', project, package, '_attribute', namespace + ':' + name]))))
 
 
 @memoize(session=True)
-def repository_path_expand(apiurl, project, repo, visited_repos=None):
+def repository_path_expand(apiurl: str, project: str, repo: str, visited_repos: Optional[set] = None):
     """Recursively list underlying projects."""
     if visited_repos is None:
         visited_repos = set()

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1,5 +1,6 @@
 from io import StringIO
 from datetime import datetime
+from typing import List
 import dateutil.parser
 import logging
 import textwrap
@@ -52,7 +53,7 @@ class StagingAPI(object):
     Class containing various api calls to work with staging projects.
     """
 
-    def __init__(self, apiurl, project):
+    def __init__(self, apiurl: str, project: str):
         """Initialize instance variables."""
 
         self.apiurl = apiurl
@@ -149,7 +150,7 @@ class StagingAPI(object):
         xpath = f'repository[@name="{repo_name}"]'
         return len(meta.xpath(xpath)) > 0
 
-    def makeurl(self, paths, query=None):
+    def makeurl(self, paths: List[str], query=None) -> str:
         """
         Wrapper around osc's makeurl passing our apiurl
         :return url made for l and query

--- a/pkglistgen/cli.py
+++ b/pkglistgen/cli.py
@@ -86,7 +86,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
         if apiurl.find('opensuse.org') > 0:
             os.environ['OBS_NAME'] = 'build.opensuse.org'
 
-        def solve_project(project, scope):
+        def solve_project(project, scope: str):
             try:
                 self.tool.reset()
                 self.tool.dry_run = self.options.dry

--- a/pkglistgen/tool.py
+++ b/pkglistgen/tool.py
@@ -8,6 +8,8 @@ import shutil
 import subprocess
 import yaml
 
+from typing import Any, Mapping, Optional
+
 from lxml import etree as ET
 
 from osc.core import checkout_package
@@ -175,7 +177,7 @@ class PkgListGen(ToolBase.ToolBase):
                     if package[0] not in g.solved_packages['*']:
                         self.logger.error(f'Missing {package[0]} in {groupname} for {arch}')
 
-    def expand_repos(self, project, repo='standard'):
+    def expand_repos(self, project: str, repo='standard'):
         return repository_path_expand(self.apiurl, project, repo)
 
     def _check_supplements(self):
@@ -506,7 +508,13 @@ class PkgListGen(ToolBase.ToolBase):
                 print('%endif', file=output)
         output.flush()
 
-    def solve_project(self, ignore_unresolvable=False, ignore_recommended=False, locale=None, locales_from=None):
+    def solve_project(
+        self,
+        ignore_unresolvable=False,
+        ignore_recommended=False,
+        locale: Optional[str] = None,
+        locales_from: Optional[str] = None
+    ):
         self.load_all_groups()
         if not self.output:
             self.logger.error('OUTPUT not defined')
@@ -601,9 +609,19 @@ class PkgListGen(ToolBase.ToolBase):
             new_lines.append(line.replace('<version></version>', product_version))
         open(product_file, 'w').write(''.join(new_lines))
 
-    def update_and_solve_target(self, api, target_project, target_config, main_repo,
-                                project, scope, force, no_checkout,
-                                only_release_packages, stop_after_solve):
+    def update_and_solve_target(
+        self,
+        api,
+        target_project: str,
+        target_config: Mapping[str, Any],
+        main_repo: str,
+        project: str,
+        scope: str,
+        force: bool,
+        no_checkout: bool,
+        only_release_packages: bool,
+        stop_after_solve: bool
+    ):
         self.all_architectures = target_config.get('pkglistgen-archs').split(' ')
         self.use_newest_version = str2bool(target_config.get('pkglistgen-use-newest-version', 'False'))
         self.repos = self.expand_repos(project, main_repo)
@@ -682,11 +700,12 @@ class PkgListGen(ToolBase.ToolBase):
             self.load_all_groups()
             self.write_group_stubs()
         else:
-            summary = self.solve_project(ignore_unresolvable=str2bool(target_config.get('pkglistgen-ignore-unresolvable')),
-                                         ignore_recommended=str2bool(
-                                             target_config.get('pkglistgen-ignore-recommended')),
-                                         locale=target_config.get('pkglistgen-locale'),
-                                         locales_from=target_config.get('pkglistgen-locales-from'))
+            summary = self.solve_project(
+                ignore_unresolvable=str2bool(target_config.get('pkglistgen-ignore-unresolvable')),
+                ignore_recommended=str2bool(target_config.get('pkglistgen-ignore-recommended')),
+                locale=target_config.get('pkglistgen-locale'),
+                locales_from=target_config.get('pkglistgen-locales-from')
+            )
 
         if stop_after_solve:
             return


### PR DESCRIPTION
This PR has the aim to achieve two things:

- switch saving the staging summary inside an OSRT namespace attribute that is newly created for this purpose
- submit the changelog to a devel project of the `000package-groups` package

The reasoning behind this effort is that with [SLSA](https://slsa.dev/) the release manager has no write access to the GA image anymore. During a `osc staging accept` the changes should be saved though. To preserve the functionality that was lost with complying to SLSA and to reduce pressure on autobuild for reviewing these changes more often then needed this PR was created.