### PR TITLE
Fix the syncing of rebuild failures for multibuild flavors

### DIFF
--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -296,8 +296,6 @@ class AcceptCommand(object):
             rebuild_result = self.api.check_pkgs(rebuild_result)
             result = set(rebuild_result) ^ set(fact_result)
 
-            print(sorted(result))
-
             for package in result:
                 self.api.rebuild_pkg(package, self.api.project, arch, None)
                 self.api.rebuild_pkg(package, self.api.crebuild, arch, None)

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1307,8 +1307,16 @@ class StagingAPI(object):
 
         return pkglist
 
-    def check_pkgs(self, rebuild_list):
-        return list(set(rebuild_list) & set(self.list_packages(self.project)))
+    def check_pkgs(self, pkg_list):
+        """Filter the package list to those still existing in the project"""
+        project_packages = set(self.list_packages(self.project))
+        ret = list()
+        for pkg in pkg_list:
+            # map multibuild flavors
+            source = pkg.split(':')[0]
+            if source in project_packages:
+                ret.append(pkg)
+        return ret
 
     def rebuild_pkg(self, package, prj, arch, code=None):
         query = {


### PR DESCRIPTION
Otherwise we don't notice test suites failing that were split out