### PR TITLE
Submit summary to devel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 .docker-tmp/
 .bash_history
 osc
+.venv
+.vscode
+.idea

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -229,7 +229,7 @@ def binary_src_debug(binary):
 
 
 @memoize(session=True)
-def devel_project_get(apiurl, target_project, target_package):
+def devel_project_get(apiurl: str, target_project: str, target_package: str):
     try:
         meta = ET.fromstringlist(show_package_meta(apiurl, target_project, target_package))
         node = meta.find('devel')

--- a/osclib/pkglistgen_comments.py
+++ b/osclib/pkglistgen_comments.py
@@ -166,7 +166,7 @@ class PkglistComments:
 
         return 1
 
-    def is_approved(self, comment, comments: dict) -> str | None:
+    def is_approved(self, comment, comments: dict) -> Optional[str]:
         if not comment:
             return None
 

--- a/osclib/pkglistgen_comments.py
+++ b/osclib/pkglistgen_comments.py
@@ -12,6 +12,7 @@ from lxml import etree as ET
 from osc.core import Package, checkout_package, http_GET, makeurl
 
 from osclib.comments import CommentAPI
+from osclib.core import devel_project_get
 
 MARKER = 'PackageListDiff'
 
@@ -309,8 +310,11 @@ class PkglistComments:
         if not approver:
             return
         sections = self.parse_sections(comment['comment'])
+        project, package = devel_project_get(self.apiurl, target, '000package-groups')
+        if project is None or package is None:
+            raise ValueError('Could not determine devel project or package for the "000package-groups"!')
         with tempfile.TemporaryDirectory() as tmpdirname:
-            checkout_package(self.apiurl, target, '000package-groups', expand_link=True, outdir=tmpdirname)
+            checkout_package(self.apiurl, project, package, expand_link=True, outdir=tmpdirname)
             self.apply_commands(tmpdirname + '/summary-staging.txt', sections)
             self.apply_changes(tmpdirname + '/package-groups.changes', sections, approver)
             package = Package(tmpdirname)


### PR DESCRIPTION
This PR has the aim to achieve to submit the changelog to a devel project of the 000package-groups package.

The reasoning behind this effort is that with [SLSA](https://slsa.dev/) the release manager has no write access to the GA image anymore. During a osc staging accept the changes should be saved though. To preserve the functionality that was lost with complying to SLSA this PR was created.