### PR TITLE
gocd/rabbit-openqa.py improvements, including fix for current crash

### DIFF
--- a/gocd/rabbit-openqa.py
+++ b/gocd/rabbit-openqa.py
@@ -213,6 +213,13 @@ class Listener(PubSubConsumer):
         self.check_some_projects()
         super(Listener, self).still_alive()
 
+    def is_production_job(self, job):
+        if '/' in job['settings'].get('BUILD', '/') or \
+           'Development' in job['group']:
+            return False
+
+        return True
+
     def jobs_for_iso(self, iso):
         values = {
             'iso': iso,
@@ -221,7 +228,7 @@ class Listener(PubSubConsumer):
         }
         jobs = self.openqa.openqa_request('GET', 'jobs', values)['jobs']
         # Ignore PR verification runs (and jobs without 'BUILD')
-        return [job for job in jobs if '/' not in job['settings'].get('BUILD', '/')]
+        return [job for job in jobs if self.is_production_job(job)]
 
     def get_step_url(self, testurl, modulename):
         failurl = testurl + '/modules/{!s}/fails'.format(quote_plus(modulename))

--- a/gocd/rabbit-openqa.py
+++ b/gocd/rabbit-openqa.py
@@ -259,12 +259,6 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Bot to sync openQA status to OBS')
     parser.add_argument("--apiurl", '-A', type=str, help='API URL of OBS')
-    parser.add_argument('-s', '--staging', type=str, default=None,
-                        help='staging project letter')
-    parser.add_argument('-f', '--force', action='store_true', default=False,
-                        help='force the write of the comment')
-    parser.add_argument('-p', '--project', type=str, default='Factory',
-                        help='openSUSE version to make the check (Factory, 13.2)')
     parser.add_argument('-d', '--debug', action='store_true', default=False,
                         help='enable debug information')
 


### PR DESCRIPTION
* gocd/rabbit-openqa.py: Remove unused parameters
* gocd/rabbit-openqa.py: Add --dry option
* gocd/rabbit-openqa.py: Ignore jobs in "Development" groups

The latter fixes the current crash caused by name conflicts between production and dev jobs (for images).