### PR TITLE
readd ToTest 15.4_ARM manager

### DIFF
--- a/gocd/totestmanager.gocd.yaml
+++ b/gocd/totestmanager.gocd.yaml
@@ -210,6 +210,27 @@ pipelines:
         - script: |-
             install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
             scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.4:Images
+  TTM.Leap_15.4_ARM:
+    group: openSUSE.Checkers
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-totest-manager
+    materials:
+      script:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+        destination: scripts
+    timer:
+      spec: 0 */15 * ? * *
+      only_on_changes: false
+    stages:
+    - Run:
+        approval: manual
+        resources:
+        - staging-bot
+        tasks:
+        - script: |-
+            install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
+            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.4:ARM
   TTM.Leap_15.4_ARM_Images:
     group: openSUSE.Checkers
     lock_behavior: unlockWhenFinished

--- a/gocd/totestmanager.gocd.yaml.erb
+++ b/gocd/totestmanager.gocd.yaml.erb
@@ -11,6 +11,7 @@ pipelines:
       openSUSE:Leap:15.3:WSL
       openSUSE:Leap:15.3:Update:Respin
       openSUSE:Leap:15.4:Images
+      openSUSE:Leap:15.4:ARM
       openSUSE:Leap:15.4:ARM:Images
       openSUSE:Leap:15.5
       openSUSE:Leap:15.5:Images


### PR DESCRIPTION
Leap 15.4 for arm 32bit is never frozen, so we do need to continuously be able to release new snapshots.