### PR TITLE
Allow specifying a devel project that has "Factory" in its name

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -53,14 +53,15 @@ def _full_project_name(self, project):
     if project.startswith(('openSUSE', 'SUSE')):
         return project
 
-    if 'Factory' in project or 'openSUSE' in project:
+    if project.startswith('Factory'):
         return 'openSUSE:%s' % project
 
-    if 'SLE' in project:
+    if project.startswith('SLE') or project.startswith('ALP'):
         return 'SUSE:%s' % project
 
     # If we can't guess, raise a Warning
-    warnings.warn('%s project not recognized.' % project)
+    if (':' not in project):
+        warnings.warn('%s project not recognized.' % project)
     return project
 
 


### PR DESCRIPTION
we should only expand with openSUSE in front if it is starting with "Factory". Also add ALP handling and hide the warning if a full project has been specified.