### PR TITLE
Port from mock to unittest.mock

### DIFF
--- a/dist/ci/testenv-tumbleweed/Dockerfile
+++ b/dist/ci/testenv-tumbleweed/Dockerfile
@@ -6,7 +6,7 @@ RUN zypper -n ar http://download.opensuse.org/repositories/openSUSE:/Tools/openS
 RUN zypper --gpg-auto-import-keys ref
 
 RUN zypper in -y osc python3-pytest python3-httpretty python3-pyxdg python3-PyYAML \
-  python3-pika python3-mock python3-cmdln python3-lxml python3-python-dateutil python3-colorama \
+  python3-pika python3-cmdln python3-lxml python3-python-dateutil python3-colorama \
   python3-influxdb python3-pytest-cov libxml2-tools curl python3-flake8 \
   shadow vim vim-data strace git sudo patch openSUSE-release openSUSE-release-ftp \
   perl-Net-SSLeay perl-Text-Diff perl-XML-Simple perl-XML-Parser build \

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ influxdb
 
 # Dependencies for testing
 httpretty
-mock

--- a/tests/accept_tests.py
+++ b/tests/accept_tests.py
@@ -6,7 +6,7 @@ from osclib.comments import CommentAPI
 from osclib.core import package_list
 from osc.core import get_request
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 from . import OBSLocal
 
 # CI-Node: Long2

--- a/tests/check_tests.py
+++ b/tests/check_tests.py
@@ -3,7 +3,7 @@ import unittest
 from osclib.check_command import CheckCommand
 
 from lxml import etree
-from mock import MagicMock
+from unittest.mock import MagicMock
 from . import OBSLocal
 
 H_REPORT = """

--- a/tests/factory_submit_request_tests.py
+++ b/tests/factory_submit_request_tests.py
@@ -3,7 +3,7 @@ import os
 
 # Needed to mock LegalAuto
 from osc.core import change_review_state
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 # Import the involved staging commands
 from osclib.freeze_command import FreezeCommand

--- a/tests/select_tests.py
+++ b/tests/select_tests.py
@@ -8,7 +8,7 @@ from osclib.ignore_command import IgnoreCommand
 from osclib.core import source_file_load
 from urllib.error import HTTPError
 from lxml import etree as ET
-from mock import MagicMock
+from unittest.mock import MagicMock
 from . import OBSLocal
 
 # CI-Node: Long1

--- a/tests/sle_submit_request_tests.py
+++ b/tests/sle_submit_request_tests.py
@@ -7,7 +7,7 @@ from osclib.core import attribute_value_save
 
 # Needed to mock LegalAuto
 from osc.core import change_review_state
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 # Import the involved staging commands
 from osclib.freeze_command import FreezeCommand


### PR DESCRIPTION
python3-mock no longer exists, use unittest.mock instead.

I just search-replaced, let's see.