### PR TITLE
Rewrite cleanup_rings.py

### DIFF
--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -61,7 +61,7 @@ class CleanupRings(object):
                 if dprj != self.api.project:
                     if not dprj.startswith(self.api.crings):
                         print("#{} not linking to base {} but {}".format(pkg, self.api.project, dprj))
-                    self.links[dpkg] = pkg
+                    self.links[pkg] = dpkg
                 # multi spec package must link to ring
                 elif len(links) > 1:
                     mainpkg = links[1].get('package')
@@ -78,7 +78,7 @@ class CleanupRings(object):
                         else:
                             if pkg != 'glibc.i686':  # FIXME: ugly exception
                                 print("osc linkpac -f {}/{} {}/{}".format(destring, mainpkg, prj, pkg))
-                                self.links[mainpkg] = pkg
+                                self.links[pkg] = mainpkg
 
     def fill_pkgdeps(self, prj, repo, arch):
         root = builddepinfo(self.api.apiurl, prj, repo, arch)

--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -5,8 +5,6 @@ from osclib.core import fileinfo_ext_all
 from osclib.core import builddepinfo
 from osclib.memoize import memoize
 
-from urllib.error import HTTPError
-
 
 class CleanupRings(object):
     def __init__(self, api):
@@ -118,13 +116,8 @@ class CleanupRings(object):
         root = ET.parse(http_GET(url)).getroot()
         for image in root.xpath(f"result[@repository = 'images' and @arch = '{arch}']/status[@code != 'excluded' and @code != 'disabled']"):
             dvd = image.get('package')
-            try:
-                url = makeurl(self.api.apiurl, ['build', project, 'images', arch, dvd, '_buildinfo'])
-                root = ET.parse(http_GET(url)).getroot()
-            except HTTPError as e:
-                if e.code == 404:
-                    continue
-                raise
+            url = makeurl(self.api.apiurl, ['build', project, 'images', arch, dvd, '_buildinfo'])
+            root = ET.parse(http_GET(url)).getroot()
             # Don't delete the image itself
             self.pkgdeps[dvd.split(':')[0]] = 'MYdvd{}'.format(self.api.rings.index(project))
             for bdep in root.findall('bdep'):

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -356,6 +356,10 @@ def fileinfo_ext_all(apiurl, project, repo, arch, package):
         filename = binary.get('filename')
         if not filename.endswith('.rpm'):
             continue
+        if filename.endswith('.src.rpm'):
+            continue
+        if '-debuginfo-' in filename or '-debugsource-' in filename:
+            continue
 
         yield fileinfo_ext(apiurl, project, repo, arch, package, filename)
 


### PR DESCRIPTION
Previously it went through each package's provides->required_by chain.
This does not deal with cycles correctly and there was only a hack to deal
with single-package cycles.

Instead, recursively walk through all required packages, starting from the
build enabled images and take note of all needed source packages.
This also handles _multibuild flavors as separate packages.

Depends on #2944.