### PR TITLE
cleanup_rings.py: Add snobol4 to whitelist

### DIFF
--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -29,6 +29,8 @@ class CleanupRings(object):
             'raspberrypi-firmware-config',
             # Added manually to notice failures early
             'vagrant',
+            # https://github.com/openSUSE/open-build-service/issues/14129
+            'snobol4',
         ]
 
     def perform(self):


### PR DESCRIPTION
Work around OBS not listing file deps in fileinfo_ext: https://github.com/openSUSE/open-build-service/issues/14129