### PR TITLE
Add flavor information to access metrics

### DIFF
--- a/metrics/access/aggregate.php
+++ b/metrics/access/aggregate.php
@@ -351,11 +351,8 @@ function summarize($data)
       if (isset($data['unique_product_flavor'][$product])) {
         $unique_flavors = $data['unique_product_flavor'][$product]));
         $flavors = array_unique(array_values($unique_flavors));
-        $summary_product += [ 'flavors' => [], ];
         foreach ($flavors as $flavor) {
-          $summary_product['flavors'] += [
-            $flavor => count(array_keys($unique_flavors, $flavor)),
-          ];
+          $summary_product[$flavor] = count(array_keys($unique_flavors, $flavor));
         }
       }
     } else {

--- a/metrics/access/aggregate.php
+++ b/metrics/access/aggregate.php
@@ -199,7 +199,7 @@ function aggregate_all($period)
   }
 
   // Write out any remaining data by simulating a date beyond all intervals.
-  error_log('write remaining data');
+  /*error_log('write remaining data');
   $date = clone $date;
   $date->add(date_interval_create_from_date_string('1 year'));
 
@@ -207,7 +207,7 @@ function aggregate_all($period)
     aggregate($intervals, $merged_protocol[$protocol], $date, $date_previous, null,
       ['protocol' => $protocol], 'protocol');
   }
-  aggregate($intervals, $merged, $date, $date_previous, null);
+  aggregate($intervals, $merged, $date, $date_previous, null);*/
 }
 
 function aggregate($intervals, &$merged, $date, $date_previous, $data, $tags = [], $prefix = 'access')
@@ -492,8 +492,8 @@ function write($points)
 
   if (!$database) {
     $database = InfluxDB\Client::fromDSN('influxdb://0.0.0.0:8086/osrt_access');
-    $database->drop();
-    $database->create();
+    // $database->drop();
+    // $database->create();
   }
 
   if (!$database->writePoints($points, Database::PRECISION_SECONDS)) die('failed to write points');

--- a/metrics/access/aggregate.php
+++ b/metrics/access/aggregate.php
@@ -294,7 +294,9 @@ function normalize(&$data)
   if (!isset($data['total_image_product'])) {
     $data['total_image_product'] = [];
   }
-  if (is_int(array_values($data['unique_product'][0][0]))) {
+  $first_product = reset($data['unique_product']);
+  $first_key = reset($first_product);
+  if (is_int($first_key)) {
     foreach ($data['unique_product'] as $product => $pairs) {
       foreach ($pairs as $key => $count) {
         $data['unique_product'][$product][$key] = ['count' => $count];
@@ -339,34 +341,16 @@ function merge_product_plus_key(&$data1, $data2)
 function merge_unique_products(&$data1, $data2)
 {
   foreach ($data2 as $product => $arrays) {
-    if (empty($data1[$product])
+    if (empty($data1[$product]))
       $data1[$product] = [];
 
     foreach ($arrays as $key => $array) {
-      if (empty($data1[$product][$key])
+      if (empty($data1[$product][$key]))
         $data1[$product][$key] = ['count' => 0];
 
-      $data1[$product][$key]['count'] = $array['count'];
+      $data1[$product][$key]['count'] += $array['count'];
       if (isset($array['flavor'])) $data1[$product][$key]['flavor'] = $array['flavor'];
       if (isset($array['ip'])) $data1[$product][$key]['ip'] = $array['ip'];
-    }
-  }
-}
-
-function merge_product_plus_flavor(&$data1, $data2)
-{
-  if (isset($data2['unique_product_flavor'])) {
-    $data2_flavors = $data2['unique_product_flavor'];
-    if (isset($data1['unique_product_flavor'])) {
-      $data1_flavors = $data1['unique_product_flavor'];
-      foreach ($data2_flavors as $product => $pairs) {
-        if (empty($data1_flavors[$product]))
-          $data1_flavors[$product] = [];
-        $data1_flavors[$product] += $data2_flavors[$product];
-      }
-      $data1['unique_product_flavor'] = $data1_flavors;
-    } else {
-      $data1['unique_product_flavor'] = $data2_flavors;
     }
   }
 }
@@ -395,7 +379,8 @@ function summarize($data)
       // A UUID should be unique to a product, as such this should provide an
       // accurate count of total unique across all products.
       $summary['-']['unique'] += $summary_product['unique'];
-      if (isset($data['unique_product'][$product][0]['flavor'])) {
+      $first_key = reset($data['unique_product'][$product]);
+      if (isset($first_key['flavor'])) {
         $unique_flavors = array_column($data['unique_product'][$product], 'flavor');
         $flavors = array_unique($unique_flavors);
         $summary_product['flavors'] = [];

--- a/metrics/access/aggregate.php
+++ b/metrics/access/aggregate.php
@@ -234,7 +234,7 @@ function aggregate($intervals, &$merged, $date, $date_previous, $data, $tags = [
         if ($prefix == 'protocol') {
           $summary = ['-' => $summary['-']];
         }
-        $flavors = []
+        $flavors = [];
         foreach ($summary as $product => $details) {
           if (isset($details['flavors'])) {
             $flavors[$product] = $details['flavors'];
@@ -308,7 +308,7 @@ function merge(&$data1, $data2)
   }
 
   merge_product_plus_key($data1['unique_product'], $data2['unique_product']);
-  $data1['unique_product_flavor'] = array_merge($data1['unique_product_flavor'], $data2['unique_product_flavor']);
+  merge_product_plus_key_string($data1['unique_product_flavor'], $data2['unique_product_flavor'])
   merge_product_plus_key($data1['total_image_product'], $data2['total_image_product']);
 
   $data1['total_invalid'] += $data2['total_invalid'];
@@ -326,6 +326,20 @@ function merge_product_plus_key(&$data1, $data2)
         $data1[$product][$key] = 0;
 
       $data1[$product][$key] += $data2[$product][$key];
+    }
+  }
+}
+
+function merge_product_plus_key_string(&$data1, $data2)
+{
+  if (isset($data2)) {
+    if (isset($data1)) {
+      foreach ($data2 as $product => $pairs) {
+        if (empty($data1[$product]))
+          $data1[$product] = [];
+        $data1[$product] += $data2[$product];
+    } else {
+      $data1 = $data2;
     }
   }
 }
@@ -359,7 +373,7 @@ function summarize($data)
       // accurate count of total unique across all products.
       $summary['-']['unique'] += $summary_product['unique'];
       if (isset($data['unique_product_flavor'][$product])) {
-        $unique_flavors = $data['unique_product_flavor'][$product]));
+        $unique_flavors = $data['unique_product_flavor'][$product];
         $flavors = array_unique(array_values($unique_flavors));
         $summary_product['flavors'] = [];
         foreach ($flavors as $flavor) {
@@ -449,7 +463,7 @@ function write_flavors($interval, DateTime $value, $flavors)
   foreach ($flavors as $product => $unique_flavors) {
     foreach($unique_flavors as $flavor => $unique_count) {
       $tags = ['product' => $product, 'flavor' => $flavor];
-      $points = new Point($measurement, $unique_count, $tags, null, $value->getTimestamp());
+      $points[] = new Point($measurement, $unique_count, $tags, [], $value->getTimestamp());
     }
   }
   write($points);

--- a/metrics/access/aggregate.php
+++ b/metrics/access/aggregate.php
@@ -294,6 +294,13 @@ function normalize(&$data)
   if (!isset($data['total_image_product'])) {
     $data['total_image_product'] = [];
   }
+  if (is_int(array_values($data['unique_product'][0][0]))) {
+    foreach ($data['unique_product'] as $product => $pairs) {
+      foreach ($pairs as $key => $count) {
+        $data['unique_product'][$product][$key] = ['count' => $count];
+      }
+    }
+  }
 }
 
 function merge(&$data1, $data2)
@@ -307,8 +314,7 @@ function merge(&$data1, $data2)
     $data1['total_product'][$product] += $data2['total_product'][$product];
   }
 
-  merge_product_plus_key($data1['unique_product'], $data2['unique_product']);
-  merge_product_plus_key_string($data1['unique_product_flavor'], $data2['unique_product_flavor'])
+  merge_unique_products($data1['unique_product'], $data2['unique_product']);
   merge_product_plus_key($data1['total_image_product'], $data2['total_image_product']);
 
   $data1['total_invalid'] += $data2['total_invalid'];
@@ -330,16 +336,37 @@ function merge_product_plus_key(&$data1, $data2)
   }
 }
 
-function merge_product_plus_key_string(&$data1, $data2)
+function merge_unique_products(&$data1, $data2)
 {
-  if (isset($data2)) {
-    if (isset($data1)) {
-      foreach ($data2 as $product => $pairs) {
-        if (empty($data1[$product]))
-          $data1[$product] = [];
-        $data1[$product] += $data2[$product];
+  foreach ($data2 as $product => $arrays) {
+    if (empty($data1[$product])
+      $data1[$product] = [];
+
+    foreach ($arrays as $key => $array) {
+      if (empty($data1[$product][$key])
+        $data1[$product][$key] = ['count' => 0];
+
+      $data1[$product][$key]['count'] = $array['count'];
+      if (isset($array['flavor'])) $data1[$product][$key]['flavor'] = $array['flavor'];
+      if (isset($array['ip'])) $data1[$product][$key]['ip'] = $array['ip'];
+    }
+  }
+}
+
+function merge_product_plus_flavor(&$data1, $data2)
+{
+  if (isset($data2['unique_product_flavor'])) {
+    $data2_flavors = $data2['unique_product_flavor'];
+    if (isset($data1['unique_product_flavor'])) {
+      $data1_flavors = $data1['unique_product_flavor'];
+      foreach ($data2_flavors as $product => $pairs) {
+        if (empty($data1_flavors[$product]))
+          $data1_flavors[$product] = [];
+        $data1_flavors[$product] += $data2_flavors[$product];
+      }
+      $data1['unique_product_flavor'] = $data1_flavors;
     } else {
-      $data1 = $data2;
+      $data1['unique_product_flavor'] = $data2_flavors;
     }
   }
 }
@@ -364,28 +391,20 @@ function summarize($data)
     ];
     if (isset($data['unique_product'][$product])) {
       $unique_product = $data['unique_product'][$product];
-      $summary_product += [
-        'unique' => count($unique_product),
-        'unqiue_average' => (float) (array_sum($unique_product) / count($unique_product)),
-        'unqiue_max' => max($unique_product),
-      ];
+      $summary_product += [ 'unique' => count($unique_product) ];
       // A UUID should be unique to a product, as such this should provide an
       // accurate count of total unique across all products.
       $summary['-']['unique'] += $summary_product['unique'];
-      if (isset($data['unique_product_flavor'][$product])) {
-        $unique_flavors = $data['unique_product_flavor'][$product];
-        $flavors = array_unique(array_values($unique_flavors));
+      if (isset($data['unique_product'][$product][0]['flavor'])) {
+        $unique_flavors = array_column($data['unique_product'][$product], 'flavor');
+        $flavors = array_unique($unique_flavors);
         $summary_product['flavors'] = [];
         foreach ($flavors as $flavor) {
           $summary_product['flavors'][$flavor] = count(array_keys($unique_flavors, $flavor));
         }
       }
     } else {
-      $summary_product += [
-        'unique' => 0,
-        'unqiue_average' => (float) 0,
-        'unqiue_max' => 0,
-      ];
+      $summary_product += [ 'unique' => 0 ];
     }
     $summary[$product] = $summary_product;
 
@@ -399,8 +418,6 @@ function summarize($data)
     $summary[$product] = [
       'total' => 0,
       'unique' => 0,
-      'unqiue_average' => (float) 0,
-      'unqiue_max' => 0,
     ];
   }
 

--- a/metrics/access/aggregate.php
+++ b/metrics/access/aggregate.php
@@ -298,6 +298,7 @@ function merge(&$data1, $data2)
   }
 
   merge_product_plus_key($data1['unique_product'], $data2['unique_product']);
+  $data1['unique_product_flavor'] = array_merge($data1['unique_product_flavor'], $data2['unique_product_flavor']);
   merge_product_plus_key($data1['total_image_product'], $data2['total_image_product']);
 
   $data1['total_invalid'] += $data2['total_invalid'];
@@ -347,6 +348,16 @@ function summarize($data)
       // A UUID should be unique to a product, as such this should provide an
       // accurate count of total unique across all products.
       $summary['-']['unique'] += $summary_product['unique'];
+      if (isset($data['unique_product_flavor'][$product])) {
+        $unique_flavors = $data['unique_product_flavor'][$product]));
+        $flavors = array_unique(array_values($unique_flavors));
+        $summary_product += [ 'flavors' => [], ];
+        foreach ($flavors as $flavor) {
+          $summary_product['flavors'] += [
+            $flavor => count(array_keys($unique_flavors, $flavor)),
+          ];
+        }
+      }
     } else {
       $summary_product += [
         'unique' => 0,

--- a/metrics/access/ingest.php
+++ b/metrics/access/ingest.php
@@ -1,7 +1,7 @@
 #!/usr/bin/php
 <?php
 
-const REGEX_LINE = '/\S+ \S+ \S+ \[([^:]+:\d+:\d+:\d+ [^\]]+)\] "(\S+)(?: (\S+) \S+)?" (\S+) (\S+) "[^"]*" "[^"]*" .* (?:size:|want:- give:- \d+ )(\S+) \S+(?: +"?(\S+-\S+-\S+-\S+-[^\s"]+|-)"? "?(dvd|ftp|mini|usb-[^"]*|livecd-[^"]*|appliance-?[^"]*|-)"?)?/';
+const REGEX_LINE = '/(\S+) \S+ \S+ \[([^:]+:\d+:\d+:\d+ [^\]]+)\] "(\S+)(?: (\S+) \S+)?" (\S+) (\S+) "[^"]*" "[^"]*" .* (?:size:|want:- give:- \d+ )(\S+) \S+(?: +"?(\S+-\S+-\S+-\S+-[^\s"]+|-)"? "?(dvd|ftp|mini|usb-[^"]*|livecd-[^"]*|appliance-?[^"]*|-)"?)?/';
 const REGEX_PRODUCT = '#/(?:(tumbleweed)|distribution/(?:leap/)?(\d+\.\d+)|openSUSE(?:_|:/)(?:leap(?:_|:/))?(factory|tumbleweed|\d+\.\d+))#i';
 const REGEX_IMAGE = '#(?:/(?:iso|live)/[^/]+-(DVD|NET|GNOME-Live|KDE-Live|Rescue-CD|Kubic-DVD)-[^/]+\.iso(?:\.torrent)?|/jeos/[^/]+-(JeOS)\.[^/]+\.(?:qcow2|vhdx|vmdk|vmx)$)#';
 
@@ -28,7 +28,7 @@ while (($line = fgets($handle)) !== false) {
   $total++;
 
   // Attempt to determine for which product was the request.
-  if (!preg_match(REGEX_PRODUCT, $match[3], $match_product)) {
+  if (!preg_match(REGEX_PRODUCT, $match[4], $match_product)) {
     continue;
   }
 
@@ -39,20 +39,20 @@ while (($line = fgets($handle)) !== false) {
   if (!isset($total_product[$product])) $total_product[$product] = 0;
   $total_product[$product] += 1;
 
-  if (count($match) == 9 && $match[7] != '-') {
-    $uuid = $match[7];
+  if (count($match) == 10 && $match[8] != '-') {
+    $uuid = $match[8];
     if (!isset($unique_product[$product])) $unique_product[$product] = [];
-    if (!isset($unique_product[$product][$uuid])) $unique_product[$product][$uuid] = 0;
-    $unique_product[$product][$uuid] += 1;
-
-    if ($match[8] != '-') {
-      $flavor = $match[8];
-      if (!isset($unique_product_flavor[$product])) $unique_product_flavor[$product] = [];
-      $unique_product_flavor[$product][$uuid] = $flavor;
+    if (!isset($unique_product[$product][$uuid])) {
+      $unique_product[$product][$uuid] = [
+        'count' => 0,
+        'flavor' => $match[9],
+        'ip' => $match[1],
+      ];
     }
+    $unique_product[$product][$uuid]['count'] += 1;
   }
 
-  if (preg_match(REGEX_IMAGE, $match[3], $match_image)) {
+  if (preg_match(REGEX_IMAGE, $match[4], $match_image)) {
     // Remove empty match groups and select non-all match.
     $values = array_filter($match_image);
     $image = next($values);
@@ -76,7 +76,6 @@ if ($position) {
     'total' => $total,
     'total_product' => $total_product,
     'unique_product' => $unique_product,
-    'unique_product_flavor' => $unique_product_flavor,
     'total_image_product' => $total_image_product,
     'total_invalid' => $total_invalid,
     'bytes' => $position,

--- a/metrics/access/ingest.php
+++ b/metrics/access/ingest.php
@@ -9,7 +9,6 @@ $total = 0;
 $total_invalid = 0;
 $total_product = [];
 $unique_product = [];
-$unique_product_flavor = [];
 $total_image_product = [];
 
 $file = $argc == 2 ? $argv[1] : 'php://stdin';
@@ -70,7 +69,6 @@ error_log('found ' . number_format($total) . ' requests across ' .
 
 ksort($total_product);
 ksort($unique_product);
-ksort($unique_product_flavor);
 if ($position) {
   echo json_encode([
     'total' => $total,

--- a/metrics/access/ingest.php
+++ b/metrics/access/ingest.php
@@ -9,6 +9,7 @@ $total = 0;
 $total_invalid = 0;
 $total_product = [];
 $unique_product = [];
+$unique_product_flavor = [];
 $total_image_product = [];
 
 $file = $argc == 2 ? $argv[1] : 'php://stdin';
@@ -43,6 +44,12 @@ while (($line = fgets($handle)) !== false) {
     if (!isset($unique_product[$product])) $unique_product[$product] = [];
     if (!isset($unique_product[$product][$uuid])) $unique_product[$product][$uuid] = 0;
     $unique_product[$product][$uuid] += 1;
+
+    if ($match[8] != '-') {
+      $flavor = $match[8];
+      if (!isset($unique_product_flavor[$product])) $unique_product_flavor[$product] = [];
+      $unique_product_flavor[$product][$uuid] = $flavor;
+    }
   }
 
   if (preg_match(REGEX_IMAGE, $match[3], $match_image)) {
@@ -63,11 +70,13 @@ error_log('found ' . number_format($total) . ' requests across ' .
 
 ksort($total_product);
 ksort($unique_product);
+ksort($unique_product_flavor);
 if ($position) {
   echo json_encode([
     'total' => $total,
     'total_product' => $total_product,
     'unique_product' => $unique_product,
+    'unique_product_flavor' => $unique_product_flavor,
     'total_image_product' => $total_image_product,
     'total_invalid' => $total_invalid,
     'bytes' => $position,

--- a/metrics/access/ingest.php
+++ b/metrics/access/ingest.php
@@ -22,9 +22,9 @@ while (($line = fgets($handle)) !== false) {
   }
 
   // Only interested in GET or HEAD requests, others are invalid.
-  if ($match[2] != 'GET' && $match[2] != 'HEAD') continue;
+  if ($match[3] != 'GET' && $match[3] != 'HEAD') continue;
   // Not interested on errors.
-  if ($match[4] >= '400') continue;
+  if ($match[5] >= '400') continue;
   $total++;
 
   // Attempt to determine for which product was the request.


### PR DESCRIPTION
The change parses information about the `flavor` and `host IP` from the access logs and ingests them to the temporary cache files. The structure of the cache JSON object has been extended.
The aggregation script has been updated to to tag the number of downloads from unique systems (based on Zypper UUID) with `flavor` tag.