### PR TITLE
Move factory-package-news-web.py script to gunicorn

### DIFF
--- a/factory-package-news/factory-package-news-web.service
+++ b/factory-package-news/factory-package-news-web.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Factory Package News Web
+After=syslog.target
+
+[Service]
+ExecStart=/usr/bin/gunicorn -b 127.0.0.1:29001 factory-package-news-web:app -u factory-news -g nogroup -k gevent --chdir /var/lib/openqa/osc-plugin-factory/factory-package-news/ --log-syslog
+Restart=always
+Type=simple
+StandardError=syslog
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This script is used eg. for the /snapshot-changes/opensuse/Tumbleweed
route and was using the WSGIScriptAlias apache command.
With the switch to nginx we need this more modern approach.

Ticket: https://progress.opensuse.org/issues/130312