### PR TITLE
also monitor the SUSE:ALP repositories

### DIFF
--- a/gocd/monitors.gocd.yaml
+++ b/gocd/monitors.gocd.yaml
@@ -89,7 +89,7 @@ pipelines:
                 git config --global user.email "coolo@suse.de"
                 git config --global user.name "GoCD Repo Monitor"
                 cd repos
-                ../scripts/gocd/rabbit-repoid.py -A https://api.suse.de SUSE:SLE
+                ../scripts/gocd/rabbit-repoid.py -A https://api.suse.de SUSE:SLE SUSE:ALP
   openSUSE.Repo.Monitor:
     group: Monitors
     lock_behavior: unlockWhenFinished


### PR DESCRIPTION
reported by openQA, which is not monitoring ALP repos