### PR TITLE
project-installcheck.py: Honour installcheck-ignore-conflicts config + tiny cleanup

### DIFF
--- a/project-installcheck.py
+++ b/project-installcheck.py
@@ -204,7 +204,7 @@ class RepoChecker():
                 # so if some other perl error happens, we don't continue
                 raise CorruptRepos
 
-            target_packages = []
+            target_packages = {}
             with open(os.path.join(dir, 'catalog.yml')) as file:
                 catalog = yaml.safe_load(file)
                 if catalog is not None:

--- a/project-installcheck.py
+++ b/project-installcheck.py
@@ -211,20 +211,21 @@ class RepoChecker():
                     target_packages = catalog.get(directories[0], [])
 
             parsed = parsed_installcheck([pfile] + primaryxmls, arch, target_packages, [])
-            for package in parsed:
-                parsed[package]['output'] = "\n".join(parsed[package]['output'])
 
-            # let's risk a N*N algorithm in the hope that we have a limited N
-            for package1 in parsed:
-                output = parsed[package1]['output']
-                for package2 in parsed:
-                    if package1 == package2:
-                        continue
-                    output = output.replace(parsed[package2]['output'], 'FOLLOWUP(' + package2 + ')')
-                parsed[package1]['output'] = output
+        for package in parsed:
+            parsed[package]['output'] = "\n".join(parsed[package]['output'])
 
-            for package in parsed:
-                parsed[package]['output'] = self._split_and_filter(parsed[package]['output'])
+        # let's risk a N*N algorithm in the hope that we have a limited N
+        for package1 in parsed:
+            output = parsed[package1]['output']
+            for package2 in parsed:
+                if package1 == package2:
+                    continue
+                output = output.replace(parsed[package2]['output'], 'FOLLOWUP(' + package2 + ')')
+            parsed[package1]['output'] = output
+
+        for package in parsed:
+            parsed[package]['output'] = self._split_and_filter(parsed[package]['output'])
 
         url = makeurl(self.apiurl, ['build', project, '_result'], {'repository': repository, 'arch': arch})
         root = ET.parse(http_GET(url)).getroot()


### PR DESCRIPTION
Now we have some packages in the distro which fail installcheck
semi-intentionally: libstdc++6-gccX (with X < system GCC) conflicts with rpm
indirectly. While this can be ignored in stagings already, this caused an issue
once it's in the distro: The installcheck failure contains the release number
and so it gets rebuilt all the time in the hope to make it installable again.