### PR TITLE
dist: Pick osc from repo built against published Tumbleweed

### DIFF
--- a/dist/ci/testenv-tumbleweed/Dockerfile
+++ b/dist/ci/testenv-tumbleweed/Dockerfile
@@ -2,7 +2,7 @@
 FROM opensuse/tumbleweed
 
 # make sure we see osc regressions earlier than it hitting tumbleweed
-RUN zypper -n ar http://download.opensuse.org/repositories/openSUSE:/Tools/openSUSE_Factory/ openSUSE:Tools
+RUN zypper -n ar http://download.opensuse.org/repositories/openSUSE:/Tools/openSUSE_Tumbleweed/ openSUSE:Tools
 RUN zypper --gpg-auto-import-keys ref
 
 RUN zypper in -y osc python3-pytest python3-httpretty python3-pyxdg python3-PyYAML \


### PR DESCRIPTION
Currently it picks osc built against openSUSE:Factory/standard, causing a mismatch in Python versions.

I manually switched https://build.opensuse.org/package/show/openSUSE:Tools:Images/osrt-testenv-tumbleweed over to this branch to unbreak it.