### PR TITLE
project-installcheck.py: Don't include ignored errors in rebuildpacs.yaml

### DIFF
--- a/project-installcheck.py
+++ b/project-installcheck.py
@@ -260,6 +260,8 @@ class RepoChecker():
                 continue
             if per_source[source]['ignored']:
                 self.logger.debug("All binaries failing the check are ignored")
+                if source in oldstate['check']:
+                    del oldstate['check'][source]
                 continue
             old_output = oldstate['check'].get(source, {}).get('problem', [])
             if sorted(old_output) == sorted(per_source[source]['output']):


### PR DESCRIPTION
This file is used as input for the reminder bot, so avoid reminding and sending del reqs for ignored packages.