### PR TITLE
version_calculate: chdir to the osclib dir

### DIFF
--- a/osclib/common.py
+++ b/osclib/common.py
@@ -3,10 +3,13 @@ NAME = 'openSUSE-release-tools'
 
 def version_calculate():
     from os import path
-    if path.exists('.git'):
+    # osclib is most likely "installed" via a symlink in ~/.osc-plugins
+    # => need to resolve the relative path
+    osc_release_tools_dir = path.abspath(path.join(path.realpath(path.dirname(__file__)), ".."))
+    if path.exists(path.join(osc_release_tools_dir, ".git")):
         from osclib.git import describe
         try:
-            return describe()
+            return describe(directory=osc_release_tools_dir)
         except FileNotFoundError:
             pass  # Fall through to final return.
 


### PR DESCRIPTION
`version_calculate()` calls describe in the current working dir, but that fails in git repositories without any commits in them. Actually we should be calling this in the osc-release-tools repository instead, hence fixing this issue.