### PR TITLE
Attempt to publish BCI repos more often

### DIFF
--- a/gocd/bci.gocd.yaml
+++ b/gocd/bci.gocd.yaml
@@ -131,7 +131,7 @@ pipelines:
     group: BCI
     lock_behavior: unlockWhenFinished
     timer:
-      spec: 0 23 9 ? * *
+      spec: 0 23 * ? * *
       only_on_changes: false
     materials:
       git:
@@ -239,7 +239,7 @@ pipelines:
     group: BCI
     lock_behavior: unlockWhenFinished
     timer:
-      spec: 0 23 9 ? * *
+      spec: 0 23 * ? * *
       only_on_changes: false
     materials:
       git:
@@ -347,7 +347,7 @@ pipelines:
     group: BCI
     lock_behavior: unlockWhenFinished
     timer:
-      spec: 0 23 9 ? * *
+      spec: 0 23 * ? * *
       only_on_changes: false
     materials:
       git:
@@ -455,7 +455,7 @@ pipelines:
     group: BCI
     lock_behavior: unlockWhenFinished
     timer:
-      spec: 0 23 9 ? * *
+      spec: 0 23 * ? * *
       only_on_changes: false
     materials:
       git:

--- a/gocd/bci.gocd.yaml.erb
+++ b/gocd/bci.gocd.yaml.erb
@@ -131,7 +131,7 @@ pipelines:
     group: BCI
     lock_behavior: unlockWhenFinished
     timer:
-      spec: 0 23 9 ? * *
+      spec: 0 23 * ? * *
       only_on_changes: false
     materials:
       git:

--- a/gocd/bci_repo_publish.py
+++ b/gocd/bci_repo_publish.py
@@ -120,6 +120,14 @@ class BCIRepoPublisher(ToolBase.ToolBase):
             self.logger.info('Current build already published, nothing to do.')
             return
 
+        # If the last published build is less than a day old, don't publish
+        newest_published_mtime = max([int(pkg['published_mtime']) for pkg in packages])
+        published_build_age_hours = int(time.time() - newest_published_mtime) // (60 * 60)
+        if published_build_age_hours < 24:
+            self.logger.info('Current published build less than a day old '
+                             f'({published_build_age_hours}h).')
+            return
+
         # Check openQA results
         openqa_passed = True
         for pkg in packages:


### PR DESCRIPTION
The goal is to publish the repo at most daily. Previously this was ensured by simply running the bot only once a day. However, due to OBS and openQA timing this was frequently attempted when either of those wasn't done yet, which happened several times in a row. To not miss times when they align, attempt publishing more often but skip a build if the previous publish was recent enough.