### PR TITLE
Draft: check_tags_in_request: search on the linked Factory project as well

### DIFF
--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -25,7 +25,7 @@ class FactorySourceChecker(ReviewBot.ReviewBot):
 
     def __init__(self, *args, **kwargs):
         ReviewBot.ReviewBot.__init__(self, *args, **kwargs)
-        self.factory = ["openSUSE:Factory"]
+        self.factory = ["openSUSE:Factory", "openSUSE.org:openSUSE:Factory"]
         self.review_messages = {'accepted': 'ok', 'declined': 'the package needs to be accepted in Factory first'}
         self.history_limit = 5
 
@@ -150,7 +150,7 @@ class TagChecker(ReviewBot.ReviewBot):
 
     def __init__(self, *args, **kwargs):
         super(TagChecker, self).__init__(*args, **kwargs)
-        self.factory = ["openSUSE:Factory"]
+        self.factory = ["openSUSE:Factory", "openSUSE.org:openSUSE:Factory"]
         self.review_messages['declined'] = """
 (This is a script, so report bugs)
 

--- a/tests/test.oscrc
+++ b/tests/test.oscrc
@@ -12,3 +12,10 @@ user=dummy
 pass=dummy
 overridden-by-local = local
 
+# IBS links the build.opensuse.org project space
+# into openSUSE.org:
+[openSUSE.org:openSUSE:Factory]
+# https://github.com/openSUSE/osc/issues/667
+user=dummy
+pass=dummy
+overridden-by-local = local


### PR DESCRIPTION
The IBS instance embeds the whole project space of build.opensuse.org under openSUSE.org:.

This change allows for the changelog checker to search there as well, thus fixing checkTagNotRequired() when running inside the IBS.