### PR TITLE
check_source.py: Don't skip various checks and reviews for non-spec packages

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -266,17 +266,13 @@ class CheckSource(ReviewBot.ReviewBot):
             return False
 
         specs = [os.path.basename(x) for x in glob.glob(os.path.join(target_package, "*.spec"))]
-        if not specs:
-            # package without spec files e.g kiwi only
-            return True
-
-        if not self.check_spec_policy('_old', target_package, specs):
+        if specs and not self.check_spec_policy('_old', target_package, specs):
             return False
 
         if not self.run_source_validator('_old', target_package):
             return False
 
-        if not self.detect_mentioned_patches('_old', target_package, specs):
+        if specs and not self.detect_mentioned_patches('_old', target_package, specs):
             return False
 
         if not self.check_urls('_old', target_package, specs):


### PR DESCRIPTION
There was an early exit for packages which don't have a .spec file, but that is too early and skipped important parts like running the source_validator and download_files services and adding the review-team review.