### PR TITLE
Disable aggregating over financial year

### DIFF
--- a/metrics/access/aggregate.php
+++ b/metrics/access/aggregate.php
@@ -154,7 +154,7 @@ function subprocess_count()
 function aggregate_all($period)
 {
   global $CACHE_DIR;
-  $intervals = ['day' => 'Y-m-d', 'week' => 'Y-W', 'month' => 'Y-m', 'FQ' => null, 'FY' => null];
+  $intervals = ['day' => 'Y-m-d', 'week' => 'Y-W', 'month' => 'Y-m', 'FQ' => null];
   $merged = [];
   $merged_protocol = [];
   $date_previous = null;


### PR DESCRIPTION
Holding all the UID statistics over the whole year consumes too much memory.