### PR TITLE
project-installcheck.py: Support arch-specific ignore-conflicts config

### DIFF
--- a/project-installcheck.py
+++ b/project-installcheck.py
@@ -240,7 +240,8 @@ class RepoChecker():
 
         per_source = dict()
 
-        ignore_conflicts = Config.get(self.apiurl, project).get('installcheck-ignore-conflicts', '').split(' ')
+        ignore_conflicts = config.get('installcheck-ignore-conflicts', '').split() + \
+            config.get(f'installcheck-ignore-conflicts-{arch}', '').split()
 
         for package, entry in parsed.items():
             source = "{}/{}/{}/{}".format(project, repository, arch, entry['source'])


### PR DESCRIPTION
Sometimes installcheck failures should be ignored for a specific architecture only.