### PR TITLE
gocd/rabbit-openqa.py: Ignore jobs without group

### DIFF
--- a/gocd/rabbit-openqa.py
+++ b/gocd/rabbit-openqa.py
@@ -292,7 +292,7 @@ class Listener(PubSubConsumer):
 
     def is_production_job(self, job):
         if '/' in job['settings'].get('BUILD', '/') or \
-           'Development' in job['group']:
+           'group' not in job or 'Development' in job['group']:
             return False
 
         return True


### PR DESCRIPTION
Jobs without a group are not production jobs either. This also avoids a KeyError later.