### PR TITLE
Release bci repositories per architecture independently

### DIFF
--- a/gocd/bci_repo_publish.py
+++ b/gocd/bci_repo_publish.py
@@ -134,6 +134,7 @@ class BCIRepoPublisher(ToolBase.ToolBase):
             return
 
         # Check openQA results
+        mandatory_arches = ('aarch64', 'x86_64')
         for pkg in packages:
             passed = 0
             pending = 0
@@ -148,14 +149,13 @@ class BCIRepoPublisher(ToolBase.ToolBase):
                 else:
                     self.logger.warning(f'https://openqa.suse.de/tests/{job["id"]} failed')
                     failed += 1
-            if passed == 0 or pending > 0 or failed > 0:
+            if pending or failed:
                 self.logger.info(f'openQA did not (yet) pass for {pkg["name"]}: {passed}/{pending}/{failed}')
                 continue
+            if passed == 0 and pkg['arch'] in mandatory_arches:
+                self.logger.info('No positive result from openQA (yet)')
+                return
             openqa_passed_packages.append(pkg)
-
-        if not openqa_passed_packages:
-            self.logger.info(f'No positive result from openQA (yet)')
-            return
 
         # Trigger publishing
         if token is None:

--- a/gocd/bci_repo_publish.py
+++ b/gocd/bci_repo_publish.py
@@ -60,7 +60,7 @@ class BCIRepoPublisher(ToolBase.ToolBase):
         return self.openqa.openqa_request('GET', 'jobs', values)['jobs']
 
     def is_repo_published(self, project, repo, arch=None):
-        """Validates that the given prj/repo is fully published and all builds
+        """Validate that the given prj/repo is fully published and all builds
         have succeeded."""
         result_filter = {'view': 'summary', 'repository': repo}
         if arch:
@@ -197,8 +197,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
 
     @cmdln.option('--token', help='The token for publishing. Does a dry run if not given.')
     def do_run(self, subcmd, opts, project):
-        """${cmd_name}: run the BCI repo publisher for the specified project,
-        e.g. 15-SP3
+        """${cmd_name}: run BCI repo publisher for the project, e.g. 15-SP5.
 
         ${cmd_usage}
         ${cmd_option_list}

--- a/gocd/bci_repo_publish.py
+++ b/gocd/bci_repo_publish.py
@@ -19,6 +19,7 @@ import re
 from lxml import etree as ET
 from openqa_client.client import OpenQA_Client
 from osc.core import http_GET, makeurl
+from random import randint
 
 
 class BCIRepoPublisher(ToolBase.ToolBase):
@@ -178,7 +179,7 @@ class BCIRepoPublisher(ToolBase.ToolBase):
         for pkg in openqa_passed_packages:
             while not self.is_repo_published(pkg['publish_prj'], 'images'):
                 self.logger.debug(f'Waiting for {pkg["publish_prj"]}')
-                time.sleep(20)
+                time.sleep(randint(10, 30))
 
 
 class CommandLineInterface(ToolBase.CommandLineInterface):


### PR DESCRIPTION
There is no real good reason to wait for all the architectures to pass testing, so if there is one architecture finished, release it.