### PR TITLE
Update factory dashboard rsync target

### DIFF
--- a/gocd/dashboard.generator.gocd.yaml
+++ b/gocd/dashboard.generator.gocd.yaml
@@ -22,4 +22,4 @@ pipelines:
             set -e
             PYTHONPATH=$PWD python3 ./dashboard/generate.py -p openSUSE:Factory > dashboard/output/index.html
             PYTHONPATH=$PWD python3 ./dashboard/generate.py -p openSUSE:Leap > dashboard/output/leap.html
-            rsync -av dashboard/output/ rsync://coolo@195.135.221.140:11873/factory-dashboard.opensuse.org/
+            rsync -av dashboard/output/ rsync://coolo@proxy-prg2.opensuse.org:11873/factory-dashboard.opensuse.org/


### PR DESCRIPTION
Machine moved to a new location, use DNS name of the new proxy server.

See https://progress.opensuse.org/issues/139118.