### PR TITLE
Revert "factory-package-news.py: Compress data files with zstd"

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -57,8 +57,6 @@ Requires:       python3-lxml
 Requires:       python3-pycurl
 Requires:       python3-python-dateutil
 Requires:       python3-pyxdg
-# factory-package-news.py
-Requires:       python3-zstandard
 Requires:       python3-requests
 # typing extensions are needed on SLE & Leap
 %if 0%{?suse_version} <= 1500


### PR DESCRIPTION
Reverts openSUSE/openSUSE-release-tools#3039

`TypeError: 'closefd' is an invalid keyword argument for this function` argh. There's no good way to use zstd from python on Leap apparently.