### PR TITLE
check_source.py: Use correct function for getting maintainer of the devel pkg

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -896,7 +896,7 @@ class CommandLineInterface(cmdln.Cmdln):
         conf.get_config(override_apiurl=self.options.apiurl)
 
         if (self.options.osc_debug):
-            conf.config['debug'] = 1
+            conf.config['debug'] = True
 
         self.checker = self.setup_checker()
         if self.options.config:

--- a/check_source.py
+++ b/check_source.py
@@ -22,7 +22,7 @@ from osclib.core import entity_exists
 from osclib.core import group_members
 from osclib.core import package_kind
 from osclib.core import create_add_role_request
-from osclib.core import maintainers_get
+from osclib.core import package_role_expand
 from osc.core import show_package_meta, show_project_meta
 from osc.core import get_request_list
 from urllib.error import HTTPError
@@ -300,7 +300,7 @@ class CheckSource(ReviewBot.ReviewBot):
             devel_project, devel_package = devel_project_fallback(self.apiurl, target_project, target_package)
             if devel_project and devel_package:
                 submitter = self.request.creator
-                maintainers = set(maintainers_get(self.apiurl, devel_project, devel_package))
+                maintainers = set(package_role_expand(self.apiurl, devel_project, devel_package))
                 known_maintainer = False
                 if maintainers:
                     if submitter in maintainers:


### PR DESCRIPTION
"maintainers_get" is a bit weird and uses /search/owner and not the given prj.

Noticed in https://build.opensuse.org/request/show/1132698.