### PR TITLE
publish bci repo right away on package set changes

### DIFF
--- a/gocd/bci_repo_publish.py
+++ b/gocd/bci_repo_publish.py
@@ -141,9 +141,8 @@ class BCIRepoPublisher(ToolBase.ToolBase):
 
         # If the last published build is less than a day old, don't publish
         oldest_published_mtime = min([int(pkg['published_mtime']) for pkg in packages])
-        published_disturls = {pkg['published_srcmd5'] for pkg in packages}
         published_build_age_hours = int(time.time() - oldest_published_mtime) // (60 * 60)
-        pending_source_changes = published_disturls.difference({pkg['built_srcmd5']for pkg in packages})
+        pending_source_changes = [pkg['name'] for pkg in packages if pkg['built_srcmd5'] != pkg['published_srcmd5']]
         if pending_source_changes:
             self.logger.info(f"Pending source changes to published, skipping waiting for 24h: {pending_source_changes}")
             # If the source commit different than the published version, we

--- a/gocd/bci_repo_publish.py
+++ b/gocd/bci_repo_publish.py
@@ -142,7 +142,9 @@ class BCIRepoPublisher(ToolBase.ToolBase):
         # If the last published build is less than a day old, don't publish
         oldest_published_mtime = min([int(pkg['published_mtime']) for pkg in packages])
         published_build_age_hours = int(time.time() - oldest_published_mtime) // (60 * 60)
-        pending_source_changes = [pkg['name'] for pkg in packages if pkg['built_srcmd5'] != pkg['published_srcmd5']]
+        pending_source_changes = [
+            f"{pkg['name']}: {pkg['built_srcmd5']}/{pkg['published_srcmd5']}"
+            for pkg in packages if pkg['built_srcmd5'] != pkg['published_srcmd5']]
         if pending_source_changes:
             self.logger.info(f"Pending source changes to published, skipping waiting for 24h: {pending_source_changes}")
             # If the source commit different than the published version, we


### PR DESCRIPTION
When there was a source commit on the bci repo, then the set of packages changed, which likely means we need those changes to pass the tests on the container release pipelines. So don't wait for 24h but publish right away.

Also trigger on the oldest published state rather than the newest one so that we do not need to wait another 24h per openQA failure to resume publishing.