### PR TITLE
Support package search in owner_fallback() and search package instead of binary in check_source

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -300,7 +300,7 @@ class CheckSource(ReviewBot.ReviewBot):
             devel_project, devel_package = devel_project_fallback(self.apiurl, target_project, target_package)
             if devel_project and devel_package:
                 submitter = self.request.creator
-                maintainers = set(maintainers_get(self.apiurl, devel_project, devel_package))
+                maintainers = set(maintainers_get(self.apiurl, devel_project, devel_package, search_mode='package'))
                 known_maintainer = False
                 if maintainers:
                     if submitter in maintainers:

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -120,17 +120,19 @@ def convert_from_osc_et(xml):
 
 
 @memoize(session=True)
-def owner_fallback(apiurl, project, package):
-    root = owner(apiurl, package, project=project)
+def owner_fallback(apiurl, project, package, search_mode='binary'):
+    # binary is the default search mode in owner()
+    root = owner(apiurl, package, project=project, mode=search_mode)
     entry = root.find('owner') if root else None
     if not entry or project.startswith(entry.get('project')):
         # Fallback to global (ex Factory) maintainer.
-        root = owner(apiurl, package)
+        root = owner(apiurl, package, mode=search_mode)
     return convert_from_osc_et(root)
 
 
 @memoize(session=True)
-def maintainers_get(apiurl, project, package=None):
+def maintainers_get(apiurl, project, package=None, search_mode='binary'):
+    # owner() supports two search mode: binary and package
     if package is None:
         meta = ET.fromstringlist(show_project_meta(apiurl, project))
         maintainers = meta.xpath('//person[@role="maintainer"]/@userid')
@@ -140,7 +142,7 @@ def maintainers_get(apiurl, project, package=None):
 
         return maintainers
 
-    root = owner_fallback(apiurl, project, package)
+    root = owner_fallback(apiurl, project, package, search_mode)
     maintainers = root.xpath('//person[@role="maintainer"]/@name')
 
     groups = root.xpath('//group[@role="maintainer"]/@name')


### PR DESCRIPTION
`owner()` supports two search mode: binary and package, the default one is `binary`, in some cases we should search `package` instead like for source checker.

The difference in API call is `/search/owner?package=xxx` vs. `/search/owner?binary=xxx`, try with livecd-openSUSE on binary search mode it gives empty collection since there is no binary matches livecd-openSUSE, with the package search mode, it gives the right result as searched by package name.