### PR TITLE
Don't abort if weakremover.inc don't exist on source project

### DIFF
--- a/gocd/microos.target.gocd.yaml
+++ b/gocd/microos.target.gocd.yaml
@@ -66,3 +66,69 @@ pipelines:
                 sleep 600
             done
             osc -A https://api.suse.de/ api "/build/SUSE:ALP:Products:Marble:6.0:PUBLISH/_result?view=summary&repository=product" | grep "result project" | grep 'code="published" state="published">' && echo PUBLISHED
+  SLCS.Images:
+    group: MicroOS
+    lock_behavior: unlockWhenFinished
+    materials:
+      repos:
+        git: git://botmaster.suse.de/suse-repos.git
+        auto_update: true
+        whitelist:
+          - SUSE:SLFO:Products:SLCS:6.0_-_images.yaml
+        destination: repos
+      scripts:
+        auto_update: true
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+        whitelist:
+          - DO_NOT_TRIGGER
+        destination: scripts
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    stages:
+    - Expect.Images.To.Finish:
+        resources:
+        - staging-bot
+        tasks:
+        - script: |
+            export PYTHONPATH=scripts
+            ./scripts/gocd/verify-repo-built-successful.py -A https://api.suse.de -p SUSE:SLFO:Products:SLCS:6.0 -r images
+
+    - Release.Images.To.Test:
+        approval: manual
+        roles:
+        - SLE
+        environment_variables:
+          OSC_CONFIG: /home/go/config/oscrc-totest-manager
+        resources:
+        - staging-bot
+        tasks:
+        - script: |-
+            set -e
+            for product in 000productcompose SLCS; do
+              osc -A https://api.suse.de release SUSE:SLFO:Products:SLCS:6.0 $product
+            done
+            sleep 600
+            while (osc -A https://api.suse.de/ api "/build/SUSE:SLFO:Products:SLCS:6.0:ToTest/_result?view=summary&repository=product" | grep "result project" | grep -v 'code="published" state="published">'); do
+                echo PENDING
+                sleep 600
+            done
+            osc -A https://api.suse.de/ api "/build/SUSE:SLFO:Products:SLCS:6.0:ToTest/_result?view=summary&repository=product" | grep "result project" | grep 'code="published" state="published">' && echo PUBLISHED
+
+    - Release.Images.To.Publish:
+        approval: manual
+        roles:
+        - SLE
+        environment_variables:
+          OSC_CONFIG: /home/go/config/oscrc-totest-manager
+        resources:
+        - staging-bot
+        tasks:
+        - script: |-
+            set -e
+            osc -A https://api.suse.de release SUSE:SLFO:Products:SLCS:6.0:ToTest
+            sleep 600
+            while (osc -A https://api.suse.de/ api "/build/SUSE:SLFO:Products:SLCS:6.0:PUBLISH/_result?view=summary&repository=product" | grep "result project" | grep -v 'code="published" state="published">'); do
+                echo PENDING
+                sleep 600
+            done
+            osc -A https://api.suse.de/ api "/build/SUSE:SLFO:Products:SLCS:6.0:PUBLISH/_result?view=summary&repository=product" | grep "result project" | grep 'code="published" state="published">' && echo PUBLISHED

--- a/osclib/freeze_command.py
+++ b/osclib/freeze_command.py
@@ -251,7 +251,7 @@ class FreezeCommand(object):
             inc = osc.core.http_GET(sourceurl).read()
             sourceurl_exists=True
         except HTTPError:
-            sourceurlurl_exists=False
+            sourceurl_exists=False
         if targeturl_exists != sourceurl_exists:
             raise Exception("weakremover.inc doesn't exist in both Staging and Parent project, please fix")
         if not(targeturl_exists) and not(sourceurl_exists):

--- a/osclib/freeze_command.py
+++ b/osclib/freeze_command.py
@@ -243,13 +243,22 @@ class FreezeCommand(object):
             targeturl = self.api.makeurl(['source', self.prj, '000release-packages', 'weakremovers.inc'],
                                          {'comment': 'Update weakremovers.inc'})
             oldinc = osc.core.http_GET(targeturl).read()
+            targeturl_exists=True
+        except HTTPError:
+            targeturl_exists=False
+        try:
             sourceurl = self.api.makeurl(['source', self.api.project, '000release-packages', 'weakremovers.inc'])
             inc = osc.core.http_GET(sourceurl).read()
-            if inc != oldinc:
-                osc.core.http_PUT(targeturl, data=inc)
+            sourceurl_exists=True
         except HTTPError:
-            # if it doesn't exist, don't update
+            sourceurlurl_exists=False
+        if targeturl_exists != sourceurl_exists:
+            raise Exception("weakremover.inc doesn't exist in both Staging and Parent project, please fix")
+        if not(targeturl_exists) and not(sourceurl_exists):
+            # nothing to do
             return
+        if inc != oldinc:
+            osc.core.http_PUT(targeturl, data=inc)
 
     def is_bootstrap(self):
         """Check if there is a bootstrap copy repository."""

--- a/osclib/freeze_command.py
+++ b/osclib/freeze_command.py
@@ -243,18 +243,18 @@ class FreezeCommand(object):
             targeturl = self.api.makeurl(['source', self.prj, '000release-packages', 'weakremovers.inc'],
                                          {'comment': 'Update weakremovers.inc'})
             oldinc = osc.core.http_GET(targeturl).read()
-            targeturl_exists=True
+            targeturl_exists = True
         except HTTPError:
-            targeturl_exists=False
+            targeturl_exists = False
         try:
             sourceurl = self.api.makeurl(['source', self.api.project, '000release-packages', 'weakremovers.inc'])
             inc = osc.core.http_GET(sourceurl).read()
-            sourceurl_exists=True
+            sourceurl_exists = True
         except HTTPError:
-            sourceurl_exists=False
+            sourceurl_exists = False
         if targeturl_exists != sourceurl_exists:
             raise Exception("weakremover.inc doesn't exist in both Staging and Parent project, please fix")
-        if not(targeturl_exists) and not(sourceurl_exists):
+        if not (targeturl_exists) and not (sourceurl_exists):
             # nothing to do
             return
         if inc != oldinc:

--- a/osclib/freeze_command.py
+++ b/osclib/freeze_command.py
@@ -243,13 +243,13 @@ class FreezeCommand(object):
             targeturl = self.api.makeurl(['source', self.prj, '000release-packages', 'weakremovers.inc'],
                                          {'comment': 'Update weakremovers.inc'})
             oldinc = osc.core.http_GET(targeturl).read()
+            sourceurl = self.api.makeurl(['source', self.api.project, '000release-packages', 'weakremovers.inc'])
+            inc = osc.core.http_GET(sourceurl).read()
+            if inc != oldinc:
+                osc.core.http_PUT(targeturl, data=inc)
         except HTTPError:
             # if it doesn't exist, don't update
             return
-        sourceurl = self.api.makeurl(['source', self.api.project, '000release-packages', 'weakremovers.inc'])
-        inc = osc.core.http_GET(sourceurl).read()
-        if inc != oldinc:
-            osc.core.http_PUT(targeturl, data=inc)
 
     def is_bootstrap(self):
         """Check if there is a bootstrap copy repository."""


### PR DESCRIPTION
For ALP, weakremover.inc might not be part of the staging parent project. Just ignore 404 error in that case.