### PR TITLE
Initial pipeline setup for Leap Micro 6.0

### DIFF
--- a/gocd/leapmicro.target.gocd.yaml
+++ b/gocd/leapmicro.target.gocd.yaml
@@ -17,7 +17,7 @@ pipelines:
         resources:
         - repo-checker
         tasks:
-          - script: ./pkglistgen.py -A https://api.opensuse.org update_and_solve -p openSUSE:Leap:Micro:5.5 -s target --only-release-packages
+          - script: ./pkglistgen.py -A https://api.opensuse.org update_and_solve -p openSUSE:Leap:Micro:6.0 -s target --only-release-packages
 
   LeapMicro.Package.Lists:
     group: Leap
@@ -35,4 +35,4 @@ pipelines:
         resources:
         - repo-checker
         tasks:
-          - script: ./pkglistgen.py -A https://api.opensuse.org --debug update_and_solve -p openSUSE:Leap:Micro:5.5 -s target
+          - script: ./pkglistgen.py -A https://api.opensuse.org --debug update_and_solve -p openSUSE:Leap:Micro:6.0 -s target

--- a/gocd/totestmanager.gocd.yaml
+++ b/gocd/totestmanager.gocd.yaml
@@ -315,7 +315,7 @@ pipelines:
         - script: |-
             install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
             scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.6:ARM:Images
-  TTM.Leap_Micro_5.5:
+  TTM.Leap_Micro_6.0:
     group: openSUSE.Checkers
     lock_behavior: unlockWhenFinished
     environment_variables:
@@ -335,8 +335,8 @@ pipelines:
         tasks:
         - script: |-
             install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
-            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:Micro:5.5
-  TTM.Leap_Micro_5.5_Images:
+            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:Micro:6.0
+  TTM.Leap_Micro_6.0_Images:
     group: openSUSE.Checkers
     lock_behavior: unlockWhenFinished
     environment_variables:
@@ -356,4 +356,4 @@ pipelines:
         tasks:
         - script: |-
             install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
-            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:Micro:5.5:Images
+            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:Micro:6.0:Images

--- a/gocd/totestmanager.gocd.yaml.erb
+++ b/gocd/totestmanager.gocd.yaml.erb
@@ -16,8 +16,8 @@ pipelines:
       openSUSE:Leap:15.6:Images
       openSUSE:Leap:15.6:ARM
       openSUSE:Leap:15.6:ARM:Images
-      openSUSE:Leap:Micro:5.5
-      openSUSE:Leap:Micro:5.5:Images
+      openSUSE:Leap:Micro:6.0
+      openSUSE:Leap:Micro:6.0:Images
   ) -%>
   TTM.<%= project.gsub('openSUSE:', '').gsub(':', '_') %>:
     group: openSUSE.Checkers

--- a/publish_distro_conf/publish_leap-micro60.config
+++ b/publish_distro_conf/publish_leap-micro60.config
@@ -1,0 +1,50 @@
+# vim:syntax=sh
+
+micro_version=6.0
+qu="" # empty string for GA, QuarterlyUpdate repins have -N in version
+logfile_base=~/publish_logs/$micro_version/$(date -d "$date" '+%Y/%m/%d/%H%M')
+synclog="${logfile_base}.log"
+deletelog="${logfile_base}-deletes.log"
+path="/distribution/leap-micro/$micro_version/product"
+flavors=(DVD-x86_64 DVD-aarch64)
+
+get_version() {
+	# get expected version from first flavor
+	if [ -z "$version" ]; then
+		version=`echo $stage/iso/openSUSE-Leap-Micro-$micro_version$qu-$flavor-Build[0123456789]*.[0123456789]*-Media.iso`
+		version=${version##*Build}
+		version=${version%-*}
+		if [ -z "$version" ]; then
+			echo "no version found, exit." | tee -a $synclog
+			exit 1
+		fi
+	fi
+}
+
+get_iso()
+{
+	iso="openSUSE-Leap-Micro-$micro_version$qu-$flavor-Build$version-Media.iso"
+}
+
+get_iso_link()
+{
+	link="$stage/iso/openSUSE-Leap-$micro_version$qu-$flavor-Current.iso"
+}
+
+get_diff_url()
+{
+	url="$diff_url_base/$micro_version/diff/$version"
+}
+
+get_mark_published_url()
+{
+	url="$diff_url_base/$micro_version/current"
+}
+
+get_changes_filename()
+{
+	# ChangeLog files from obsgendiff are used instead
+	#changes="$changes_dir_base/jump/$jump_version/Changes.$version.txt"
+	:
+#	changes="$changes_dir_base/leap/$micro_version/Changes.$version.txt"
+}

--- a/publish_distro_conf/publish_leap-micro60_appliances.config
+++ b/publish_distro_conf/publish_leap-micro60_appliances.config
@@ -1,0 +1,58 @@
+# vim:syntax=sh
+
+micro_version=6.0
+release=0
+logfile_base=~/publish_logs/$micro_version-appliances/$(date -d "$date" '+%Y/%m/%d/%H%M')
+synclog="${logfile_base}.log"
+deletelog="${logfile_base}-deletes.log"
+path="/distribution/leap-micro/$micro_version/appliances"
+flavors=(Default Default-RT Default-SelfInstall)
+repos=()
+extra_repos=()
+isodir=""
+
+get_version() {
+	# get expected version from first flavor
+	if [ -z "$version" ]; then
+		version=`echo $stage/openSUSE-Leap-Micro.x86_64-$micro_version.$release-$flavor-Build*.raw.xz`
+		version=${version##*Build}
+		version=${version%.*}
+		if [ -z "$version" ]; then
+			echo "no version found, exit." | tee -a $synclog
+			exit 1
+		fi
+	fi
+}
+
+_get_iso()
+{
+	local snapshot="$1"
+	local suffix=xz
+#	echo "openSUSE-Leap-Micro-$micro_version-JeOS.x86_64-$micro_version.0-$flavor-$snapshot.$suffix"
+	echo "openSUSE-Leap-Micro.x86_64-$micro_version.$release-$flavor-$snapshot.$suffix"
+}
+
+get_iso()
+{
+	iso=`_get_iso "Build$version"`
+}
+
+get_iso_link()
+{
+	link="$stage/`_get_iso Current`"
+}
+
+get_diff_url()
+{
+	url=""
+}
+
+get_mark_published_url()
+{
+	url=""
+}
+
+get_changes_filename()
+{
+	changes=""
+}


### PR DESCRIPTION
Regarding publish_distro Seems like initial configuration suggests that we'll use two digit versioning (6.0) for images rather than three digit (5.5.0) if we mimic SLEM 6.0) but that can be tweaked on the way, once there is something to be published.

Right now pkglistgen is what I care about.