### PR TITLE
gocd: add rebuild pipeline for ALP

### DIFF
--- a/gocd/rebuild-trigger-alp.gocd.yaml
+++ b/gocd/rebuild-trigger-alp.gocd.yaml
@@ -1,0 +1,22 @@
+format_version: 3
+pipelines:
+  Trigger.Rebuild.Factory:
+    group: ALP.Checkers
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    materials:
+      script:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    timer:
+      spec: 0 0 * ? * *
+      only_on_changes: false
+    stages:
+    - Run:
+        approval: manual
+        resources:
+          - repo-checker
+        tasks:
+          - script: |-
+              echo "ALP Standard"
+              ./project-installcheck.py -A https://api.suse.de --debug check --add-comments --store SUSE:ALP:Source:Standard:1.0:Staging/dashboard SUSE:ALP:Source:Standard:1.0


### PR DESCRIPTION
This is needed when we switch ALP Standard to rebuild=direct