### PR TITLE
build-fail-reminder: don't escape characters

### DIFF
--- a/build-fail-reminder.py
+++ b/build-fail-reminder.py
@@ -242,7 +242,7 @@ def main(args):
                 # Package failed to build for 6 weeks - file a delete request
                 r = osc.core.Request()
                 r.add_action('delete', tgt_project=project, tgt_package=package)
-                r.description = "[botdel] Package has had build problems for &gt;= 6 weeks"
+                r.description = "[botdel] Package has had build problems for >= 6 weeks"
                 r.create(apiurl)
 
     if len(ProjectComplainList):


### PR DESCRIPTION
osc uses the string literally, make the generated log entry more readable by using the correct characters instead of a character reference.

Previous behavior were  commit messages showing character references which are not useful for humans:

```
$ osc log -D openSUSE:Factory kopete |head -4
----------------------------------------------------------------------------
r134 | anag+factory | 2024-02-08 18:02:03 | 8b84f116348051059ea6ac6b364667a7 | 23.08.4 | rq1144747

[botdel] Package has had build problems for &gt;= 6 weeks
```

Change tested using:

```
r = osc.core.Request()
r.add_action('delete', tgt_project='home:crameleon:ignore', tgt_package='dummy2')
r.description = 'foo >= 1'
r.create('https://api.opensuse.org')

$ osc request list home:crameleon:ignore dummy2
1147567  State:new        By:crameleon    When:2024-02-19T12:18:04
        Created by: crameleon
        delete:                                                             home:crameleon:ignore/dummy2
        Descr: foo >= 1
 

$ osc request log 1147567
...
----------------------------------------------------------------------------
created | crameleon | 2024-02-19T12:18:04

foo >= 1

$  osc log -D home:crameleon:ignore dummy2|head -n4
----------------------------------------------------------------------------
r2 | crameleon | 2024-02-19 12:28:43 | 83b58530a64eab9b3792d6eec7fbae4c | unknown | rq1147567

foo >= 1
```
