### PR TITLE
pkglistgen: Don't always regenerate .changes

### DIFF
--- a/pkglistgen/file_utils.py
+++ b/pkglistgen/file_utils.py
@@ -1,3 +1,4 @@
+import fnmatch
 import glob
 import os
 import os.path
@@ -20,8 +21,12 @@ def move_list(file_list, destination):
 
 
 def unlink_all_except(path, ignore_list=['_service'], ignore_hidden=True):
+    """ignore_list is a list of globs"""
     for name in os.listdir(path):
-        if name in ignore_list or (ignore_hidden and name.startswith('.')):
+        if ignore_hidden and name.startswith('.'):
+            continue
+
+        if any([fnmatch.fnmatch(name, pattern) for pattern in ignore_list]):
             continue
 
         name_path = os.path.join(path, name)

--- a/pkglistgen/tool.py
+++ b/pkglistgen/tool.py
@@ -679,7 +679,7 @@ class PkgListGen(ToolBase.ToolBase):
             checkout_package(api.apiurl, project, package, expand_link=True,
                              prj_dir=cache_dir, outdir=os.path.join(cache_dir, package))
 
-        file_utils.unlink_all_except(release_dir, ['weakremovers.inc'])
+        file_utils.unlink_all_except(release_dir, ['weakremovers.inc', '*.changes'])
         if not only_release_packages:
             file_utils.unlink_all_except(product_dir)
         ignore_list = ['supportstatus.txt', 'summary-staging.txt', 'package-groups.changes']


### PR DESCRIPTION
Change file_utils.unlink_all_except to accept globs and use it to keep .changes.