### PR TITLE
gocd: sp/micro-targets: ensure the pipeline exits on failures

### DIFF
--- a/gocd/microos.target.gocd.yaml
+++ b/gocd/microos.target.gocd.yaml
@@ -37,6 +37,7 @@ pipelines:
         - staging-bot
         tasks:
         - script: |-
+            set -e
             for product in 000product SLE-Micro; do
               osc -A https://api.suse.de release SUSE:ALP:Products:Marble:6.0 $product
             done
@@ -57,6 +58,7 @@ pipelines:
         - staging-bot
         tasks:
         - script: |-
+            set -e
             osc -A https://api.suse.de release SUSE:ALP:Products:Marble:6.0:ToTest
             sleep 600
             while (osc -A https://api.suse.de/ api "/build/SUSE:ALP:Products:Marble:6.0:PUBLISH/_result?view=summary&repository=images" | grep "result project" | grep -v 'code="published" state="published">'); do

--- a/gocd/sp.target.gocd.yaml
+++ b/gocd/sp.target.gocd.yaml
@@ -74,6 +74,7 @@ pipelines:
         - staging-bot
         tasks:
         - script: |-
+            set -e
             osc -A https://api.suse.de release SUSE:SLE-15-SP6:GA:TEST
             sleep 600
             while (osc -A https://api.suse.de/ api "/build/SUSE:SLE-15-SP6:GA:PUBLISH/_result?view=summary&repository=containers" | grep "result project" | grep -v 'code="published" state="published">'); do


### PR DESCRIPTION
This was already implemented in ddd2304022e313eca9b391a043b12ecb9afe3bf7 for SLE GA to TEST, but missing in Micro and on the TEST -> PUBLISH leg in SLE.

Releasing from TEST to PUBLISH might still fail for various reasons. If it happens, ensure the pipeline exits early with non-zero exit code.