### PR TITLE
Revert "gocd: microos: Release both 000product and 000productcompose ."

### DIFF
--- a/gocd/microos.target.gocd.yaml
+++ b/gocd/microos.target.gocd.yaml
@@ -38,7 +38,7 @@ pipelines:
         tasks:
         - script: |-
             set -e
-            for product in 000product 000productcompose SL-Micro; do
+            for product in 000product SL-Micro; do
               osc -A https://api.suse.de release SUSE:ALP:Products:Marble:6.0 $product
             done
             sleep 600
@@ -47,11 +47,6 @@ pipelines:
                 sleep 600
             done
             osc -A https://api.suse.de/ api "/build/SUSE:ALP:Products:Marble:6.0:ToTest/_result?view=summary&repository=images" | grep "result project" | grep 'code="published" state="published">' && echo PUBLISHED
-            while (osc -A https://api.suse.de/ api "/build/SUSE:ALP:Products:Marble:6.0:ToTest/_result?view=summary&repository=product" | grep "result project" | grep -v 'code="published" state="published">'); do
-                echo PENDING
-                sleep 600
-            done
-            osc -A https://api.suse.de/ api "/build/SUSE:ALP:Products:Marble:6.0:ToTest/_result?view=summary&repository=product" | grep "result project" | grep 'code="published" state="published">' && echo PUBLISHED
 
     - Release.Images.To.Publish:
         approval: manual
@@ -71,8 +66,3 @@ pipelines:
                 sleep 600
             done
             osc -A https://api.suse.de/ api "/build/SUSE:ALP:Products:Marble:6.0:PUBLISH/_result?view=summary&repository=images" | grep "result project" | grep 'code="published" state="published">' && echo PUBLISHED
-            while (osc -A https://api.suse.de/ api "/build/SUSE:ALP:Products:Marble:6.0:PUBLISH/_result?view=summary&repository=product" | grep "result project" | grep -v 'code="published" state="published">'); do
-                echo PENDING
-                sleep 600
-            done
-            osc -A https://api.suse.de/ api "/build/SUSE:ALP:Products:Marble:6.0:PUBLISH/_result?view=summary&repository=product" | grep "result project" | grep 'code="published" state="published">' && echo PUBLISHED


### PR DESCRIPTION
This reverts commit 1e9554f94fdb4d34bd7847b0bbe04a9e9b8b2f1a. Releasing the product composer output makes the GoCD hang seemingly forever.