### PR TITLE
pkglistgen.py: Run product-composer iif there's a *.productcompose.in file and a 000productcompose directory.

### DIFF
--- a/pkglistgen/tool.py
+++ b/pkglistgen/tool.py
@@ -769,9 +769,7 @@ class PkgListGen(ToolBase.ToolBase):
 
         # new product-composer
         fn = os.path.join(group_dir, 'default.productcompose.in')
-        if os.path.isfile(fn):
-            if not os.path.isdir(self.productcompose_dir):
-                raise Exception('default.productcompose.in exists, but output directory is missing in git!')
+        if os.path.isfile(fn) and os.path.isdir(self.productcompose_dir):
             lines = open(fn).readlines()
             new_lines = []
             for line in lines:
@@ -789,6 +787,7 @@ class PkgListGen(ToolBase.ToolBase):
         else:
             # No template file, so we don't create one either
             self.skip_productcompose = True
+            logging.debug('skipping productcompose')
 
         logging.debug('-> do_update')
         # make sure we only calculcate existant architectures


### PR DESCRIPTION
Previously pkglistgen.py assumed that a project either used product-builder or the new product-composer, by exiting unrecoverably when a *.productcompose.in file was found but the relative 000productcompose directory was absent.

This is not the case for SL Micro as the shared SLFO codebase is still an hybrid OBS/git project and hence its stagings are not git based and can't use product composer.

This patch was tested for the SUSE:ALP:Source:Standard:1.0:Staging:A and SUSE:ALP:Products:Marble:6.0 projects (together with https://github.com/openSUSE/openSUSE-release-tools/pull/3078). Instead of raising an exception when the 000productcompose directory is not found it makes a log stating that product-composer will be skipped.