### PR TITLE
Support msgid domain override

### DIFF
--- a/factory-package-news/announcer.py
+++ b/factory-package-news/announcer.py
@@ -130,7 +130,7 @@ msg['From'] = config['sender']
 msg['To'] = config['to']
 msg['Mail-Followup-To'] = config['to']
 msg['Date'] = email.utils.formatdate(localtime=1)
-msg['Message-ID'] = email.utils.make_msgid()
+msg['Message-ID'] = email.utils.make_msgid(domain=config.get(domain))
 
 if options.dry:
     print("sending ...")


### PR DESCRIPTION
The domain set by email.utils defaults to the one from the calling system. Systems having theirs set to "localhost" risk increased spam scoring. Allow the override of the domain on such systems using a configuration option.

Note: please test this yourself, I could not find a fitting YAML configuration file in this repository and don't know where you are executing this script from. I only confirmed the `domain` option to work by copying the message and SMTP lines into a short sample Python script, which executed and sent the mail as expected.