### PR TITLE
fix slfo stagings pipelines

### DIFF
--- a/gocd/slfo-stagings.gocd.yaml
+++ b/gocd/slfo-stagings.gocd.yaml
@@ -23,6 +23,7 @@ pipelines:
               - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
                   --staging SUSE:SLFO:Main:Staging:A
                   --only-release-packages --force
+                  --git-url https://src.suse.de/products/SL-Micro#6.1
           SUSE.SLFO.Main.Staging.B:
             resources:
               - repo-checker
@@ -30,6 +31,7 @@ pipelines:
               - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
                   --staging SUSE:SLFO:Main:Staging:B
                   --only-release-packages --force
+                  --git-url https://src.suse.de/products/SL-Micro#6.1
           SUSE.SLFO.Main.Staging.C:
             resources:
               - repo-checker
@@ -37,6 +39,7 @@ pipelines:
               - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
                   --staging SUSE:SLFO:Main:Staging:C
                   --only-release-packages --force
+                  --git-url https://src.suse.de/products/SL-Micro#6.1
           SUSE.SLFO.Main.Staging.D:
             resources:
               - repo-checker
@@ -44,6 +47,7 @@ pipelines:
               - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
                   --staging SUSE:SLFO:Main:Staging:D
                   --only-release-packages --force
+                  --git-url https://src.suse.de/products/SL-Micro#6.1
           SUSE.SLFO.Main.Staging.E:
             resources:
               - repo-checker
@@ -51,6 +55,7 @@ pipelines:
               - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
                   --staging SUSE:SLFO:Main:Staging:E
                   --only-release-packages --force
+                  --git-url https://src.suse.de/products/SL-Micro#6.1
           SUSE.SLFO.Main.Staging.F:
             resources:
               - repo-checker
@@ -58,6 +63,7 @@ pipelines:
               - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
                   --staging SUSE:SLFO:Main:Staging:F
                   --only-release-packages --force
+                  --git-url https://src.suse.de/products/SL-Micro#6.1
           SUSE.SLFO.Main.Staging.G:
             resources:
               - repo-checker
@@ -65,6 +71,7 @@ pipelines:
               - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
                   --staging SUSE:SLFO:Main:Staging:G
                   --only-release-packages --force
+                  --git-url https://src.suse.de/products/SL-Micro#6.1
           SUSE.SLFO.Main.Staging.H:
             resources:
               - repo-checker
@@ -72,6 +79,7 @@ pipelines:
               - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
                   --staging SUSE:SLFO:Main:Staging:H
                   --only-release-packages --force
+                  --git-url https://src.suse.de/products/SL-Micro#6.1
           SUSE.SLFO.Main.Staging.S:
             resources:
               - repo-checker
@@ -79,6 +87,7 @@ pipelines:
               - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
                   --staging SUSE:SLFO:Main:Staging:S
                   --only-release-packages --force
+                  --git-url https://src.suse.de/products/SL-Micro#6.1
           SUSE.SLFO.Main.Staging.V:
             resources:
               - repo-checker
@@ -86,6 +95,7 @@ pipelines:
               - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
                   --staging SUSE:SLFO:Main:Staging:V
                   --only-release-packages --force
+                  --git-url https://src.suse.de/products/SL-Micro#6.1
           SUSE.SLFO.Main.Staging.Y:
             resources:
               - repo-checker
@@ -93,6 +103,7 @@ pipelines:
               - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
                   --staging SUSE:SLFO:Main:Staging:Y
                   --only-release-packages --force
+                  --git-url https://src.suse.de/products/SL-Micro#6.1
 
   SUSE.SLFO.Main.Staging.A:
     environment_variables:

--- a/gocd/slfo-stagings.gocd.yaml.erb
+++ b/gocd/slfo-stagings.gocd.yaml.erb
@@ -25,6 +25,7 @@ pipelines:
               - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
                   --staging SUSE:SLFO:Main:Staging:<%= letter %>
                   --only-release-packages --force
+                  --git-url https://src.suse.de/products/SL-Micro#6.1
 <% end -%>
 <% stagings.each do |letter| %>
   SUSE.SLFO.Main.Staging.<%= letter %>:


### PR DESCRIPTION
add --git-url to pkglistgen.py calls to not use the old system

This needs https://github.com/openSUSE/openSUSE-release-tools/pull/3089 to work correctly