### PR TITLE
Leap 15: disable skippkg-finder for 15.6

### DIFF
--- a/gocd/pkglistgen.opensuse.gocd.yaml
+++ b/gocd/pkglistgen.opensuse.gocd.yaml
@@ -149,7 +149,6 @@ pipelines:
             resources:
             - repo-checker
             tasks:
-            - script: python3 ./skippkg-finder.py -A https://api.opensuse.org -o openSUSE:Leap:15.6 -s SUSE:SLE-15-SP6:GA
             - script: python3 ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Leap:15.6 -s target
   Update.Repos.Leap.openSUSE_Leap_15.6:
     group: Leap

--- a/gocd/pkglistgen.opensuse.gocd.yaml.erb
+++ b/gocd/pkglistgen.opensuse.gocd.yaml.erb
@@ -115,7 +115,6 @@ pipelines:
             resources:
             - repo-checker
             tasks:
-            - script: python3 ./skippkg-finder.py -A https://api.opensuse.org -o openSUSE:Leap:15.6 -s SUSE:SLE-15-SP6:GA
             - script: python3 ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p <%= project[0] %><%= options %>
 <% end -%>
 <% %w(openSUSE:Leap:15.6).each do |project| -%>


### PR DESCRIPTION
It's time to disable skippkg-finder for 15.6, NON_FTP_PACKAGES.group should not changed anymore, for not to be affected by any new updates then skippkg-finder should run anymore.