### PR TITLE
Adjust the staging configuration of ALP to maintenance needs

### DIFF
--- a/gocd/alp-stagings.gocd.yaml
+++ b/gocd/alp-stagings.gocd.yaml
@@ -1,98 +1,6 @@
 ---
 format_version: 3
 pipelines:
-  ALP.Source.Standard.1_0.Stagings.RelPkgs:
-    environment_variables:
-      OSC_CONFIG: /home/go/config/oscrc-staging-bot
-    group: ALP.Stagings
-    lock_behavior: unlockWhenFinished
-    timer:
-      spec: 0 0 * ? * *
-      only_on_changes: false
-    materials:
-      scripts:
-        git: https://github.com/openSUSE/openSUSE-release-tools.git
-    stages:
-    - Generate.Release.Package:
-        approval: manual
-        jobs:
-          ALP.Source.Standard.1_0.Staging.A:
-            resources:
-              - repo-checker
-            tasks:
-              - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
-                  --staging SUSE:ALP:Source:Standard:1.0:Staging:A
-                  --only-release-packages --force
-          ALP.Source.Standard.1_0.Staging.B:
-            resources:
-              - repo-checker
-            tasks:
-              - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
-                  --staging SUSE:ALP:Source:Standard:1.0:Staging:B
-                  --only-release-packages --force
-          ALP.Source.Standard.1_0.Staging.C:
-            resources:
-              - repo-checker
-            tasks:
-              - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
-                  --staging SUSE:ALP:Source:Standard:1.0:Staging:C
-                  --only-release-packages --force
-          ALP.Source.Standard.1_0.Staging.D:
-            resources:
-              - repo-checker
-            tasks:
-              - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
-                  --staging SUSE:ALP:Source:Standard:1.0:Staging:D
-                  --only-release-packages --force
-          ALP.Source.Standard.1_0.Staging.E:
-            resources:
-              - repo-checker
-            tasks:
-              - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
-                  --staging SUSE:ALP:Source:Standard:1.0:Staging:E
-                  --only-release-packages --force
-          ALP.Source.Standard.1_0.Staging.F:
-            resources:
-              - repo-checker
-            tasks:
-              - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
-                  --staging SUSE:ALP:Source:Standard:1.0:Staging:F
-                  --only-release-packages --force
-          ALP.Source.Standard.1_0.Staging.G:
-            resources:
-              - repo-checker
-            tasks:
-              - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
-                  --staging SUSE:ALP:Source:Standard:1.0:Staging:G
-                  --only-release-packages --force
-          ALP.Source.Standard.1_0.Staging.H:
-            resources:
-              - repo-checker
-            tasks:
-              - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
-                  --staging SUSE:ALP:Source:Standard:1.0:Staging:H
-                  --only-release-packages --force
-          ALP.Source.Standard.1_0.Staging.S:
-            resources:
-              - repo-checker
-            tasks:
-              - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
-                  --staging SUSE:ALP:Source:Standard:1.0:Staging:S
-                  --only-release-packages --force
-          ALP.Source.Standard.1_0.Staging.V:
-            resources:
-              - repo-checker
-            tasks:
-              - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
-                  --staging SUSE:ALP:Source:Standard:1.0:Staging:V
-                  --only-release-packages --force
-          ALP.Source.Standard.1_0.Staging.Y:
-            resources:
-              - repo-checker
-            tasks:
-              - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
-                  --staging SUSE:ALP:Source:Standard:1.0:Staging:Y
-                  --only-release-packages --force
 
   ALP.Source.Standard.1_0.Staging.A:
     environment_variables:
@@ -135,33 +43,6 @@ pipelines:
               - script: |-
                   ./scripts/staging-installcheck.py -A $STAGING_API -p SUSE:ALP:Source:Standard:1.0 -s $STAGING_PROJECT
 
-    - Update.000product:
-        resources:
-          - repo-checker
-        tasks:
-          - script: |-
-              export PYTHONPATH=$PWD/scripts
-              cd scripts/gocd
-
-              if ../pkglistgen.py --debug -A $STAGING_API update_and_solve --staging $STAGING_PROJECT --force; then
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s success
-              else
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s failure
-                exit 1
-              fi
-
-    - Enable.images.repo:
-        resources:
-          - staging-bot
-        tasks:
-          - script: |-
-              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-              export PYTHONPATH=$PWD/scripts
-              while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
-                sleep 60
-              done
-              ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
-
   ALP.Source.Standard.1_0.Staging.B:
     environment_variables:
       STAGING_PROJECT: SUSE:ALP:Source:Standard:1.0:Staging:B
@@ -202,33 +83,6 @@ pipelines:
             tasks:
               - script: |-
                   ./scripts/staging-installcheck.py -A $STAGING_API -p SUSE:ALP:Source:Standard:1.0 -s $STAGING_PROJECT
-
-    - Update.000product:
-        resources:
-          - repo-checker
-        tasks:
-          - script: |-
-              export PYTHONPATH=$PWD/scripts
-              cd scripts/gocd
-
-              if ../pkglistgen.py --debug -A $STAGING_API update_and_solve --staging $STAGING_PROJECT --force; then
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s success
-              else
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s failure
-                exit 1
-              fi
-
-    - Enable.images.repo:
-        resources:
-          - staging-bot
-        tasks:
-          - script: |-
-              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-              export PYTHONPATH=$PWD/scripts
-              while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
-                sleep 60
-              done
-              ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   ALP.Source.Standard.1_0.Staging.C:
     environment_variables:
@@ -271,33 +125,6 @@ pipelines:
               - script: |-
                   ./scripts/staging-installcheck.py -A $STAGING_API -p SUSE:ALP:Source:Standard:1.0 -s $STAGING_PROJECT
 
-    - Update.000product:
-        resources:
-          - repo-checker
-        tasks:
-          - script: |-
-              export PYTHONPATH=$PWD/scripts
-              cd scripts/gocd
-
-              if ../pkglistgen.py --debug -A $STAGING_API update_and_solve --staging $STAGING_PROJECT --force; then
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s success
-              else
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s failure
-                exit 1
-              fi
-
-    - Enable.images.repo:
-        resources:
-          - staging-bot
-        tasks:
-          - script: |-
-              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-              export PYTHONPATH=$PWD/scripts
-              while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
-                sleep 60
-              done
-              ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
-
   ALP.Source.Standard.1_0.Staging.D:
     environment_variables:
       STAGING_PROJECT: SUSE:ALP:Source:Standard:1.0:Staging:D
@@ -338,33 +165,6 @@ pipelines:
             tasks:
               - script: |-
                   ./scripts/staging-installcheck.py -A $STAGING_API -p SUSE:ALP:Source:Standard:1.0 -s $STAGING_PROJECT
-
-    - Update.000product:
-        resources:
-          - repo-checker
-        tasks:
-          - script: |-
-              export PYTHONPATH=$PWD/scripts
-              cd scripts/gocd
-
-              if ../pkglistgen.py --debug -A $STAGING_API update_and_solve --staging $STAGING_PROJECT --force; then
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s success
-              else
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s failure
-                exit 1
-              fi
-
-    - Enable.images.repo:
-        resources:
-          - staging-bot
-        tasks:
-          - script: |-
-              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-              export PYTHONPATH=$PWD/scripts
-              while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
-                sleep 60
-              done
-              ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   ALP.Source.Standard.1_0.Staging.E:
     environment_variables:
@@ -407,33 +207,6 @@ pipelines:
               - script: |-
                   ./scripts/staging-installcheck.py -A $STAGING_API -p SUSE:ALP:Source:Standard:1.0 -s $STAGING_PROJECT
 
-    - Update.000product:
-        resources:
-          - repo-checker
-        tasks:
-          - script: |-
-              export PYTHONPATH=$PWD/scripts
-              cd scripts/gocd
-
-              if ../pkglistgen.py --debug -A $STAGING_API update_and_solve --staging $STAGING_PROJECT --force; then
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s success
-              else
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s failure
-                exit 1
-              fi
-
-    - Enable.images.repo:
-        resources:
-          - staging-bot
-        tasks:
-          - script: |-
-              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-              export PYTHONPATH=$PWD/scripts
-              while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
-                sleep 60
-              done
-              ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
-
   ALP.Source.Standard.1_0.Staging.F:
     environment_variables:
       STAGING_PROJECT: SUSE:ALP:Source:Standard:1.0:Staging:F
@@ -474,33 +247,6 @@ pipelines:
             tasks:
               - script: |-
                   ./scripts/staging-installcheck.py -A $STAGING_API -p SUSE:ALP:Source:Standard:1.0 -s $STAGING_PROJECT
-
-    - Update.000product:
-        resources:
-          - repo-checker
-        tasks:
-          - script: |-
-              export PYTHONPATH=$PWD/scripts
-              cd scripts/gocd
-
-              if ../pkglistgen.py --debug -A $STAGING_API update_and_solve --staging $STAGING_PROJECT --force; then
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s success
-              else
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s failure
-                exit 1
-              fi
-
-    - Enable.images.repo:
-        resources:
-          - staging-bot
-        tasks:
-          - script: |-
-              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-              export PYTHONPATH=$PWD/scripts
-              while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
-                sleep 60
-              done
-              ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   ALP.Source.Standard.1_0.Staging.G:
     environment_variables:
@@ -543,33 +289,6 @@ pipelines:
               - script: |-
                   ./scripts/staging-installcheck.py -A $STAGING_API -p SUSE:ALP:Source:Standard:1.0 -s $STAGING_PROJECT
 
-    - Update.000product:
-        resources:
-          - repo-checker
-        tasks:
-          - script: |-
-              export PYTHONPATH=$PWD/scripts
-              cd scripts/gocd
-
-              if ../pkglistgen.py --debug -A $STAGING_API update_and_solve --staging $STAGING_PROJECT --force; then
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s success
-              else
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s failure
-                exit 1
-              fi
-
-    - Enable.images.repo:
-        resources:
-          - staging-bot
-        tasks:
-          - script: |-
-              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-              export PYTHONPATH=$PWD/scripts
-              while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
-                sleep 60
-              done
-              ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
-
   ALP.Source.Standard.1_0.Staging.H:
     environment_variables:
       STAGING_PROJECT: SUSE:ALP:Source:Standard:1.0:Staging:H
@@ -610,33 +329,6 @@ pipelines:
             tasks:
               - script: |-
                   ./scripts/staging-installcheck.py -A $STAGING_API -p SUSE:ALP:Source:Standard:1.0 -s $STAGING_PROJECT
-
-    - Update.000product:
-        resources:
-          - repo-checker
-        tasks:
-          - script: |-
-              export PYTHONPATH=$PWD/scripts
-              cd scripts/gocd
-
-              if ../pkglistgen.py --debug -A $STAGING_API update_and_solve --staging $STAGING_PROJECT --force; then
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s success
-              else
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s failure
-                exit 1
-              fi
-
-    - Enable.images.repo:
-        resources:
-          - staging-bot
-        tasks:
-          - script: |-
-              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-              export PYTHONPATH=$PWD/scripts
-              while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
-                sleep 60
-              done
-              ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 
   ALP.Source.Standard.1_0.Staging.S:
     environment_variables:
@@ -679,33 +371,6 @@ pipelines:
               - script: |-
                   ./scripts/staging-installcheck.py -A $STAGING_API -p SUSE:ALP:Source:Standard:1.0 -s $STAGING_PROJECT
 
-    - Update.000product:
-        resources:
-          - repo-checker
-        tasks:
-          - script: |-
-              export PYTHONPATH=$PWD/scripts
-              cd scripts/gocd
-
-              if ../pkglistgen.py --debug -A $STAGING_API update_and_solve --staging $STAGING_PROJECT --force; then
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s success
-              else
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s failure
-                exit 1
-              fi
-
-    - Enable.images.repo:
-        resources:
-          - staging-bot
-        tasks:
-          - script: |-
-              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-              export PYTHONPATH=$PWD/scripts
-              while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
-                sleep 60
-              done
-              ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
-
   ALP.Source.Standard.1_0.Staging.V:
     environment_variables:
       STAGING_PROJECT: SUSE:ALP:Source:Standard:1.0:Staging:V
@@ -747,33 +412,6 @@ pipelines:
               - script: |-
                   ./scripts/staging-installcheck.py -A $STAGING_API -p SUSE:ALP:Source:Standard:1.0 -s $STAGING_PROJECT
 
-    - Update.000product:
-        resources:
-          - repo-checker
-        tasks:
-          - script: |-
-              export PYTHONPATH=$PWD/scripts
-              cd scripts/gocd
-
-              if ../pkglistgen.py --debug -A $STAGING_API update_and_solve --staging $STAGING_PROJECT --force; then
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s success
-              else
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s failure
-                exit 1
-              fi
-
-    - Enable.images.repo:
-        resources:
-          - staging-bot
-        tasks:
-          - script: |-
-              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-              export PYTHONPATH=$PWD/scripts
-              while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
-                sleep 60
-              done
-              ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
-
   ALP.Source.Standard.1_0.Staging.Y:
     environment_variables:
       STAGING_PROJECT: SUSE:ALP:Source:Standard:1.0:Staging:Y
@@ -814,30 +452,3 @@ pipelines:
             tasks:
               - script: |-
                   ./scripts/staging-installcheck.py -A $STAGING_API -p SUSE:ALP:Source:Standard:1.0 -s $STAGING_PROJECT
-
-    - Update.000product:
-        resources:
-          - repo-checker
-        tasks:
-          - script: |-
-              export PYTHONPATH=$PWD/scripts
-              cd scripts/gocd
-
-              if ../pkglistgen.py --debug -A $STAGING_API update_and_solve --staging $STAGING_PROJECT --force; then
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s success
-              else
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s failure
-                exit 1
-              fi
-
-    - Enable.images.repo:
-        resources:
-          - staging-bot
-        tasks:
-          - script: |-
-              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-              export PYTHONPATH=$PWD/scripts
-              while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
-                sleep 60
-              done
-              ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success

--- a/gocd/alp-stagings.gocd.yaml.erb
+++ b/gocd/alp-stagings.gocd.yaml.erb
@@ -2,30 +2,6 @@
 <% stagings = %w(A B C D E F G H S V Y) -%>
 format_version: 3
 pipelines:
-  ALP.Source.Standard.1_0.Stagings.RelPkgs:
-    environment_variables:
-      OSC_CONFIG: /home/go/config/oscrc-staging-bot
-    group: ALP.Stagings
-    lock_behavior: unlockWhenFinished
-    timer:
-      spec: 0 0 * ? * *
-      only_on_changes: false
-    materials:
-      scripts:
-        git: https://github.com/openSUSE/openSUSE-release-tools.git
-    stages:
-    - Generate.Release.Package:
-        approval: manual
-        jobs:
-<% stagings.each do |letter| -%>
-          ALP.Source.Standard.1_0.Staging.<%= letter %>:
-            resources:
-              - repo-checker
-            tasks:
-              - script: ./pkglistgen.py -A https://api.suse.de update_and_solve
-                  --staging SUSE:ALP:Source:Standard:1.0:Staging:<%= letter %>
-                  --only-release-packages --force
-<% end -%>
 <% stagings.each do |letter| %>
   ALP.Source.Standard.1_0.Staging.<%= letter %>:
     environment_variables:
@@ -67,31 +43,4 @@ pipelines:
             tasks:
               - script: |-
                   ./scripts/staging-installcheck.py -A $STAGING_API -p SUSE:ALP:Source:Standard:1.0 -s $STAGING_PROJECT
-
-    - Update.000product:
-        resources:
-          - repo-checker
-        tasks:
-          - script: |-
-              export PYTHONPATH=$PWD/scripts
-              cd scripts/gocd
-
-              if ../pkglistgen.py --debug -A $STAGING_API update_and_solve --staging $STAGING_PROJECT --force; then
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s success
-              else
-                ./report-status.py -A $STAGING_API -p $STAGING_PROJECT -n packagelists -r standard -s failure
-                exit 1
-              fi
-
-    - Enable.images.repo:
-        resources:
-          - staging-bot
-        tasks:
-          - script: |-
-              osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=images&flag=build"
-              export PYTHONPATH=$PWD/scripts
-              while osc -A $STAGING_API api "/build/$STAGING_PROJECT/_result?view=summary&repository=images" | grep 'dirty=.true.'; do
-                sleep 60
-              done
-              ./scripts/gocd/report-status.py -A $STAGING_API -p $STAGING_PROJECT -n images:enabled -r standard -s success
 <% end -%>


### PR DESCRIPTION
This basically remove things only needed during product development:
* Updating of release packages
* re-generation of 000product content
* Selectively enabling the images repository