### PR TITLE
cleanup_rings: whitelist 'devscripts'

### DIFF
--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -31,6 +31,8 @@ class CleanupRings(object):
             'vagrant',
             # https://github.com/openSUSE/open-build-service/issues/14129
             'snobol4',
+            # We need devscripts:checkbashism in Ring1, removing the main flavor is not possible
+            'devscripts',
         ]
 
     def perform(self):


### PR DESCRIPTION
devscripts has a sub-flavor for checknashisms that is required in Ring1 (for rpmlint)
The flavor "" is technically not required, but removing the package would make the
sub-flavor vanish as well.
