### PR TITLE
check_source: fix crash AttributeError: 'CheckSource' object has no attribute 'review_message'

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -180,11 +180,11 @@ class CheckSource(ReviewBot.ReviewBot):
                     scm_pool_repository = f"https://src.opensuse.org/pool/{source_package}"
                     if not scm_sync.text.startswith(scm_pool_repository):
                         # devel project uses scm sync not from the trusted src location
-                        self.review_message['declined'] = f"Expected a devel project scm sync from {scm_pool_repository}"
+                        self.review_messages['declined'] = f"Expected a devel project scm sync from {scm_pool_repository}"
                         return False
                     if not self.source_is_scm_staging_submission(source_project):
                         # Not a submission coming from the scm-sync bot
-                        self.review_message['declined'] = "Expected a submitrequest coming from scm-sync project"
+                        self.review_messages['declined'] = "Expected a submitrequest coming from scm-sync project"
                         return False
 
             else:


### PR DESCRIPTION
An old typo, that was introduced in an attempt to support scm synced PRs
