### PR TITLE
slfo-stagings: add a timeout for Build.product, and do not run if repo is missing

### DIFF
--- a/gocd/slfo-stagings.gocd.yaml
+++ b/gocd/slfo-stagings.gocd.yaml
@@ -59,13 +59,18 @@ pipelines:
               fi
 
     - Build.product:
+        timeout: 180
         resources:
           - staging-bot
         tasks:
           - script: |-
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ! ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; do
+              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
+                if [ ${ret} -eq 2 ]; then
+                    echo "product repository not found. Project configuration issue?" >&2
+                    exit 1
+                fi
                 sleep 60
               done
 
@@ -138,13 +143,18 @@ pipelines:
               fi
 
     - Build.product:
+        timeout: 180
         resources:
           - staging-bot
         tasks:
           - script: |-
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ! ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; do
+              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
+                if [ ${ret} -eq 2 ]; then
+                    echo "product repository not found. Project configuration issue?" >&2
+                    exit 1
+                fi
                 sleep 60
               done
 
@@ -217,13 +227,18 @@ pipelines:
               fi
 
     - Build.product:
+        timeout: 180
         resources:
           - staging-bot
         tasks:
           - script: |-
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ! ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; do
+              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
+                if [ ${ret} -eq 2 ]; then
+                    echo "product repository not found. Project configuration issue?" >&2
+                    exit 1
+                fi
                 sleep 60
               done
 
@@ -296,13 +311,18 @@ pipelines:
               fi
 
     - Build.product:
+        timeout: 180
         resources:
           - staging-bot
         tasks:
           - script: |-
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ! ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; do
+              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
+                if [ ${ret} -eq 2 ]; then
+                    echo "product repository not found. Project configuration issue?" >&2
+                    exit 1
+                fi
                 sleep 60
               done
 
@@ -375,13 +395,18 @@ pipelines:
               fi
 
     - Build.product:
+        timeout: 180
         resources:
           - staging-bot
         tasks:
           - script: |-
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ! ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; do
+              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
+                if [ ${ret} -eq 2 ]; then
+                    echo "product repository not found. Project configuration issue?" >&2
+                    exit 1
+                fi
                 sleep 60
               done
 
@@ -454,13 +479,18 @@ pipelines:
               fi
 
     - Build.product:
+        timeout: 180
         resources:
           - staging-bot
         tasks:
           - script: |-
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ! ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; do
+              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
+                if [ ${ret} -eq 2 ]; then
+                    echo "product repository not found. Project configuration issue?" >&2
+                    exit 1
+                fi
                 sleep 60
               done
 
@@ -533,13 +563,18 @@ pipelines:
               fi
 
     - Build.product:
+        timeout: 180
         resources:
           - staging-bot
         tasks:
           - script: |-
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ! ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; do
+              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
+                if [ ${ret} -eq 2 ]; then
+                    echo "product repository not found. Project configuration issue?" >&2
+                    exit 1
+                fi
                 sleep 60
               done
 
@@ -612,13 +647,18 @@ pipelines:
               fi
 
     - Build.product:
+        timeout: 180
         resources:
           - staging-bot
         tasks:
           - script: |-
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ! ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; do
+              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
+                if [ ${ret} -eq 2 ]; then
+                    echo "product repository not found. Project configuration issue?" >&2
+                    exit 1
+                fi
                 sleep 60
               done
 
@@ -691,13 +731,18 @@ pipelines:
               fi
 
     - Build.product:
+        timeout: 180
         resources:
           - staging-bot
         tasks:
           - script: |-
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ! ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; do
+              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
+                if [ ${ret} -eq 2 ]; then
+                    echo "product repository not found. Project configuration issue?" >&2
+                    exit 1
+                fi
                 sleep 60
               done
 
@@ -770,13 +815,18 @@ pipelines:
               fi
 
     - Build.product:
+        timeout: 180
         resources:
           - staging-bot
         tasks:
           - script: |-
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ! ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; do
+              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
+                if [ ${ret} -eq 2 ]; then
+                    echo "product repository not found. Project configuration issue?" >&2
+                    exit 1
+                fi
                 sleep 60
               done
 
@@ -849,13 +899,18 @@ pipelines:
               fi
 
     - Build.product:
+        timeout: 180
         resources:
           - staging-bot
         tasks:
           - script: |-
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ! ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; do
+              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
+                if [ ${ret} -eq 2 ]; then
+                    echo "product repository not found. Project configuration issue?" >&2
+                    exit 1
+                fi
                 sleep 60
               done
 

--- a/gocd/slfo-stagings.gocd.yaml.erb
+++ b/gocd/slfo-stagings.gocd.yaml.erb
@@ -60,13 +60,18 @@ pipelines:
               fi
 
     - Build.product:
+        timeout: 180
         resources:
           - staging-bot
         tasks:
           - script: |-
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ! ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; do
+              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
+                if [ ${ret} -eq 2 ]; then
+                    echo "product repository not found. Project configuration issue?" >&2
+                    exit 1
+                fi
                 sleep 60
               done
 

--- a/gocd/verify-repo-built-successful.py
+++ b/gocd/verify-repo-built-successful.py
@@ -14,9 +14,10 @@ from lxml import etree as ET
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Check if all packages built fine')
     parser.add_argument('--apiurl', '-A', type=str, help='API URL of OBS')
-    parser.add_argument('-p', '--project', type=str, help='Project to check')
+    parser.add_argument('-p', '--project', type=str, help='Project to check',
+                        required=True)
     parser.add_argument('-r', '--repository', type=str,
-                        help='Repository to check')
+                        help='Repository to check', required=True)
 
     args = parser.parse_args()
 

--- a/gocd/verify-repo-built-successful.py
+++ b/gocd/verify-repo-built-successful.py
@@ -27,7 +27,14 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     logger = logging.getLogger(__name__)
 
-    # first check if repo is finished
+    # first check if repo is available
+    url = makeurl(apiurl, ['source', args.project, "_meta"])
+    root = ET.parse(http_GET(url)).getroot()
+    if not root.xpath(f'repository[@name="{args.repository}"]'):
+        logger.error(f'Repository {args.repository} is not available in {args.project}')
+        sys.exit(2)
+
+    # then check if repo is finished
     archs = target_archs(apiurl, args.project, args.repository)
     for arch in archs:
         url = makeurl(apiurl, ['build', args.project, args.repository, arch], {'view': 'status'})


### PR DESCRIPTION
Ensure that the 'product' repo is configured in the project meta.

Unfortunately, since we're checking in the configuration of the staging
itself, rather than the parent project's, there are increased chances of
some human/tooling error that might drop the repository from the
configuration. This will make the job run an endless loop.

Also, add a timeout for 180 minutes for the job. It is enough for
the product build process, and if it isn't, it's better to cancel
and have human eyes looking at it.

This PR also changes `verify-repo-build-successful.py` so that it detects if the
repository is missing (and will exit with retcode `2`), and it also marks
the `--project` and `--repository` arguments required as the script expect those
to be set.