### PR TITLE
Automatic publishing of repos for LEAPM 6.0

### DIFF
--- a/gocd/leapmicro.target.gocd.yaml
+++ b/gocd/leapmicro.target.gocd.yaml
@@ -36,3 +36,23 @@ pipelines:
         - repo-checker
         tasks:
           - script: ./pkglistgen.py --verbose -A https://api.opensuse.org update_and_solve --project openSUSE:Leap:Micro:6.0 --scope target --engine product_composer --force
+
+
+  LeapMicro.Publish:
+    group: Leap
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    timer:
+      spec: 0 50 * ? * *
+      only_on_changes: false
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    stages:
+    - Publish.000productcompose:
+        resources:
+        - repo-checker
+        tasks:
+          - script: osc -A https://api.opensuse.org release --target-project=openSUSE:Leap:Micro:6.0:ToTest --target-repository=product -r product openSUSE:Leap:Micro:6.0 000productcompose
+

--- a/gocd/leapmicro.target.gocd.yaml
+++ b/gocd/leapmicro.target.gocd.yaml
@@ -44,7 +44,7 @@ pipelines:
     environment_variables:
       OSC_CONFIG: /home/go/config/oscrc-staging-bot
     timer:
-      spec: 0 50 * ? * *
+      spec: 0 50 0,12 ? * *
       only_on_changes: false
     materials:
       git:


### PR DESCRIPTION
I'd like to agree on how often gets the project republished.

The idea is that we have basically an unlocked project, where we keep on republishing repository and ensure that it contains all released updates for SLEM 6.0. This would be happening for 12 months and then would be disabled.

If there is a way to detect a change in underlying repository, that woud be perfect. Otherwise I think set it up for once a day would be sufficient.

Since we no longer have a regular install DVD, there is no corresponding test suite, we only have one for the :Images subproject/appliances. https://openqa.opensuse.org/group_overview/101