### PR TITLE
Install tools explicitly to avoid busybox variants being picked

### DIFF
--- a/dist/ci/testenv-tumbleweed/Dockerfile
+++ b/dist/ci/testenv-tumbleweed/Dockerfile
@@ -8,7 +8,7 @@ RUN zypper --gpg-auto-import-keys ref
 RUN zypper in -y osc python3-pytest python3-httpretty python3-pyxdg python3-PyYAML \
   python3-pika python3-cmdln python3-lxml python3-python-dateutil python3-colorama \
   python3-influxdb python3-pytest-cov libxml2-tools curl python3-flake8 python3-requests \
-  shadow vim vim-data strace git sudo patch openSUSE-release openSUSE-release-ftp \
+  shadow vim vim-data strace git sudo patch unzip which cpio gawk openSUSE-release openSUSE-release-ftp \
   perl-Net-SSLeay perl-Text-Diff perl-XML-Simple perl-XML-Parser build \
   obs-service-download_files obs-service-format_spec_file obs-scm-bridge
 RUN useradd tester -d /code/tests/home


### PR DESCRIPTION
zypper has the nasty habit of picking the alphabetically first package variant, which is not what we want