### PR TITLE
WIP: tests: OBSLocal: do not pick up __name__ when updating existing config

### DIFF
--- a/tests/OBSLocal.py
+++ b/tests/OBSLocal.py
@@ -404,7 +404,8 @@ class StagingWorkflow(ABC):
 
         config_lines = []
         for key, value in config.items():
-            config_lines.append(f'{key} = {value}')
+            if key not in ['__name__']:
+                config_lines.append(f'{key} = {value}')
 
         attribute_value_save(APIURL, self.project, 'Config', '\n'.join(config_lines))
 


### PR DESCRIPTION
The `__name__` option is added by OscConfigParser automatically, and it contains the section name.

When updating the configuration in FactoryWorkflow.remote_config_set(), `__name__` would be fetched as part of the existing configuration that needs to be updated and would in turn be submitted again.

Since osc 1.8.0, having duplicate options is not supported [0]. Let's skip `__name__` when updating the mock configuration, as it's an internal option that we don't want to touch anyway.

[0] https://github.com/openSUSE/osc/commit/360a94c4a3745dfe59863c6a112acf8bcf38840d