### PR TITLE
pkglistgen: add sort reasonings in product_composer mode

### DIFF
--- a/pkglistgen/group.py
+++ b/pkglistgen/group.py
@@ -330,19 +330,19 @@ class Group(object):
                 continue
             if name in missing:
                 if ignore_broken and name not in self.required:
-                    msg = ' {} not found on {}'.format(name, ','.join(sorted(missing[name])))
-                    content += prefix + "#- " + msg + "\n"
+                    msg = f" {name} not found on {','.join(sorted(missing[name]))}"
+                    content += f"{prefix} #- {msg}\n"
                     self.logger.error(msg)
                 continue
             if name in unresolvable:
                 if ignore_broken and name not in self.required:
-                    msg = ' {} uninstallable: {}'.format(name, unresolvable[name])
-                    content += prefix + "#- " + msg + "\n"
+                    msg = f" {name} uninstallable: {unresolvable[name]}"
+                    content += f"{prefix} #- {msg}\n"
                     self.logger.error(msg)
                 continue
-            content += prefix + "- " + name
+            content += f"{prefix} - {name}"
             if comment:
-                content += " # " + comment
+                content += f" # {comment}"
             content += "\n"
 
         content += "\n"

--- a/pkglistgen/group.py
+++ b/pkglistgen/group.py
@@ -341,6 +341,8 @@ class Group(object):
                     self.logger.error(msg)
                 continue
             content += f"{prefix} - {name}"
+            if name in packages and packages[name]:
+                content += f" # reason: {packages[name]}"
             if comment:
                 content += f" # {comment}"
             content += "\n"


### PR DESCRIPTION
Reasonings are really useful to understand why a package has been
pulled in. This commit adds those back in product_composer mode
and it matches the legacy behaviour.

Note: this PR also moves `Group.tocompose()` to f-strings to match the rest of the file.