### PR TITLE
gocd: sle15: Split publish pipelines

### DIFF
--- a/gocd/sp.target.gocd.yaml
+++ b/gocd/sp.target.gocd.yaml
@@ -1,6 +1,6 @@
 format_version: 3
 pipelines:
-  SLE15.SP7.Images:
+  SLE15.SP7.Images.To.Test:
     group: SLE15.Target
     lock_behavior: unlockWhenFinished
     materials:
@@ -29,7 +29,7 @@ pipelines:
             ./scripts/gocd/verify-repo-built-successful.py -A https://api.suse.de -p SUSE:SLE-15-SP7:GA -r containerfile
             ./scripts/gocd/verify-repo-built-successful.py -A https://api.suse.de -p SUSE:SLE-15-SP7:GA -r images
 
-    - Release.Images.To.Test:
+    - Release.Images:
         approval: manual
         roles:
         - SLE
@@ -64,7 +64,25 @@ pipelines:
             done
             osc -A https://api.suse.de/ api "/build/SUSE:SLE-15-SP7:GA:TEST/_result?view=summary&repository=images" | grep "result project" | grep 'code="published" state="published">' && echo PUBLISHED
 
-    - Release.Images.To.Publish:
+  SLE15.SP7.Images.To.Publish:
+    group: SLE15.Target
+    materials:
+      repos:
+        git: git://botmaster.suse.de/suse-repos.git
+        auto_update: true
+        whitelist:
+          - SUSE:SLE-15-SP7:GA_-_images.yaml
+        destination: repos
+      scripts:
+        auto_update: true
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+        whitelist:
+          - DO_NOT_TRIGGER
+        destination: scripts
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    stages:
+    - Release.Images:
         approval: manual
         roles:
         - SLE


### PR DESCRIPTION
This allows to always publish from :TEST to :PUBLISH even without the :GA -> :TEST step.

Useful for when gocd cleans up old pipeline runs.

Pretty much the same thing as #3102.