### PR TITLE
metrics: Use https for openQA influxdb endpoint

### DIFF
--- a/metrics/telegraf/openqa.conf
+++ b/metrics/telegraf/openqa.conf
@@ -1,4 +1,4 @@
 [[inputs.http]]
-  urls = ["http://openqa.opensuse.org/admin/influxdb/jobs"]
+  urls = ["https://openqa.opensuse.org/admin/influxdb/jobs"]
   data_format = "influx"
 


### PR DESCRIPTION
As per discussion in https://progress.opensuse.org/issues/159669