### PR TITLE
Check devel pkg maintainers in devel_project_review_needed

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -16,6 +16,7 @@ from osclib.core import action_is_patchinfo
 from osclib.core import devel_project_fallback
 from osclib.core import group_members
 from osclib.core import maintainers_get
+from osclib.core import package_role_expand
 from osclib.core import request_action_key
 from osclib.core import request_age
 from osclib.memoize import memoize
@@ -403,6 +404,11 @@ class ReviewBot(object):
     def devel_project_review_needed(self, request, project, package):
         author = request.creator
         maintainers = set(maintainers_get(self.apiurl, project, package))
+
+        if len(maintainers) == 0:
+            devel_project, devel_package = devel_project_fallback(self.apiurl, project, package)
+            if devel_package:
+                maintainers = set(package_role_expand(self.apiurl, devel_project, devel_package))
 
         if author in maintainers:
             return False


### PR DESCRIPTION
If a devel pkg maintainer submits, don't add a review on the devel pkg. Without this change it only looked at the /search/owner result which doesn't always work.

Example: https://build.opensuse.org/request/show/1193836

Previously:

```sh
> ./check_source.py --dry --debug --osc-debug --verbose id 1193836
DEBUG: makeurl: /request/1193836?withfullhistory=1
[D] Starting new HTTPS connection (1): api.opensuse.org:443
[D] https://api.opensuse.org:None "GET /request/1193836?withfullhistory=1 HTTP/1.1" 401 503
[D] Starting new HTTPS connection (2): api.opensuse.org:443
[D] https://api.opensuse.org:None "GET /request/1193836?withfullhistory=1 HTTP/1.1" 200 None
[I] checking 1193836
DEBUG: makeurl: /search/project?match=starts-with%28remoteurl%2C+%22http%22%29
[D] https://api.opensuse.org:None "GET /search/project?match=starts-with%28remoteurl%2C+%22http%22%29 HTTP/1.1" 200 None
DEBUG: makeurl: /source/openSUSE:Factory/_attribute/OSRT:Config?
[D] https://api.opensuse.org:None "GET /source/openSUSE:Factory/_attribute/OSRT:Config HTTP/1.1" 200 None
DEBUG: makeurl: /group/factory-staging?
[D] https://api.opensuse.org:None "GET /group/factory-staging HTTP/1.1" 200 None
DEBUG: makeurl: /comments/request/1193836?
[D] https://api.opensuse.org:None "GET /comments/request/1193836 HTTP/1.1" 200 None
DEBUG: makeurl: /source/openSUSE:Factory?view=info&package=opensuse-postfix-image&nofilename=1
[D] https://api.opensuse.org:None "GET /source/openSUSE:Factory?view=info&package=opensuse-postfix-image&nofilename=1 HTTP/1.1" 200 190
[D] https://api.opensuse.org:None "GET /search/request?match=state/@name='new'+and+(action/target/@project='openSUSE:Factory'+and+action/target/@package='opensuse-postfix-image')+and+(action/@type='delete'+or+action/@type='submit') HTTP/1.1" 200 None
DEBUG: makeurl: /search/owner?binary=opensuse-postfix-image&project=openSUSE%3AFactory
[D] https://api.opensuse.org:None "GET /search/owner?binary=opensuse-postfix-image&project=openSUSE%3AFactory HTTP/1.1" 200 None
DEBUG: makeurl: /search/owner?binary=opensuse-postfix-image
[D] https://api.opensuse.org:None "GET /search/owner?binary=opensuse-postfix-image HTTP/1.1" 200 None
DEBUG: makeurl: /source/openSUSE:Factory/opensuse-postfix-image/_meta?
[D] https://api.opensuse.org:None "GET /source/openSUSE:Factory/opensuse-postfix-image/_meta HTTP/1.1" 200 None
[D] skipped adding duplicate review for devel:kubic:containers/opensuse-postfix-image
DEBUG: makeurl: /request/1193836?
[D] https://api.opensuse.org:None "GET /request/1193836 HTTP/1.1" 200 None
[I] 1193836 accepted: ok
[D] 1193836 review not changed
```

Now:

```sh
> ./check_source.py --dry --debug --osc-debug --verbose id 1193836
DEBUG: makeurl: /request/1193836?withfullhistory=1
[D] Starting new HTTPS connection (1): api.opensuse.org:443
[D] https://api.opensuse.org:None "GET /request/1193836?withfullhistory=1 HTTP/1.1" 200 None
[I] checking 1193836
DEBUG: makeurl: /search/project?match=starts-with%28remoteurl%2C+%22http%22%29
[D] https://api.opensuse.org:None "GET /search/project?match=starts-with%28remoteurl%2C+%22http%22%29 HTTP/1.1" 200 None
DEBUG: makeurl: /source/openSUSE:Factory/_attribute/OSRT:Config?
[D] https://api.opensuse.org:None "GET /source/openSUSE:Factory/_attribute/OSRT:Config HTTP/1.1" 200 None
DEBUG: makeurl: /group/factory-staging?
[D] https://api.opensuse.org:None "GET /group/factory-staging HTTP/1.1" 200 None
DEBUG: makeurl: /comments/request/1193836?
[D] https://api.opensuse.org:None "GET /comments/request/1193836 HTTP/1.1" 200 None
DEBUG: makeurl: /source/openSUSE:Factory?view=info&package=opensuse-postfix-image&nofilename=1
[D] https://api.opensuse.org:None "GET /source/openSUSE:Factory?view=info&package=opensuse-postfix-image&nofilename=1 HTTP/1.1" 200 190
[D] https://api.opensuse.org:None "GET /search/request?match=state/@name='new'+and+(action/target/@project='openSUSE:Factory'+and+action/target/@package='opensuse-postfix-image')+and+(action/@type='delete'+or+action/@type='submit') HTTP/1.1" 200 None
DEBUG: makeurl: /search/owner?binary=opensuse-postfix-image&project=openSUSE%3AFactory
[D] https://api.opensuse.org:None "GET /search/owner?binary=opensuse-postfix-image&project=openSUSE%3AFactory HTTP/1.1" 200 None
DEBUG: makeurl: /search/owner?binary=opensuse-postfix-image
[D] https://api.opensuse.org:None "GET /search/owner?binary=opensuse-postfix-image HTTP/1.1" 200 None
DEBUG: makeurl: /source/openSUSE:Factory/opensuse-postfix-image/_meta?
[D] https://api.opensuse.org:None "GET /source/openSUSE:Factory/opensuse-postfix-image/_meta HTTP/1.1" 200 None
DEBUG: makeurl: /source/devel:kubic:containers/opensuse-postfix-image/_meta?
[D] https://api.opensuse.org:None "GET /source/devel:kubic:containers/opensuse-postfix-image/_meta HTTP/1.1" 200 None
DEBUG: makeurl: /source/devel:kubic:containers/_meta?
[D] https://api.opensuse.org:None "GET /source/devel:kubic:containers/_meta HTTP/1.1" 200 None
DEBUG: makeurl: /group/factory-maintainers?
[D] https://api.opensuse.org:None "GET /group/factory-maintainers HTTP/1.1" 200 None
[D] devel project review not needed
DEBUG: makeurl: /request/1193836?
[D] https://api.opensuse.org:None "GET /request/1193836 HTTP/1.1" 200 None
[I] 1193836 accepted: ok
[D] 1193836 review not changed
```