### PR TITLE
legal-auto: Link to legal review via comment

### DIFF
--- a/legal-auto.py
+++ b/legal-auto.py
@@ -20,6 +20,7 @@ from lxml import etree as ET
 import osc.conf
 import osc.core
 from osclib.cache_manager import CacheManager
+from osclib.comments import CommentAPI
 import ReviewBot
 
 http_GET = osc.core.http_GET
@@ -79,6 +80,12 @@ class LegalAuto(ReviewBot.ReviewBot):
         url = osc.core.makeurl(self.legaldb, ['requests'], {'external_link': self.request_nick(),
                                                             'package': package['id']})
         REQ.post(url, headers=self.legaldb_headers)
+
+        comment_api = CommentAPI(self.apiurl)
+        review_url = osc.core.makeurl(self.legaldb, ['reviews', 'details', str(package['id'])])
+        review_comment = f"Legal review details available at {review_url} (access may be restricted)"
+        comment_api.add_comment(request_id=self.request.reqid, comment=review_comment)
+
         return [package['id']]
 
     def valid_for_opensuse(self, target_project, report):


### PR DESCRIPTION
It's rather hard for packagers to find the matching legal review for their OBS/IBS request. A comment with link should help make legal information more widely accessible.

I'm not the maintainer of legal-auto, but this has been a rather frequent request i've been getting from LegalDB users.