### PR TITLE
ttm: support Leap 16.0 development structure

### DIFF
--- a/gocd/totestmanager.gocd.yaml
+++ b/gocd/totestmanager.gocd.yaml
@@ -252,6 +252,27 @@ pipelines:
         - script: |-
             install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
             scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.6:ARM:Images
+  TTM.Leap_16.0:
+    group: openSUSE.Checkers
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-totest-manager
+    materials:
+      script:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+        destination: scripts
+    timer:
+      spec: 0 */15 * ? * *
+      only_on_changes: false
+    stages:
+    - Run:
+        approval: manual
+        resources:
+        - staging-bot
+        tasks:
+        - script: |-
+            install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
+            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:16.0
   TTM.Leap_Micro_6.0:
     group: openSUSE.Checkers
     lock_behavior: unlockWhenFinished

--- a/gocd/totestmanager.gocd.yaml.erb
+++ b/gocd/totestmanager.gocd.yaml.erb
@@ -13,6 +13,7 @@ pipelines:
       openSUSE:Leap:15.6:Images
       openSUSE:Leap:15.6:ARM
       openSUSE:Leap:15.6:ARM:Images
+      openSUSE:Leap:16.0
       openSUSE:Leap:Micro:6.0
       openSUSE:Leap:Micro:6.0:Images
   ) -%>

--- a/ttm/manager.py
+++ b/ttm/manager.py
@@ -72,6 +72,14 @@ class ToTestManager(ToolBase.ToolBase):
                 return result.group(1)
         raise NotFoundException(f"can't find {project} iso version")
 
+    def productcompose_build_version(self, project, tree, repo=None, arch=None):
+        for binary in self.binaries_of_product(project, tree, repo=repo, arch=arch):
+            result = re.match(
+                r'.*-(?:Build|Snapshot)([0-9.]+)(.report)', binary)
+            if result:
+                return result.group(1)
+        raise NotFoundException(f"can't find {project} productcompose version")
+
     def version_from_totest_project(self):
         if len(self.project.main_products):
             return self.iso_build_version(self.project.test_project, self.project.main_products[0])

--- a/ttm/releaser.py
+++ b/ttm/releaser.py
@@ -76,6 +76,11 @@ class ToTestReleaser(ToTestManager):
             return self.release_version()
 
         if len(self.project.main_products):
+            # 000productcompose has ftp built only and the build number
+            # agama-installer carry over build number from 000prodcutcompose
+            # but they are not from the same package container
+            if 'productcompose' in self.project.main_products[0]:
+                return self.productcompose_build_version(self.project.name, self.project.main_products[0])
             return self.iso_build_version(self.project.name, self.project.main_products[0])
 
         return self.iso_build_version(self.project.name, self.project.image_products[0].package,
@@ -286,8 +291,12 @@ class ToTestReleaser(ToTestManager):
                 self.release_package(self.project.name, product, repository=self.project.product_repo)
 
             for cd in self.project.main_products:
-                self.release_package(self.project.name, cd, set_release=set_release,
-                                     repository=self.project.product_repo)
+                # do not set release number if it is productcompose
+                if 'productcompose' in self.project.main_products[0]:
+                    self.release_package(self.project.name, cd, repository=self.project.product_repo)
+                else:
+                    self.release_package(self.project.name, cd, set_release=set_release,
+                                         repository=self.project.product_repo)
 
         for cd in self.project.livecd_products:
             self.release_package('%s:Live' %
@@ -295,8 +304,11 @@ class ToTestReleaser(ToTestManager):
                                  repository=self.project.livecd_repo)
 
         for image in self.project.image_products:
+            source_repo = self.project.product_repo
+            if self.project.same_target_images_repo_for_source_repo:
+                source_repo = self.project.totest_images_repo
             self.release_package(self.project.name, image.package, set_release=set_release,
-                                 repository=self.project.product_repo,
+                                 repository=source_repo,
                                  target_project=self.project.test_project,
                                  target_repository=self.project.totest_images_repo)
 

--- a/ttm/totest.py
+++ b/ttm/totest.py
@@ -31,6 +31,7 @@ class ToTest(object):
         self.set_snapshot_number = False
         self.snapshot_number_prefix = "Snapshot"
         self.take_source_from_product = False
+        self.same_target_images_repo_for_source_repo = False
         self.arch = 'x86_64'
         self.openqa_server = None
 


### PR DESCRIPTION
The description of the Leap 16.0 setup
* **000productcompose** is the main product but it builds ftp only. Build on `product` repo.
* **agama-installer** need to have identical build number as 000productcompose had. Build on `images` repo.
* **000productcompose** would not set release number while releasing to `ToTest`, but **agama-installer** does.

Tested this change with **Build36.40**