### PR TITLE
pkglistgen: add an ability to update weakremovers.inc only

### DIFF
--- a/gocd/pkglistgen.opensuse.gocd.yaml
+++ b/gocd/pkglistgen.opensuse.gocd.yaml
@@ -129,3 +129,24 @@ pipelines:
             - repo-checker
             tasks:
               - script: python3 -u ./pkglistgen.py --apiurl https://api.opensuse.org handle_update_repos openSUSE:Leap:16.0
+  Update.Weakremovers.Leap_16_0:
+    group: Leap
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    timer:
+      spec: 0 0 0/4 ? * *
+      only_on_changes: false
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    stages:
+    - Update:
+        approval:
+          type: manual
+        jobs:
+          openSUSE_Leap_16.0:
+            resources:
+            - repo-checker
+            tasks:
+              - script: python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Leap:16.0 -s target --only-update-weakremovers

--- a/gocd/pkglistgen.opensuse.gocd.yaml.erb
+++ b/gocd/pkglistgen.opensuse.gocd.yaml.erb
@@ -80,3 +80,26 @@ pipelines:
             tasks:
               - script: python3 -u ./pkglistgen.py --apiurl https://api.opensuse.org handle_update_repos <%= project %>
 <% end -%>
+  Update.Weakremovers.Leap_16_0:
+    group: Leap
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    timer:
+      spec: 0 0 0/4 ? * *
+      only_on_changes: false
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    stages:
+    - Update:
+        approval:
+          type: manual
+        jobs:
+<% %w(openSUSE:Leap:16.0).each do |project| -%>
+          <%= project.gsub(':', '_') %>:
+            resources:
+            - repo-checker
+            tasks:
+              - script: python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p <%= project %> -s target --only-update-weakremovers
+<% end -%>

--- a/pkglistgen/cli.py
+++ b/pkglistgen/cli.py
@@ -53,6 +53,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
     @cmdln.option('--stop-after-solve', action='store_true', help='only create group files')
     @cmdln.option('--staging', help='Only solve that one staging')
     @cmdln.option('--only-release-packages', action='store_true', help='Generate 000release-packages only')
+    @cmdln.option('--only-update-weakremovers', action='store_true', help='Update weakremovers.inc file only')
     @cmdln.option('--custom-cache-tag', help='add custom tag to cache dir to avoid issues when running in parallel')
     def do_update_and_solve(self, subcmd, opts):
         """${cmd_name}: update and solve for given scope
@@ -73,11 +74,14 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
         if not opts.scope:
             raise ValueError('--scope or --staging required')
 
+        if opts.only_release_packages and opts.only_update_weakremovers:
+            raise ValueError('--only-release-packages and --only-update-weakremovers can not be used together.')
+
         if opts.engine not in ENGINE_NAMES:
             raise ValueError(f"Illegal engine: {opts.engine} . Supported engines are {', '.join(ENGINE_NAMES)}.")
-        elif opts.engine == Engine.product_composer.name and opts.only_release_packages:
-            raise ValueError(f"--only-release-packages makes no sense with {Engine.product_composer.name} engine, as it does not handle "
-                             "000release-packages!")
+        elif opts.engine == Engine.product_composer.name and (opts.only_release_packages or opts.only_update_weakremovers):
+            raise ValueError(f"--only-release-packages or --only-update-weakremovers makes no sense with {Engine.product_composer.name} "
+                             "engine, as it does not handle 000release-packages!")
 
         apiurl = conf.config['apiurl']
         Config(apiurl, opts.project)
@@ -106,6 +110,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
                                                          engine=Engine[opts.engine],
                                                          force=opts.force, no_checkout=opts.no_checkout,
                                                          only_release_packages=opts.only_release_packages,
+                                                         only_update_weakremovers=opts.only_update_weakremovers,
                                                          stop_after_solve=opts.stop_after_solve,
                                                          custom_cache_tag=opts.custom_cache_tag)
             except MismatchedRepoException:


### PR DESCRIPTION
Add an --only-update-weakremovers option to be able to update weakremovers.inc only. With this option, pkglistgen will checkout release package and update weakremovers.inc, nothing else, no needed to have other product package involved.

Since Leap 16.0 don't use pkglistgen anymore but productcomposer, we still need a tool to recalculate weakremovers.inc according to the binary pool from the current and the previous version, therefore lets reuse pkglistgen's code for weakremovers handling.