### PR TITLE
Sync Agama Live ISO to OSD for all architectures

### DIFF
--- a/gocd/monitors.gocd.yaml
+++ b/gocd/monitors.gocd.yaml
@@ -89,7 +89,7 @@ pipelines:
                 git config --global user.email "coolo@suse.de"
                 git config --global user.name "GoCD Repo Monitor"
                 cd repos
-                ../scripts/gocd/rabbit-repoid.py -A https://api.suse.de SUSE:SLE SUSE:ALP
+                ../scripts/gocd/rabbit-repoid.py -A https://api.suse.de SUSE:SLE SUSE:ALP Devel:YaST
   openSUSE.Repo.Monitor:
     group: Monitors
     lock_behavior: unlockWhenFinished


### PR DESCRIPTION
We have added synchronization with Agama/YaST Head development.

Ticket: https://progress.opensuse.org/issues/166973