### PR TITLE
pcheck: fix creation of submit requests

### DIFF
--- a/osc-pcheck.py
+++ b/osc-pcheck.py
@@ -114,7 +114,7 @@ class oscapi:
         query = {'cmd': 'create'}
         url = osc.core.makeurl(self.apiurl, ['request'], query=query)
 
-        data = '<request type="submit"><submit><source project="{project}" package="{package}" rev="{rev}"/>' \
-               '<target project="{target}" package="{package}"/></submit><state name="new"/><description>{message}</description>' \
+        data = '<request><action type="submit"><source project="{project}" package="{package}" rev="{rev}"/>' \
+               '<target project="{target}" package="{package}"/></action><state name="new"/><description>{message}</description>' \
                '</request>'.format(project=project, package=package, target=target, rev=currev, message=message)
         osc.core.http_POST(url, data=data)


### PR DESCRIPTION
Use the proper API calls `<request><action type="submit">…` instead of
the no longer working `<request type="submit">…`
