### PR TITLE
slfo-packagelist-uploader: Leap 16.0 should stay with main branch

### DIFF
--- a/gocd/checkers.opensuse.gocd.yaml
+++ b/gocd/checkers.opensuse.gocd.yaml
@@ -196,4 +196,4 @@ pipelines:
             resources:
             - repo-checker
             tasks:
-              - script: ./slfo-packagelist-uploader.py --project openSUSE:Leap:16.0 --branch 1.1
+              - script: ./slfo-packagelist-uploader.py --project openSUSE:Leap:16.0


### PR DESCRIPTION
Leap 16.0 should stay with main branch for now until perhaps 1.3 branch created.