### PR TITLE
cleanup_rings: Also keep the main package if a multibuild flavor is needed

### DIFF
--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -29,8 +29,6 @@ class CleanupRings(object):
             'raspberrypi-firmware-config',
             # https://github.com/openSUSE/open-build-service/issues/14129
             'snobol4',
-            # We need devscripts:checkbashism in Ring1, removing the main flavor is not possible
-            'devscripts',
         ]
 
     def perform(self):
@@ -211,7 +209,7 @@ class CleanupRings(object):
                         # Outside of ring0, if one multibuild flavor is needed, add all of them
                         mainpkg = pkg.split(":")[0]
                         for src in self.sources:
-                            if src.startswith(f"{mainpkg}:"):
+                            if src.startswith(f"{mainpkg}:") or src == mainpkg:
                                 new_deps[src] = pkg
 
                         # Same for link groups

--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -27,8 +27,6 @@ class CleanupRings(object):
             'u-boot',
             'raspberrypi-firmware-dt',
             'raspberrypi-firmware-config',
-            # Added manually to notice failures early
-            'vagrant',
             # https://github.com/openSUSE/open-build-service/issues/14129
             'snobol4',
             # We need devscripts:checkbashism in Ring1, removing the main flavor is not possible

--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -146,12 +146,12 @@ class CleanupRings(object):
                     self.pkgdeps[b] = 'MYinstall'
 
     @memoize(session=True)
-    def package_get_requiredby(self, project, package, repo, arch):
+    def package_get_requiredby(apiurl, project, package, repo, arch):
         "For a given package, return which source packages it provides runtime deps for."
         ret = set()
-        for fileinfo in fileinfo_ext_all(self.api.apiurl, project, repo, arch, package):
+        for fileinfo in fileinfo_ext_all(apiurl, project, repo, arch, package):
             for requiredby in fileinfo.findall('provides_ext/requiredby[@name]'):
-                ret.add(self.bin2src[requiredby.get('name')])
+                ret.add(requiredby.get('name'))
 
         return ret
 
@@ -247,7 +247,8 @@ class CleanupRings(object):
                 # is needed (no built images) so we continue where x86_64 left off
                 maybe_unneeded = self.sources.difference(all_needed_sources)
                 for pkg in sorted(maybe_unneeded):
-                    requiredby = self.package_get_requiredby(prj, pkg, 'standard', arch)
+                    requiredby = CleanupRings.package_get_requiredby(self.api.apiurl, prj, pkg, 'standard', arch)
+                    requiredby = {self.bin2src[pkg] for pkg in requiredby}
                     requiredby = requiredby.intersection(all_needed_sources)
                     # Required by needed packages?
                     if len(requiredby):

--- a/osclib/memoize.py
+++ b/osclib/memoize.py
@@ -118,7 +118,8 @@ def memoize(ttl=None, session=False, add_invalidate=False):
             # representation.
             key = pickle.dumps(obj, protocol=-1)
             key = pickle.dumps(pickle.loads(key), protocol=-1)
-            return key
+            # shelve only support str keys
+            return key if session else str(key)
 
         def _invalidate(*args, **kwargs):
             key = _key((args, kwargs))


### PR DESCRIPTION
And provide a major speedup for debugging with `@memoize(session=False)`.

Current result:

```
# For openSUSE:Factory:Rings:0-Bootstrap:
# Multibuild flavor autoconf:testsuite not needed
# Multibuild flavor binutils:aarch64 not needed
# Multibuild flavor binutils:arm not needed
# Multibuild flavor binutils:bpf not needed
# Multibuild flavor binutils:ppc64 not needed
# Multibuild flavor binutils:ppc64le not needed
# Multibuild flavor binutils:riscv64 not needed
# Multibuild flavor binutils:s390x not needed
# Multibuild flavor gcc14:cross-aarch64-gcc14 not needed
# Multibuild flavor gcc14:cross-aarch64-gcc14-bootstrap not needed
# Multibuild flavor gcc14:cross-arm-gcc14 not needed
# Multibuild flavor gcc14:cross-arm-none-gcc14-bootstrap not needed
# Multibuild flavor gcc14:cross-bpf-gcc14 not needed
# Multibuild flavor gcc14:cross-ppc64-gcc14 not needed
# Multibuild flavor gcc14:cross-ppc64le-gcc14-bootstrap not needed
# Multibuild flavor gcc14:cross-riscv64-gcc14 not needed
# Multibuild flavor gcc14:cross-riscv64-gcc14-bootstrap not needed
# Multibuild flavor gcc14:cross-s390x-gcc14-bootstrap not needed
# Multibuild flavor glibc:cross-aarch64 not needed
# Multibuild flavor glibc:cross-ppc64le not needed
# Multibuild flavor glibc:cross-riscv64 not needed
# Multibuild flavor glibc:cross-s390x not needed
# Multibuild flavor lua54:test not needed
# Multibuild flavor perl:testsuite not needed
# Multibuild flavor systemtap:systemtap-dtrace not needed
# For openSUSE:Factory:Rings:1-MinimalX:
# Multibuild flavor ninja:test not needed
# Multibuild flavor u-boot:tools not needed
```