### PR TITLE
osclib/list_command.py: Allow showing details for packages not in rings.

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -93,6 +93,8 @@ def clean_args(args):
               help='split the requests into individual groups')
 @cmdln.option('--supersede', action='store_true',
               help='replace staged requests when superseded')
+@cmdln.option('--adi-details', action='store_true',
+              help='show detailed summary for packages that are not in any ring')
 @cmdln.option('--filter-from', metavar='STAGING',
               help='filter request list to only those from a specific staging')
 @cmdln.option('-p', '--project', dest='project', metavar='PROJECT',
@@ -307,7 +309,7 @@ def do_staging(self, subcmd, opts, *args):
         osc staging frozenage [STAGING...]
         osc staging ignore [-m MESSAGE] REQUEST...
         osc staging unignore [--cleanup] [REQUEST...|all]
-        osc staging list [--supersede]
+        osc staging list [--supersede] [--adi-details]
         osc staging lock [-m MESSAGE]
         osc staging select [--no-freeze] [--remove-exclusion] [--move [--filter-from STAGING]]
             STAGING REQUEST...
@@ -578,7 +580,7 @@ def do_staging(self, subcmd, opts, *args):
         elif cmd == 'unignore':
             UnignoreCommand(api).perform(args[1:], opts.cleanup)
         elif cmd == 'list':
-            ListCommand(api).perform(supersede=opts.supersede)
+            ListCommand(api).perform(supersede=opts.supersede, adi_details=opts.adi_details)
         elif cmd == 'lock':
             lock.hold(opts.message)
         elif cmd == 'adi':


### PR DESCRIPTION
This PR implements the ability to show for packages that do not belong to any ring the same details that are shown for packages that do live in rings.  Due to concerns about compatibility and volume of the output the feature is hidden behind a new --no-ring-detailed command line flag.

The following is an example of the change with the flag enabled:
![image](https://github.com/user-attachments/assets/79772b65-6e7e-4cb2-86e9-e1817cf622c9)
and this is with the flag disabled
![Screenshot From 2024-10-31 15-00-29](https://github.com/user-attachments/assets/ee20a83b-d00d-4043-8a51-a845fa3d1317)

