### PR TITLE
Add Leap Micro 6.1 ttm and pkglist workflows

### DIFF
--- a/gocd/leapmicro.target.gocd.yaml
+++ b/gocd/leapmicro.target.gocd.yaml
@@ -56,3 +56,57 @@ pipelines:
         tasks:
           - script: osc -A https://api.opensuse.org release --target-project=openSUSE:Leap:Micro:6.0:ToTest --target-repository=product -r product openSUSE:Leap:Micro:6.0 000productcompose
 
+  LeapMicro61.RelPkgs:
+    group: Leap
+    lock_behavior: unlockWhenFinished
+    timer:
+      spec: 0 10 * ? * *
+      only_on_changes: false
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    stages:
+    - Create.Release.Packages:
+        approval: manual
+        resources:
+        - repo-checker
+        tasks:
+          - script: ./pkglistgen.py -A https://api.opensuse.org update_and_solve -p openSUSE:Leap:Micro:6.1 -s target --only-release-packages
+
+  LeapMicro61.Package.Lists:
+    group: Leap
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    timer:
+      spec: 0 40 * ? * *
+      only_on_changes: false
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    stages:
+    - Update.000productcompose:
+        resources:
+        - repo-checker
+        tasks:
+          - script: ./pkglistgen.py --verbose -A https://api.opensuse.org update_and_solve --project openSUSE:Leap:Micro:6.1 --scope target --engine product_composer --force
+
+  LeapMicro61.Publish:
+    group: Leap
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    timer:
+      spec: 0 50 0,12 ? * *
+      only_on_changes: false
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    stages:
+    - Publish.000productcompose:
+        resources:
+        - repo-checker
+        tasks:
+          - script: osc -A https://api.opensuse.org release --target-project=openSUSE:Leap:Micro:6.1:ToTest --target-repository=product -r product openSUSE:Leap:Micro:6.1 000productcompose


### PR DESCRIPTION
* keep it aside from 6.0 which is still being actively published to cover for all maintenance updates