### PR TITLE
gocd: slfo-stagings: fail on broken/failed products

### DIFF
--- a/gocd/slfo-stagings.gocd.yaml
+++ b/gocd/slfo-stagings.gocd.yaml
@@ -1160,20 +1160,24 @@ pipelines:
           - staging-bot
         tasks:
           - script: |-
-              minutes=0
+              minutes=1
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
-                if [ ${ret} -eq 2 ]; then
-                    echo "product repository not found. Project configuration issue?" >&2
-                    exit 1
-                elif [ ${minutes} -gt 180 ]; then
-                    echo "Product is still failing after timeout, exiting..." >&2
+              # Let the scheduler warm up first
+              sleep 60
+              while osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -E 'statuscount code="(blocked|scheduled|building)"'; do
+                if [ ${minutes} -gt 180 ]; then
+                    echo "Product is still building after timeout, exiting..." >&2
                     exit 1
                 fi
                 sleep 60
                 minutes=$(expr $minutes + 1)
               done
+              # Always fail on broken/failed products
+              if osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -qE 'statuscount code="(broken|failed)"'; then
+                    echo "Some products failed to build, exiting..." >&2
+                    exit 1
+              fi
 
     - Enable.images.repo:
         resources:
@@ -1250,20 +1254,24 @@ pipelines:
           - staging-bot
         tasks:
           - script: |-
-              minutes=0
+              minutes=1
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
-                if [ ${ret} -eq 2 ]; then
-                    echo "product repository not found. Project configuration issue?" >&2
-                    exit 1
-                elif [ ${minutes} -gt 180 ]; then
-                    echo "Product is still failing after timeout, exiting..." >&2
+              # Let the scheduler warm up first
+              sleep 60
+              while osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -E 'statuscount code="(blocked|scheduled|building)"'; do
+                if [ ${minutes} -gt 180 ]; then
+                    echo "Product is still building after timeout, exiting..." >&2
                     exit 1
                 fi
                 sleep 60
                 minutes=$(expr $minutes + 1)
               done
+              # Always fail on broken/failed products
+              if osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -qE 'statuscount code="(broken|failed)"'; then
+                    echo "Some products failed to build, exiting..." >&2
+                    exit 1
+              fi
 
     - Enable.images.repo:
         resources:
@@ -1340,20 +1348,24 @@ pipelines:
           - staging-bot
         tasks:
           - script: |-
-              minutes=0
+              minutes=1
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
-                if [ ${ret} -eq 2 ]; then
-                    echo "product repository not found. Project configuration issue?" >&2
-                    exit 1
-                elif [ ${minutes} -gt 180 ]; then
-                    echo "Product is still failing after timeout, exiting..." >&2
+              # Let the scheduler warm up first
+              sleep 60
+              while osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -E 'statuscount code="(blocked|scheduled|building)"'; do
+                if [ ${minutes} -gt 180 ]; then
+                    echo "Product is still building after timeout, exiting..." >&2
                     exit 1
                 fi
                 sleep 60
                 minutes=$(expr $minutes + 1)
               done
+              # Always fail on broken/failed products
+              if osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -qE 'statuscount code="(broken|failed)"'; then
+                    echo "Some products failed to build, exiting..." >&2
+                    exit 1
+              fi
 
     - Enable.images.repo:
         resources:
@@ -1430,20 +1442,24 @@ pipelines:
           - staging-bot
         tasks:
           - script: |-
-              minutes=0
+              minutes=1
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
-                if [ ${ret} -eq 2 ]; then
-                    echo "product repository not found. Project configuration issue?" >&2
-                    exit 1
-                elif [ ${minutes} -gt 180 ]; then
-                    echo "Product is still failing after timeout, exiting..." >&2
+              # Let the scheduler warm up first
+              sleep 60
+              while osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -E 'statuscount code="(blocked|scheduled|building)"'; do
+                if [ ${minutes} -gt 180 ]; then
+                    echo "Product is still building after timeout, exiting..." >&2
                     exit 1
                 fi
                 sleep 60
                 minutes=$(expr $minutes + 1)
               done
+              # Always fail on broken/failed products
+              if osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -qE 'statuscount code="(broken|failed)"'; then
+                    echo "Some products failed to build, exiting..." >&2
+                    exit 1
+              fi
 
     - Enable.images.repo:
         resources:
@@ -1520,20 +1536,24 @@ pipelines:
           - staging-bot
         tasks:
           - script: |-
-              minutes=0
+              minutes=1
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
-                if [ ${ret} -eq 2 ]; then
-                    echo "product repository not found. Project configuration issue?" >&2
-                    exit 1
-                elif [ ${minutes} -gt 180 ]; then
-                    echo "Product is still failing after timeout, exiting..." >&2
+              # Let the scheduler warm up first
+              sleep 60
+              while osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -E 'statuscount code="(blocked|scheduled|building)"'; do
+                if [ ${minutes} -gt 180 ]; then
+                    echo "Product is still building after timeout, exiting..." >&2
                     exit 1
                 fi
                 sleep 60
                 minutes=$(expr $minutes + 1)
               done
+              # Always fail on broken/failed products
+              if osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -qE 'statuscount code="(broken|failed)"'; then
+                    echo "Some products failed to build, exiting..." >&2
+                    exit 1
+              fi
 
     - Enable.images.repo:
         resources:
@@ -1610,20 +1630,24 @@ pipelines:
           - staging-bot
         tasks:
           - script: |-
-              minutes=0
+              minutes=1
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
-                if [ ${ret} -eq 2 ]; then
-                    echo "product repository not found. Project configuration issue?" >&2
-                    exit 1
-                elif [ ${minutes} -gt 180 ]; then
-                    echo "Product is still failing after timeout, exiting..." >&2
+              # Let the scheduler warm up first
+              sleep 60
+              while osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -E 'statuscount code="(blocked|scheduled|building)"'; do
+                if [ ${minutes} -gt 180 ]; then
+                    echo "Product is still building after timeout, exiting..." >&2
                     exit 1
                 fi
                 sleep 60
                 minutes=$(expr $minutes + 1)
               done
+              # Always fail on broken/failed products
+              if osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -qE 'statuscount code="(broken|failed)"'; then
+                    echo "Some products failed to build, exiting..." >&2
+                    exit 1
+              fi
 
     - Enable.images.repo:
         resources:
@@ -1700,20 +1724,24 @@ pipelines:
           - staging-bot
         tasks:
           - script: |-
-              minutes=0
+              minutes=1
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
-                if [ ${ret} -eq 2 ]; then
-                    echo "product repository not found. Project configuration issue?" >&2
-                    exit 1
-                elif [ ${minutes} -gt 180 ]; then
-                    echo "Product is still failing after timeout, exiting..." >&2
+              # Let the scheduler warm up first
+              sleep 60
+              while osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -E 'statuscount code="(blocked|scheduled|building)"'; do
+                if [ ${minutes} -gt 180 ]; then
+                    echo "Product is still building after timeout, exiting..." >&2
                     exit 1
                 fi
                 sleep 60
                 minutes=$(expr $minutes + 1)
               done
+              # Always fail on broken/failed products
+              if osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -qE 'statuscount code="(broken|failed)"'; then
+                    echo "Some products failed to build, exiting..." >&2
+                    exit 1
+              fi
 
     - Enable.images.repo:
         resources:
@@ -1790,20 +1818,24 @@ pipelines:
           - staging-bot
         tasks:
           - script: |-
-              minutes=0
+              minutes=1
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
-                if [ ${ret} -eq 2 ]; then
-                    echo "product repository not found. Project configuration issue?" >&2
-                    exit 1
-                elif [ ${minutes} -gt 180 ]; then
-                    echo "Product is still failing after timeout, exiting..." >&2
+              # Let the scheduler warm up first
+              sleep 60
+              while osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -E 'statuscount code="(blocked|scheduled|building)"'; do
+                if [ ${minutes} -gt 180 ]; then
+                    echo "Product is still building after timeout, exiting..." >&2
                     exit 1
                 fi
                 sleep 60
                 minutes=$(expr $minutes + 1)
               done
+              # Always fail on broken/failed products
+              if osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -qE 'statuscount code="(broken|failed)"'; then
+                    echo "Some products failed to build, exiting..." >&2
+                    exit 1
+              fi
 
     - Enable.images.repo:
         resources:
@@ -1880,20 +1912,24 @@ pipelines:
           - staging-bot
         tasks:
           - script: |-
-              minutes=0
+              minutes=1
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
-                if [ ${ret} -eq 2 ]; then
-                    echo "product repository not found. Project configuration issue?" >&2
-                    exit 1
-                elif [ ${minutes} -gt 180 ]; then
-                    echo "Product is still failing after timeout, exiting..." >&2
+              # Let the scheduler warm up first
+              sleep 60
+              while osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -E 'statuscount code="(blocked|scheduled|building)"'; do
+                if [ ${minutes} -gt 180 ]; then
+                    echo "Product is still building after timeout, exiting..." >&2
                     exit 1
                 fi
                 sleep 60
                 minutes=$(expr $minutes + 1)
               done
+              # Always fail on broken/failed products
+              if osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -qE 'statuscount code="(broken|failed)"'; then
+                    echo "Some products failed to build, exiting..." >&2
+                    exit 1
+              fi
 
     - Enable.images.repo:
         resources:
@@ -1970,20 +2006,24 @@ pipelines:
           - staging-bot
         tasks:
           - script: |-
-              minutes=0
+              minutes=1
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
-                if [ ${ret} -eq 2 ]; then
-                    echo "product repository not found. Project configuration issue?" >&2
-                    exit 1
-                elif [ ${minutes} -gt 180 ]; then
-                    echo "Product is still failing after timeout, exiting..." >&2
+              # Let the scheduler warm up first
+              sleep 60
+              while osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -E 'statuscount code="(blocked|scheduled|building)"'; do
+                if [ ${minutes} -gt 180 ]; then
+                    echo "Product is still building after timeout, exiting..." >&2
                     exit 1
                 fi
                 sleep 60
                 minutes=$(expr $minutes + 1)
               done
+              # Always fail on broken/failed products
+              if osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -qE 'statuscount code="(broken|failed)"'; then
+                    echo "Some products failed to build, exiting..." >&2
+                    exit 1
+              fi
 
     - Enable.images.repo:
         resources:
@@ -2060,20 +2100,24 @@ pipelines:
           - staging-bot
         tasks:
           - script: |-
-              minutes=0
+              minutes=1
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
-                if [ ${ret} -eq 2 ]; then
-                    echo "product repository not found. Project configuration issue?" >&2
-                    exit 1
-                elif [ ${minutes} -gt 180 ]; then
-                    echo "Product is still failing after timeout, exiting..." >&2
+              # Let the scheduler warm up first
+              sleep 60
+              while osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -E 'statuscount code="(blocked|scheduled|building)"'; do
+                if [ ${minutes} -gt 180 ]; then
+                    echo "Product is still building after timeout, exiting..." >&2
                     exit 1
                 fi
                 sleep 60
                 minutes=$(expr $minutes + 1)
               done
+              # Always fail on broken/failed products
+              if osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -qE 'statuscount code="(broken|failed)"'; then
+                    echo "Some products failed to build, exiting..." >&2
+                    exit 1
+              fi
 
     - Enable.images.repo:
         resources:

--- a/gocd/slfo-stagings.gocd.yaml.erb
+++ b/gocd/slfo-stagings.gocd.yaml.erb
@@ -273,20 +273,24 @@ pipelines:
           - staging-bot
         tasks:
           - script: |-
-              minutes=0
+              minutes=1
               osc -A $STAGING_API api -X POST "/source/$STAGING_PROJECT?cmd=remove_flag&repository=product&flag=build"
               export PYTHONPATH=$PWD/scripts
-              while ./scripts/gocd/verify-repo-built-successful.py -A $STAGING_API -p $STAGING_PROJECT -r product; ret=$?; [ ${ret} -ne 0 ]; do
-                if [ ${ret} -eq 2 ]; then
-                    echo "product repository not found. Project configuration issue?" >&2
-                    exit 1
-                elif [ ${minutes} -gt 180 ]; then
-                    echo "Product is still failing after timeout, exiting..." >&2
+              # Let the scheduler warm up first
+              sleep 60
+              while osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -E 'statuscount code="(blocked|scheduled|building)"'; do
+                if [ ${minutes} -gt 180 ]; then
+                    echo "Product is still building after timeout, exiting..." >&2
                     exit 1
                 fi
                 sleep 60
                 minutes=$(expr $minutes + 1)
               done
+              # Always fail on broken/failed products
+              if osc -A $STAGING_API api -X GET "/build/$STAGING_PROJECT/_result?view=summary&repository=product&arch=local" | grep -qE 'statuscount code="(broken|failed)"'; then
+                    echo "Some products failed to build, exiting..." >&2
+                    exit 1
+              fi
 
     - Enable.images.repo:
         resources:


### PR DESCRIPTION
Rather than using verify-repo-built-successful.py, check with the API directly whether the product is blocked, scheduled or building.

Since it might happen for a product being broken/failed (even after a successful pkglistgen run), just fail in that case.