### PR TITLE
Add Leap Micro 6.2 pipeline and publish_distro part

### DIFF
--- a/gocd/leapmicro.target.gocd.yaml
+++ b/gocd/leapmicro.target.gocd.yaml
@@ -110,3 +110,58 @@ pipelines:
         - repo-checker
         tasks:
           - script: osc -A https://api.opensuse.org release --target-project=openSUSE:Leap:Micro:6.1:ToTest --target-repository=product -r product openSUSE:Leap:Micro:6.1 000productcompose
+
+  LeapMicro62.RelPkgs:
+    group: Leap
+    lock_behavior: unlockWhenFinished
+    timer:
+      spec: 0 10 * ? * *
+      only_on_changes: false
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    stages:
+    - Create.Release.Packages:
+        approval: manual
+        resources:
+        - repo-checker
+        tasks:
+          - script: ./pkglistgen.py -A https://api.opensuse.org update_and_solve -p openSUSE:Leap:Micro:6.2 -s target --only-release-packages
+
+  LeapMicro62.Package.Lists:
+    group: Leap
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    timer:
+      spec: 0 40 * ? * *
+      only_on_changes: false
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    stages:
+    - Update.000productcompose:
+        resources:
+        - repo-checker
+        tasks:
+          - script: ./pkglistgen.py --verbose -A https://api.opensuse.org update_and_solve --project openSUSE:Leap:Micro:6.2 --scope target --engine product_composer --force
+
+  LeapMicro62.Publish:
+    group: Leap
+    lock_behavior: unlockWhenFinished
+    environment_variables:
+      OSC_CONFIG: /home/go/config/oscrc-staging-bot
+    timer:
+      spec: 0 50 0,12 ? * *
+      only_on_changes: false
+    materials:
+      git:
+        git: https://github.com/openSUSE/openSUSE-release-tools.git
+    stages:
+    - Publish.000productcompose:
+        resources:
+        - repo-checker
+        tasks:
+          - script: osc -A https://api.opensuse.org release --target-project=openSUSE:Leap:Micro:6.1:ToTest --target-repository=product -r product openSUSE:Leap:Micro:6.2 000productcompose

--- a/publish_distro_conf/publish_leap-micro62.config
+++ b/publish_distro_conf/publish_leap-micro62.config
@@ -1,0 +1,52 @@
+# vim:syntax=sh
+
+micro_version=6.2
+qu="" # empty string for GA, QuarterlyUpdate repins have -N in version
+logfile_base=~/publish_logs/$micro_version/$(date -d "$date" '+%Y/%m/%d/%H%M')
+synclog="${logfile_base}.log"
+deletelog="${logfile_base}-deletes.log"
+path="/distribution/leap-micro/$micro_version/product"
+flavors=(x86_64 aarch64)
+
+# openSUSE-Leap-Micro-6.1-aarch64-Build13.1.iso is the filename by 000productcompose
+get_version() {
+	# get expected version from first flavor
+	if [ -z "$version" ]; then
+		version=`echo $stage/iso/openSUSE-Leap-Micro-$micro_version$qu-$flavor-Build[0123456789]*.[0123456789]*.iso`
+		version=${version##*Build}
+		version=${version%-*}
+		if [ -z "$version" ]; then
+			echo "no version found, exit." | tee -a $synclog
+			exit 1
+		fi
+	fi
+}
+
+get_iso()
+{
+	# openSUSE-Leap-Micro-6.1-aarch64-Build13.1.iso
+	iso="openSUSE-Leap-Micro-$micro_version$qu-$flavor-Build$version.iso"
+}
+
+get_iso_link()
+{
+	link="$stage/iso/openSUSE-Leap-$micro_version$qu-$flavor-Current.iso"
+}
+
+get_diff_url()
+{
+	url="$diff_url_base/$micro_version/diff/$version"
+}
+
+get_mark_published_url()
+{
+	url="$diff_url_base/$micro_version/current"
+}
+
+get_changes_filename()
+{
+	# ChangeLog files from obsgendiff are used instead
+	#changes="$changes_dir_base/jump/$jump_version/Changes.$version.txt"
+	:
+#	changes="$changes_dir_base/leap/$micro_version/Changes.$version.txt"
+}

--- a/publish_distro_conf/publish_leap-micro62_appliances.config
+++ b/publish_distro_conf/publish_leap-micro62_appliances.config
@@ -1,0 +1,57 @@
+# vim:syntax=sh
+
+micro_version=6.2
+logfile_base=~/publish_logs/$micro_version-appliances/$(date -d "$date" '+%Y/%m/%d/%H%M')
+synclog="${logfile_base}.log"
+deletelog="${logfile_base}-deletes.log"
+path="/distribution/leap-micro/$micro_version/appliances"
+flavors=(Default-SelfInstall)
+repos=()
+extra_repos=()
+isodir=""
+
+get_version() {
+	# get expected version from first flavor
+	if [ -z "$version" ]; then
+		version=`echo $stage/openSUSE-Leap-Micro.x86_64-$micro_version-$flavor-Build*.raw.xz`
+		version=${version##*Build}
+		version=${version%.*}
+		if [ -z "$version" ]; then
+			echo "no version found, exit." | tee -a $synclog
+			exit 1
+		fi
+	fi
+}
+
+_get_iso()
+{
+	local snapshot="$1"
+	local suffix=xz
+#	echo "openSUSE-Leap-Micro-$micro_version-JeOS.x86_64-$micro_version.0-$flavor-$snapshot.$suffix"
+	echo "openSUSE-Leap-Micro.x86_64-$micro_version-$flavor-$snapshot.$suffix"
+}
+
+get_iso()
+{
+	iso=`_get_iso "Build$version"`
+}
+
+get_iso_link()
+{
+	link="$stage/`_get_iso Current`"
+}
+
+get_diff_url()
+{
+	url=""
+}
+
+get_mark_published_url()
+{
+	url=""
+}
+
+get_changes_filename()
+{
+	changes=""
+}


### PR DESCRIPTION
* Pipeline for Leap Micro 6.2
* We'll have to update ~mirror/publish_* wrapper on pontifex wih publish_distro for Micro 6.2 