### PR TITLE
packaging: Do not reference python3-osc

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -35,7 +35,6 @@ BuildRequires:  python3-PyYAML
 BuildRequires:  python3-cmdln
 BuildRequires:  python3-colorama
 BuildRequires:  python3-lxml
-BuildRequires:  python3-osc
 BuildRequires:  python3-pycurl
 BuildRequires:  python3-python-dateutil
 BuildRequires:  python3-pyxdg
@@ -269,7 +268,6 @@ Group:          Development/Tools/Other
 # TODO Update requirements, but for now base deps.
 Requires:       %{name} = %{version}
 Requires:       osc >= 0.165.1
-Requires:       python3-osc
 BuildArch:      noarch
 
 %description -n osclib


### PR DESCRIPTION
This is only a symbol provided by the actual osc package.

One of the main issues attempted to be addressed was ensuring that the
plugin matches the python version used by osc, but the symbol
'python3-*' does not guarantee that at all, as the symbol just moves between
python-flavors, based on primary python.
