### PR TITLE
maintenance bot: add support for git-based devel projects

### DIFF
--- a/check_maintenance_incidents.py
+++ b/check_maintenance_incidents.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import logging
 import sys
 
 import osc.conf
@@ -8,7 +9,7 @@ from urllib.error import HTTPError, URLError
 import yaml
 
 from osclib.memoize import memoize
-from osclib.core import action_is_patchinfo
+from osclib.core import action_is_patchinfo, devel_project_get
 from osclib.core import owner_fallback
 from osclib.core import maintainers_get
 
@@ -29,6 +30,17 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
         if action_is_patchinfo(a):
             a = req.actions[1]
         project = a.tgt_releaseproject if a.type == 'maintenance_incident' else req.actions[0].tgt_project
+
+        if project.startswith('openSUSE:'):
+            prj, pkg = devel_project_get(self.apiurl, "openSUSE:Factory", package)
+            if prj is None and package.find(".") > 0:
+                prj, pkg = devel_project_get(self.apiurl, "openSUSE:Factory", package[0:package.rfind(".")])
+            logging.debug(f'using devel project {prj}/{pkg}')
+            if prj is not None:
+                msg = f'Submission for {pkg} by someone who is not maintainer in the devel project ({prj}). Please review'
+                self.add_review(req, by_project=prj, by_package=pkg, msg=msg)
+                return
+
         root = owner_fallback(self.apiurl, project, package)
 
         for p in root.findall('./owner'):

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -327,6 +327,7 @@ def devel_project_get(apiurl: str, target_project: str, target_package: str) -> 
 
     if target_project.endswith('openSUSE:Factory'):
         devel_pkgs = factory_git_devel_project_mapping(apiurl)
+        logging.debug(f"fetched git devel packages, looking for {target_package}")
         if target_package in devel_pkgs:
             return devel_pkgs[target_package], target_package
     return None, None

--- a/tests/maintenance_tests.py
+++ b/tests/maintenance_tests.py
@@ -115,6 +115,17 @@ class TestMaintenance(OBSLocal.TestCase):
                 </directory>
             """)
 
+        httpretty.register_uri(httpretty.GET,
+                               APIURL + "/source/openSUSE:Factory/mysql-workbench/_meta",
+                               match_querystring=True,
+                               body="""
+                  <package name="mysql-workbench" project="openSUSE:Factory">
+                    <title>MySQL Workbench</title>
+                    <description>UI for MySQL server</description>
+                    <devel project="server:database" package="mysql-workbench"/>
+                  </package>
+            """)
+
         result = {'devel_review_added': None}
 
         def change_request(result, method, uri, headers):


### PR DESCRIPTION
fixes maintenance requests like 1268814 where devel project information is only in git and the `/search/owner` API call is not very useful anymore.

https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/6ILLOYQ3W4IWTA47WTXBANZZGLHTFYBB/
