### PR TITLE
rabbit-openqa: relax failure on name collisions

### DIFF
--- a/gocd/rabbit-openqa.py
+++ b/gocd/rabbit-openqa.py
@@ -172,7 +172,8 @@ class Project(object):
                         obsolete_jobs.append(id)
                         continue
 
-                raise Exception(f'Names of job #{id} and #{taken_names[name]} collide: {name}')
+                self.logger.error(f'Names of job #{id} and #{taken_names[name]} collide: {name}')
+                return
             taken_names[name] = id
 
         for id in obsolete_jobs:


### PR DESCRIPTION
Rather than raising an exception, log the error and skip reporting for the specific staging. This allows the listener to continue processing other projects.