### PR TITLE
rabbit-openqa: encode the product version in job name

### DIFF
--- a/gocd/rabbit-openqa.py
+++ b/gocd/rabbit-openqa.py
@@ -105,7 +105,7 @@ class Project(object):
             openqa_infos[job['id']] = {'url': self.listener.test_url(job)}
             openqa_infos[job['id']]['state'] = self.map_openqa_result(job)
             openqa_infos[job['id']]['build'] = job['settings']['BUILD']
-            openqa_infos[job['id']]['name'] = f"{job['settings']['FLAVOR']}-{job['settings']['TEST']}@{job['settings']['MACHINE']}"
+            openqa_infos[job['id']]['name'] = f"{job['settings']['VERSION']}-{job['settings']['FLAVOR']}-{job['settings']['TEST']}@{job['settings']['MACHINE']}"
 
     def compare_simple_builds(build1, build2):
         """Simple build number comparison"""


### PR DESCRIPTION
The bot in the SUSE side [crashed recently](https://botmaster.suse.de/go/tab/build/detail/SUSE.openQA/69498/Run/1/Run) due to a name collision:

    File "/godata/pipelines/SUSE.openQA/./scripts/gocd/rabbit-openqa.py", line 284, in check_some_projects
      project.update_staging_status(staging)
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
    File "/godata/pipelines/SUSE.openQA/./scripts/gocd/rabbit-openqa.py", line 175, in update_staging_status
      raise Exception(f'Names of job #{id} and #{taken_names[name]} collide: {name}')
  Exception: Names of job #17092411 and #16972018 collide: Default-qcow-Updates-Staging-install_ltp+sle-micro+Default-qcow-Updates-Staging@aarch64

This is a bit of a niche situation, as the project is in the SUSE:SLFO:Kernel:1.0 project, where we share the kernel between SLFO 1.0 and 1.1.

This means that the same tests are run against both Micro 6.0 and Micro 6.1, and might thus collide.

Now, setting this as a Draft since I suppose we should discuss whether this should be applied to every project (where the version information is redundant, and might add entropy to already crowded test names), or maybe gate it to an attribute where it can be enabled on the project side, as it might be useful for just a bunch of projects. Suggestions welcome.