### PR TITLE
osclib: core: explicitly replace OBS instance prefix in devel_project_fallback

### DIFF
--- a/osclib/core.py
+++ b/osclib/core.py
@@ -345,7 +345,7 @@ def devel_project_fallback(apiurl, target_project, target_package):
             project, package = devel_project_get(apiurl, 'openSUSE.org:openSUSE:Factory', target_package)
             if project:
                 # Strip openSUSE.org: prefix since string since not used for lookup.
-                project = project.split(':', 1)[1]
+                project = project.replace("openSUSE.org:", "", count=1)
 
     return project, package
 


### PR DESCRIPTION
When getting the devel project via the build service API, and the source project is accessed via interconnect, the returned devel project contains the instance prefix.

However, when checking directly in the Factory git mapping, the interconnected prefix is not being added to the result.

As such, ensure we handle this case too - and just replace the instance name if found.