### PR TITLE
Return None if devel package does not exist on the OBS according to the stored data on the git

### DIFF
--- a/osclib/core.py
+++ b/osclib/core.py
@@ -328,7 +328,8 @@ def devel_project_get(apiurl: str, target_project: str, target_package: str) -> 
     if target_project.endswith('openSUSE:Factory'):
         devel_pkgs = factory_git_devel_project_mapping(apiurl)
         logging.debug(f"fetched git devel packages, looking for {target_package}")
-        if target_package in devel_pkgs:
+        if target_package in devel_pkgs and\
+                entity_exists(apiurl, devel_pkgs[target_package], target_package):
             return devel_pkgs[target_package], target_package
     return None, None
 


### PR DESCRIPTION
Fixes https://github.com/openSUSE/openSUSE-release-tools/issues/3241