### PR TITLE
TTM: do allow to override product_repo for ftp

### DIFF
--- a/ttm/totest.py
+++ b/ttm/totest.py
@@ -9,6 +9,7 @@
 # Distribute under GPLv2 or GPLv3
 
 import yaml
+import re
 from osclib.core import attribute_value_load
 
 
@@ -48,6 +49,7 @@ class ToTest(object):
         self.containerfile_products = []
         self.livecd_products = []
         self.image_products = []
+        self.product_repo_overrides = {}
 
         self.test_subproject = 'ToTest'
         self.base = project.split(':')[0]
@@ -67,6 +69,15 @@ class ToTest(object):
         # Set default for totest_images_repo
         if self.totest_images_repo is None:
             self.totest_images_repo = self.product_repo
+
+        # do allow to override repository for ftp product
+        ftp_products_copy = self.ftp_products.copy()
+        for product in ftp_products_copy:
+            extract_product = re.search(r"(.+)/product_repo:(.+)", product)
+            if extract_product:
+                self.ftp_products.remove(product)
+                self.ftp_products.append(extract_product.group(1))
+                self.product_repo_overrides[extract_product.group(1)] = extract_product.group(2)
 
     def parse_images(self, products):
         parsed = []


### PR DESCRIPTION
Override `product_repo` for ftp product if the format follows **PRODUCT/product_repo:REPONAME**, eg. `0openSUSE/product_repo:product`

Ftp tree build will migrate to _productcomposer_ in Factory which designed to have individual repository for oss, and non-oss, and overall it can not use images repo since product-builder is still up for those products.