### PR TITLE
check_maintenance_incidents.py: Expand devel pkg roles for maintainer check

### DIFF
--- a/tests/maintenance_tests.py
+++ b/tests/maintenance_tests.py
@@ -126,6 +126,152 @@ class TestMaintenance(OBSLocal.TestCase):
                 </collection>
             """)
 
+    def test_maintainer_submit(self):
+
+        httpretty.register_uri(httpretty.GET,
+                               APIURL + '/search/request',
+                               body="""
+                <collection matches="1">
+                  <request id="261355" creator="bruno_friedmann">
+                    <action type="maintenance_incident">
+                      <source project="home:brassh" package="mysql-workbench" rev="857c77d2ba1d347b6dc50a1e5bcb74e1"/>
+                      <target project="openSUSE:Maintenance" releaseproject="openSUSE:13.2:Update"/>
+                    </action>
+                    <state name="review" who="lnussel_factory" when="2014-11-13T10:46:52">
+                      <comment></comment>
+                    </state>
+                    <review state="new" by_user="maintbot">
+                      <comment></comment>
+                    </review>
+                    <history who="bruno_friedmann" when="2014-11-13T09:18:19">
+                      <description>Request created</description>
+                      <comment>...</comment>
+                    </history>
+                    <history who="lnussel_factory" when="2014-11-13T10:46:52">
+                      <description>Request got a new review request</description>
+                    </history>
+                    <description>...</description>
+                  </request>
+                </collection>
+            """)
+
+        httpretty.register_uri(httpretty.GET,
+                               APIURL + "/request/261355",
+                               match_querystring=True,
+                               body="""
+              <request id="261355" creator="bruno_friedmann">
+                <action type="maintenance_incident">
+                  <source project="home:brassh" package="mysql-workbench" rev="857c77d2ba1d347b6dc50a1e5bcb74e1"/>
+                  <target project="openSUSE:Maintenance" releaseproject="openSUSE:13.2:Update"/>
+                </action>
+                <state name="review" who="lnussel_factory" when="2014-11-13T10:46:52">
+                  <comment></comment>
+                </state>
+                <review state="new" by_user="maintbot">
+                  <comment></comment>
+                </review>
+                <history who="bruno_friedmann" when="2014-11-13T09:18:19">
+                  <description>Request created</description>
+                  <comment>...</comment>
+                </history>
+                <history who="lnussel_factory" when="2014-11-13T10:46:52">
+                  <description>Request got a new review request</description>
+                </history>
+                <description>...</description>
+              </request>
+            """)
+
+        result = {'devel_review_added': None}
+
+        def change_request(result, method, uri, headers):
+            query = parse_qs(urlparse(uri).query)
+            if query == {'by_package': ['mysql-workbench'], 'cmd': ['addreview'], 'by_project': ['server:database']}:
+                result['devel_review_added'] = True
+            return (200, headers, '<status code="ok"/>')
+
+        httpretty.register_uri(httpretty.POST,
+                               APIURL + "/request/261355",
+                               body=lambda method, uri, headers: change_request(result, method, uri, headers))
+
+        self.checker.requests = []
+        self.checker.set_request_ids_search_review()
+        self.checker.check_requests()
+
+        self.assertFalse(result['devel_review_added'])
+
+    def test_prj_maintainer_submit(self):
+
+        httpretty.register_uri(httpretty.GET,
+                               APIURL + '/search/request',
+                               body="""
+                <collection matches="1">
+                  <request id="261355" creator="factory-maintainer">
+                    <action type="maintenance_incident">
+                      <source project="home:brassh" package="mysql-workbench" rev="857c77d2ba1d347b6dc50a1e5bcb74e1"/>
+                      <target project="openSUSE:Maintenance" releaseproject="openSUSE:13.2:Update"/>
+                    </action>
+                    <state name="review" who="lnussel_factory" when="2014-11-13T10:46:52">
+                      <comment></comment>
+                    </state>
+                    <review state="new" by_user="maintbot">
+                      <comment></comment>
+                    </review>
+                    <history who="factory-maintainer" when="2014-11-13T09:18:19">
+                      <description>Request created</description>
+                      <comment>...</comment>
+                    </history>
+                    <history who="lnussel_factory" when="2014-11-13T10:46:52">
+                      <description>Request got a new review request</description>
+                    </history>
+                    <description>...</description>
+                  </request>
+                </collection>
+            """)
+
+        httpretty.register_uri(httpretty.GET,
+                               APIURL + "/request/261355",
+                               match_querystring=True,
+                               body="""
+              <request id="261355" creator="factory-maintainer">
+                <action type="maintenance_incident">
+                  <source project="home:brassh" package="mysql-workbench" rev="857c77d2ba1d347b6dc50a1e5bcb74e1"/>
+                  <target project="openSUSE:Maintenance" releaseproject="openSUSE:13.2:Update"/>
+                </action>
+                <state name="review" who="lnussel_factory" when="2014-11-13T10:46:52">
+                  <comment></comment>
+                </state>
+                <review state="new" by_user="maintbot">
+                  <comment></comment>
+                </review>
+                <history who="factory-maintainer" when="2014-11-13T09:18:19">
+                  <description>Request created</description>
+                  <comment>...</comment>
+                </history>
+                <history who="lnussel_factory" when="2014-11-13T10:46:52">
+                  <description>Request got a new review request</description>
+                </history>
+                <description>...</description>
+              </request>
+            """)
+
+        result = {'devel_review_added': None}
+
+        def change_request(result, method, uri, headers):
+            query = parse_qs(urlparse(uri).query)
+            if query == {'by_package': ['mysql-workbench'], 'cmd': ['addreview'], 'by_project': ['server:database']}:
+                result['devel_review_added'] = True
+            return (200, headers, '<status code="ok"/>')
+
+        httpretty.register_uri(httpretty.POST,
+                               APIURL + "/request/261355",
+                               body=lambda method, uri, headers: change_request(result, method, uri, headers))
+
+        self.checker.requests = []
+        self.checker.set_request_ids_search_review()
+        self.checker.check_requests()
+
+        self.assertFalse(result['devel_review_added'])
+
     def test_non_maintainer_submit(self):
         """same as above but already has devel project as reviewer
         """

--- a/tests/maintenance_tests.py
+++ b/tests/maintenance_tests.py
@@ -31,6 +31,101 @@ class TestMaintenance(OBSLocal.TestCase):
                                           logger=self.logger)
         self.checker.override_allow = False  # Test setup cannot handle.
 
+        httpretty.register_uri(httpretty.GET,
+                               APIURL + "/source/home:brassh/mysql-workbench",
+                               match_querystring=True,
+                               body="""
+                <directory name="mysql-workbench" rev="6" vrev="6" srcmd5="858204decf53f923d5574dbe6ae63b15">
+                  <linkinfo project="openSUSE:13.2" package="mysql-workbench" srcmd5="ed9c3b12388cbd14868eb3faabe34685"
+                      baserev="ed9c3b12388cbd14868eb3faabe34685" xsrcmd5="08bfb4f40cb1e2de8f9cd4633bf02eb1"
+                      lsrcmd5="858204decf53f923d5574dbe6ae63b15" />
+                  <serviceinfo code="succeeded" xsrcmd5="6ec4305a8e5363e26a7f4895a0ae12d2" />
+                  <entry name="_link" md5="85ef5fb38ca1ec7c300311fda9f4b3d1" size="121" mtime="1414567341" />
+                  <entry name="mysql-workbench-community-6.1.7-src.tar.gz" md5="ac059e239869fb77bf5d7a1f5845a8af"
+                      size="24750696" mtime="1404405925" />
+                  <entry name="mysql-workbench-ctemplate.patch" md5="06ccba1f8275cd9408f515828ecede19" size="1322" mtime="1404658323" />
+                  <entry name="mysql-workbench-glib.patch" md5="67fd7d8e3503ce0909381bde747c8a1e" size="1785" mtime="1415732509" />
+                  <entry name="mysql-workbench-mysql_options4.patch" md5="9c07dfe1b94af95daf3e16bd6a161684"
+                         size="910" mtime="1404658324" />
+                  <entry name="mysql-workbench-no-check-for-updates.patch" md5="1f0c9514ff8218d361ea46d3031b2b64"
+                         size="1139" mtime="1404658324" />
+                  <entry name="mysql-workbench.changes" md5="26bc54777e6a261816b72f64c69630e4" size="13354" mtime="1415747835" />
+                  <entry name="mysql-workbench.spec" md5="88b562a93f01b842a5798f809e3c8188" size="7489" mtime="1415745943" />
+                  <entry name="openSUSE_(Vendor_Package).xml" md5="ab041af98d7748c216e7e5787ec36f65"
+                    size="743" mtime="1315923090" />
+                  <entry name="patch-desktop-categories.patch" md5="c24b3283573c34a5e072be122388f8e1"
+                    size="391" mtime="1376991147" />
+                </directory>
+            """)
+
+        httpretty.register_uri(httpretty.GET,
+                               APIURL + "/source/openSUSE:Factory/mysql-workbench/_meta",
+                               match_querystring=True,
+                               body="""
+                  <package name="mysql-workbench" project="openSUSE:Factory">
+                    <title>MySQL Workbench</title>
+                    <description>UI for MySQL server</description>
+                    <devel project="server:database" package="mysql-workbench"/>
+                  </package>
+            """)
+
+        httpretty.register_uri(httpretty.GET,
+                               APIURL + "/source/server:database/mysql-workbench/_meta",
+                               match_querystring=True,
+                               body="""
+                  <package name="mysql-workbench" project="server:database">
+                    <title>MySQL Workbench</title>
+                    <description>UI for MySQL server</description>
+                    <person userid="Gankov" role="maintainer"/>
+                    <person userid="bruno_friedmann" role="maintainer"/>
+                  </package>
+            """)
+
+        httpretty.register_uri(httpretty.GET,
+                               APIURL + "/source/server:database/_meta",
+                               match_querystring=True,
+                               body="""
+                  <project name="server:database">
+                    <title>Databases</title>
+                    <description>Server Database software</description>
+                    <group groupid="factory-maintainers" role="maintainer"/>
+                  </project>
+            """)
+
+        httpretty.register_uri(httpretty.GET,
+                               APIURL + "/group/factory-maintainers",
+                               match_querystring=True,
+                               body="""
+                  <group>
+                    <title>factory-maintainers</title>
+                    <maintainer userid="dimstar_suse"/>
+                    <maintainer userid="maxlin_factory"/>
+                    <person>
+                        <person userid="factory-maintainer"/>
+                        <person userid="dimstar_suse"/>
+                    </person>
+                  </group>
+            """)
+
+        httpretty.register_uri(httpretty.GET,
+                               APIURL + "/search/owner?project=openSUSE:13.2:Update&binary=mysql-workbench",
+                               match_querystring=True,
+                               body="""
+                <collection/>
+            """)
+
+        httpretty.register_uri(httpretty.GET,
+                               APIURL + "/search/owner?binary=mysql-workbench",
+                               match_querystring=True,
+                               body="""
+                <collection>
+                  <owner rootproject="openSUSE" project="server:database" package="mysql-workbench">
+                    <person name="Gankov" role="maintainer"/>
+                    <person name="bruno_friedmann" role="maintainer"/>
+                  </owner>
+                </collection>
+            """)
+
     def test_non_maintainer_submit(self):
         """same as above but already has devel project as reviewer
         """
@@ -49,6 +144,9 @@ class TestMaintenance(OBSLocal.TestCase):
                     </state>
                     <review state="new" by_user="maintbot">
                       <comment></comment>
+                    </review>
+                    <review state="new" by_package="mysql-workbench" by_project="server:database">
+                      <comment>review by devel project</comment>
                     </review>
                     <history who="brassh" when="2014-11-13T09:18:19">
                       <description>Request created</description>
@@ -88,49 +186,11 @@ class TestMaintenance(OBSLocal.TestCase):
               </request>
             """)
 
-        httpretty.register_uri(httpretty.GET,
-                               APIURL + "/source/home:brassh/mysql-workbench",
-                               match_querystring=True,
-                               body="""
-                <directory name="mysql-workbench" rev="6" vrev="6" srcmd5="858204decf53f923d5574dbe6ae63b15">
-                  <linkinfo project="openSUSE:13.2" package="mysql-workbench" srcmd5="ed9c3b12388cbd14868eb3faabe34685"
-                      baserev="ed9c3b12388cbd14868eb3faabe34685" xsrcmd5="08bfb4f40cb1e2de8f9cd4633bf02eb1"
-                      lsrcmd5="858204decf53f923d5574dbe6ae63b15" />
-                  <serviceinfo code="succeeded" xsrcmd5="6ec4305a8e5363e26a7f4895a0ae12d2" />
-                  <entry name="_link" md5="85ef5fb38ca1ec7c300311fda9f4b3d1" size="121" mtime="1414567341" />
-                  <entry name="mysql-workbench-community-6.1.7-src.tar.gz" md5="ac059e239869fb77bf5d7a1f5845a8af"
-                      size="24750696" mtime="1404405925" />
-                  <entry name="mysql-workbench-ctemplate.patch" md5="06ccba1f8275cd9408f515828ecede19" size="1322" mtime="1404658323" />
-                  <entry name="mysql-workbench-glib.patch" md5="67fd7d8e3503ce0909381bde747c8a1e" size="1785" mtime="1415732509" />
-                  <entry name="mysql-workbench-mysql_options4.patch" md5="9c07dfe1b94af95daf3e16bd6a161684"
-                         size="910" mtime="1404658324" />
-                  <entry name="mysql-workbench-no-check-for-updates.patch" md5="1f0c9514ff8218d361ea46d3031b2b64"
-                         size="1139" mtime="1404658324" />
-                  <entry name="mysql-workbench.changes" md5="26bc54777e6a261816b72f64c69630e4" size="13354" mtime="1415747835" />
-                  <entry name="mysql-workbench.spec" md5="88b562a93f01b842a5798f809e3c8188" size="7489" mtime="1415745943" />
-                  <entry name="openSUSE_(Vendor_Package).xml" md5="ab041af98d7748c216e7e5787ec36f65"
-                    size="743" mtime="1315923090" />
-                  <entry name="patch-desktop-categories.patch" md5="c24b3283573c34a5e072be122388f8e1"
-                    size="391" mtime="1376991147" />
-                </directory>
-            """)
-
-        httpretty.register_uri(httpretty.GET,
-                               APIURL + "/source/openSUSE:Factory/mysql-workbench/_meta",
-                               match_querystring=True,
-                               body="""
-                  <package name="mysql-workbench" project="openSUSE:Factory">
-                    <title>MySQL Workbench</title>
-                    <description>UI for MySQL server</description>
-                    <devel project="server:database" package="mysql-workbench"/>
-                  </package>
-            """)
-
         result = {'devel_review_added': None}
 
         def change_request(result, method, uri, headers):
             query = parse_qs(urlparse(uri).query)
-            if query == {'by_user': ['maintbot'], 'cmd': ['changereviewstate'], 'newstate': ['accepted']}:
+            if query == {'by_package': ['mysql-workbench'], 'cmd': ['addreview'], 'by_project': ['server:database']}:
                 result['devel_review_added'] = True
             return (200, headers, '<status code="ok"/>')
 
@@ -138,30 +198,11 @@ class TestMaintenance(OBSLocal.TestCase):
                                APIURL + "/request/261355",
                                body=lambda method, uri, headers: change_request(result, method, uri, headers))
 
-        httpretty.register_uri(httpretty.GET,
-                               APIURL + "/search/owner?project=openSUSE:13.2:Update&binary=mysql-workbench",
-                               match_querystring=True,
-                               body="""
-                <collection/>
-            """)
-
-        httpretty.register_uri(httpretty.GET,
-                               APIURL + "/search/owner?binary=mysql-workbench",
-                               match_querystring=True,
-                               body="""
-                <collection>
-                  <owner rootproject="openSUSE" project="server:database" package="mysql-workbench">
-                    <person name="Gankov" role="maintainer"/>
-                    <person name="bruno_friedmann" role="maintainer"/>
-                  </owner>
-                </collection>
-            """)
-
         self.checker.requests = []
         self.checker.set_request_ids_search_review()
         self.checker.check_requests()
 
-        self.assertTrue(result['devel_review_added'])
+        self.assertFalse(result['devel_review_added'])
 
     def test_non_maintainer_double_review(self):
 
@@ -224,67 +265,17 @@ class TestMaintenance(OBSLocal.TestCase):
               </request>
             """)
 
-        httpretty.register_uri(httpretty.GET,
-                               APIURL + "/source/home:brassh/mysql-workbench",
-                               match_querystring=True,
-                               body="""
-                <directory name="mysql-workbench" rev="6" vrev="6" srcmd5="858204decf53f923d5574dbe6ae63b15">
-                  <linkinfo project="openSUSE:13.2" package="mysql-workbench"
-                            srcmd5="ed9c3b12388cbd14868eb3faabe34685" baserev="ed9c3b12388cbd14868eb3faabe34685"
-                            xsrcmd5="08bfb4f40cb1e2de8f9cd4633bf02eb1" lsrcmd5="858204decf53f923d5574dbe6ae63b15" />
-                  <serviceinfo code="succeeded" xsrcmd5="6ec4305a8e5363e26a7f4895a0ae12d2" />
-                  <entry name="_link" md5="85ef5fb38ca1ec7c300311fda9f4b3d1" size="121" mtime="1414567341" />
-                  <entry name="mysql-workbench-community-6.1.7-src.tar.gz" md5="ac059e239869fb77bf5d7a1f5845a8af"
-                         size="24750696" mtime="1404405925" />
-                  <entry name="mysql-workbench-ctemplate.patch" md5="06ccba1f8275cd9408f515828ecede19"
-                         size="1322" mtime="1404658323" />
-                  <entry name="mysql-workbench-glib.patch" md5="67fd7d8e3503ce0909381bde747c8a1e"
-                         size="1785" mtime="1415732509" />
-                  <entry name="mysql-workbench-mysql_options4.patch" md5="9c07dfe1b94af95daf3e16bd6a161684"
-                         size="910" mtime="1404658324" />
-                  <entry name="mysql-workbench-no-check-for-updates.patch" md5="1f0c9514ff8218d361ea46d3031b2b64"
-                         size="1139" mtime="1404658324" />
-                  <entry name="mysql-workbench.changes" md5="26bc54777e6a261816b72f64c69630e4"
-                         size="13354" mtime="1415747835" />
-                  <entry name="mysql-workbench.spec" md5="88b562a93f01b842a5798f809e3c8188"
-                         size="7489" mtime="1415745943" />
-                  <entry name="openSUSE_(Vendor_Package).xml" md5="ab041af98d7748c216e7e5787ec36f65"
-                         size="743" mtime="1315923090" />
-                  <entry name="patch-desktop-categories.patch" md5="c24b3283573c34a5e072be122388f8e1"
-                         size="391" mtime="1376991147" />
-                </directory>
-            """)
-
         result = {'devel_review_added': None}
 
         def change_request(result, method, uri, headers):
-            u = urlparse(uri)
-            if u.query == 'by_package=mysql-workbench&cmd=addreview&by_project=server%3Adatabase':
+            query = parse_qs(urlparse(uri).query)
+            if query == {'by_package': ['mysql-workbench'], 'cmd': ['addreview'], 'by_project': ['server:database']}:
                 result['devel_review_added'] = True
             return (200, headers, '<status code="ok"/>')
 
         httpretty.register_uri(httpretty.POST,
                                APIURL + "/request/261355",
                                body=lambda method, uri, headers: change_request(result, method, uri, headers))
-
-        httpretty.register_uri(httpretty.GET,
-                               APIURL + "/search/owner?project=openSUSE:13.2:Update&binary=mysql-workbench",
-                               match_querystring=True,
-                               body="""
-                <collection/>
-            """)
-
-        httpretty.register_uri(httpretty.GET,
-                               APIURL + "/search/owner?binary=mysql-workbench",
-                               match_querystring=True,
-                               body="""
-                <collection>
-                  <owner rootproject="openSUSE" project="server:database" package="mysql-workbench">
-                    <person name="Gankov" role="maintainer"/>
-                    <person name="bruno_friedmann" role="maintainer"/>
-                  </owner>
-                </collection>
-            """)
 
         self.checker.requests = []
         self.checker.set_request_ids_search_review()


### PR DESCRIPTION
Similar to #3041

https://build.opensuse.org/requests/1294764

> Submission for etcd by someone who is not maintainer in the devel project (devel:kubic). Please review

It uses `/search/owner` to determine the maintainers, but that does not expand roles recursively. If the submitter is not one of the owners, it adds a prj/pkg review which is recursive.