### PR TITLE
Fix flake8 warning

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -94,8 +94,9 @@ def search_paginated_generator(apiurl, queries=None, **kwargs):
 points = []
 
 
-def point(measurement, fields, datetime, tags={}, delta=False):
-    global points
+def point(measurement, fields, datetime, tags=None, delta=False):
+    if tags is None:
+        tags = {}
     points.append(Point(measurement, tags, fields, timestamp(datetime), delta))
 
 


### PR DESCRIPTION
There are actually two warnings. one about "global points" being unused, as this is only used for reading not for assignment, the global is not necessary. The second is about the mutable argument default