### PR TITLE
TTM: only publish override repos if publish_multiple_product_repo config is enabled

### DIFF
--- a/ttm/publisher.py
+++ b/ttm/publisher.py
@@ -305,7 +305,7 @@ class ToTestPublisher(ToTestManager):
         self.api.switch_flag_in_prj(
             self.project.test_project, flag='publish', state='enable',
             repository=self.project.product_repo)
-        if len(self.project.product_repo_overrides):
+        if self.project.publish_multiple_product_repo and len(self.project.product_repo_overrides):
             for key, value in self.project.product_repo_overrides.items():
                 self.api.switch_flag_in_prj(self.project.test_project, flag='publish',
                                             state='enable', repository=value)

--- a/ttm/totest.py
+++ b/ttm/totest.py
@@ -50,6 +50,8 @@ class ToTest(object):
         self.livecd_products = []
         self.image_products = []
         self.product_repo_overrides = {}
+        # publish the default product_repo, ignore product_repo_overrides
+        self.publish_multiple_product_repo = False
 
         self.test_subproject = 'ToTest'
         self.base = project.split(':')[0]


### PR DESCRIPTION
ftp product might released to the default product_repo in ToTest, add an config bit to be able to enable the default product_repo or the override repos.