### PR TITLE
adjust the various pipeline for the changed Leap 16.0 product build setup

### DIFF
--- a/gocd/pkglistgen.opensuse.gocd.yaml
+++ b/gocd/pkglistgen.opensuse.gocd.yaml
@@ -124,11 +124,11 @@ pipelines:
         approval:
           type: manual
         jobs:
-          openSUSE_Leap_16.0:
+          openSUSE_Leap_16.0_Products:
             resources:
             - repo-checker
             tasks:
-              - script: python3 -u ./pkglistgen.py --apiurl https://api.opensuse.org handle_update_repos openSUSE:Leap:16.0
+              - script: python3 -u ./pkglistgen.py --apiurl https://api.opensuse.org handle_update_repos openSUSE:Leap:16.0:Products
   Update.Weakremovers.Leap_16_0:
     group: Leap
     lock_behavior: unlockWhenFinished
@@ -145,11 +145,11 @@ pipelines:
         approval:
           type: manual
         jobs:
-          openSUSE_Leap_16.0:
+          openSUSE_Leap_16.0_Products:
             resources:
             - repo-checker
             tasks:
-              - script: python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Leap:16.0 -s target --only-update-weakremovers
+              - script: python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Leap:16.0:Products -s target --only-update-weakremovers
   SkippkgFinder.Leap_16_0:
     group: Leap
     lock_behavior: unlockWhenFinished
@@ -187,4 +187,4 @@ pipelines:
         resources:
         - repo-checker
         tasks:
-          - script: ./pkglistgen.py --verbose -A https://api.opensuse.org update_and_solve --project openSUSE:Leap:16.0 --scope target --engine product_composer --force
+          - script: ./pkglistgen.py --verbose -A https://api.opensuse.org update_and_solve --project openSUSE:Leap:16.0:Products --scope target --engine product_composer --force

--- a/gocd/pkglistgen.opensuse.gocd.yaml
+++ b/gocd/pkglistgen.opensuse.gocd.yaml
@@ -166,11 +166,11 @@ pipelines:
         approval:
           type: manual
         jobs:
-          openSUSE_Leap_16.0:
+          openSUSE_Leap_16.0_Products:
             resources:
             - repo-checker
             tasks:
-              - script: python3 ./skippkg-finder.py -A https://api.opensuse.org -o openSUSE:Leap:16.0
+              - script: python3 ./skippkg-finder.py -A https://api.opensuse.org -o openSUSE:Leap:16.0:Products
   OfflineInstaller.PackageLists.Leap_16_0:
     group: Leap
     lock_behavior: unlockWhenFinished

--- a/gocd/pkglistgen.opensuse.gocd.yaml.erb
+++ b/gocd/pkglistgen.opensuse.gocd.yaml.erb
@@ -119,7 +119,7 @@ pipelines:
         approval:
           type: manual
         jobs:
-<% %w(openSUSE:Leap:16.0).each do |project| -%>
+<% %w(openSUSE:Leap:16.0:Products).each do |project| -%>
           <%= project.gsub(':', '_') %>:
             resources:
             - repo-checker

--- a/gocd/pkglistgen.opensuse.gocd.yaml.erb
+++ b/gocd/pkglistgen.opensuse.gocd.yaml.erb
@@ -73,7 +73,7 @@ pipelines:
         approval:
           type: manual
         jobs:
-<% %w(openSUSE:Leap:16.0).each do |project| -%>
+<% %w(openSUSE:Leap:16.0:Products).each do |project| -%>
           <%= project.gsub(':', '_') %>:
             resources:
             - repo-checker
@@ -96,7 +96,7 @@ pipelines:
         approval:
           type: manual
         jobs:
-<% %w(openSUSE:Leap:16.0).each do |project| -%>
+<% %w(openSUSE:Leap:16.0:Products).each do |project| -%>
           <%= project.gsub(':', '_') %>:
             resources:
             - repo-checker
@@ -142,4 +142,4 @@ pipelines:
         resources:
         - repo-checker
         tasks:
-          - script: ./pkglistgen.py --verbose -A https://api.opensuse.org update_and_solve --project openSUSE:Leap:16.0 --scope target --engine product_composer --force
+          - script: ./pkglistgen.py --verbose -A https://api.opensuse.org update_and_solve --project openSUSE:Leap:16.0:Products --scope target --engine product_composer --force

--- a/gocd/totestmanager.gocd.yaml
+++ b/gocd/totestmanager.gocd.yaml
@@ -168,7 +168,7 @@ pipelines:
         - script: |-
             install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
             scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:15.6:ARM:Images
-  TTM.Leap_16.0:
+  TTM.Leap_16.0_Products:
     group: openSUSE.Checkers
     lock_behavior: unlockWhenFinished
     environment_variables:
@@ -188,7 +188,7 @@ pipelines:
         tasks:
         - script: |-
             install -D /home/go/config/openqa-client.conf /home/go/.config/openqa/client.conf
-            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:16.0
+            scripts/totest-manager.py -A https://api.opensuse.org --debug run openSUSE:Leap:16.0:Products
   TTM.Leap_Micro_6.0:
     group: openSUSE.Checkers
     lock_behavior: unlockWhenFinished

--- a/gocd/totestmanager.gocd.yaml.erb
+++ b/gocd/totestmanager.gocd.yaml.erb
@@ -9,7 +9,7 @@ pipelines:
       openSUSE:Factory:zSystems
       openSUSE:Leap:15.6:Images
       openSUSE:Leap:15.6:ARM:Images
-      openSUSE:Leap:16.0
+      openSUSE:Leap:16.0:Products
       openSUSE:Leap:Micro:6.0
       openSUSE:Leap:Micro:6.0:Images
       openSUSE:Leap:Micro:6.1

--- a/skippkg-finder.py
+++ b/skippkg-finder.py
@@ -27,6 +27,8 @@ class SkippkgFinder(object):
     def __init__(self, opensuse_project, print_only):
         self.opensuse_project = opensuse_project
         self.opensuse_nonfree_project = opensuse_project + ":NonFree"
+        if not opensuse_project[-1].isdigit():
+            self.opensuse_nonfree_project = opensuse_project.rsplit(':', 1)[0] + ":NonFree"
         self.print_only = print_only
         self.apiurl = osc.conf.config['apiurl']
         self.debug = osc.conf.config['debug']


### PR DESCRIPTION
product package are now moved to `Products` subproject of `openSUSE:Leap:16.0` project after sources has switched to git.