### PR TITLE
TTM: allow to override test_project attribute from config

### DIFF
--- a/ttm/totest.py
+++ b/ttm/totest.py
@@ -58,7 +58,8 @@ class ToTest(object):
 
         self.jobs_num = 42
         self.load_config(apiurl)
-        self.test_project = f'{project}:{self.test_subproject}'
+        if not hasattr(self, 'test_project'):
+            self.test_project = f'{project}:{self.test_subproject}'
 
     def load_config(self, apiurl):
         config = yaml.safe_load(attribute_value_load(apiurl, self.name, 'ToTestManagerConfig'))


### PR DESCRIPTION
A usecase is like Leap 16.0 has product images built in openSUSE:Leap:16.0:Products project, the buildresult will release to openSUSE:Leap:16.0:ToTest project, we should be able to override test_project attribute via ToTestManagerConfig.