### PR TITLE
Add pkglistgen bot for git workflow project PRs

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -593,6 +593,7 @@ exit 0
 
 %files pkglistgen
 %{_bindir}/osrt-pkglistgen
+%{_bindir}/osrt-git-pkglistgen
 %{_bindir}/osrt-skippkg-finder
 %{_datadir}/%{source_dir}/pkglistgen
 %{_datadir}/%{source_dir}/pkglistgen.py

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -634,6 +634,7 @@ exit 0
 
 %files pkglistgen
 %{_bindir}/osrt-pkglistgen
+%{_bindir}/osrt-git-pkglistgen
 %{_bindir}/osrt-skippkg-finder
 %{_datadir}/%{source_dir}/pkglistgen
 %{_datadir}/%{source_dir}/pkglistgen.py

--- a/git-pkglistgen.py
+++ b/git-pkglistgen.py
@@ -1,0 +1,190 @@
+#!/usr/bin/python3
+import sys
+import ReviewBot
+
+import logging
+
+import traceback
+
+from osc import conf
+from osc.core import makeurl, http_POST
+from osclib.conf import Config
+from osclib.stagingapi import StagingAPI
+from pkglistgen.engine import Engine
+from pkglistgen.tool import PkgListGen, MismatchedRepoException
+
+DEFAULT_AUTOGITS_REVIEWER = "autogits_obs_staging_bot"
+DEFAULT_ENGINE = "product_composer"
+DEFAULT_ENABLE_REPOSITORIES = "product images"
+
+
+class GitPkgListGenBot(ReviewBot.ReviewBot):
+    """A review bot that runs pkglistgen on staging QA projects"""
+
+    def __init__(self, *args, **kwargs):
+        ReviewBot.ReviewBot.__init__(self, *args, **kwargs)
+
+        conf.get_config()
+
+        self.tool = PkgListGen()
+        self.apiurl = conf.config["apiurl"]
+
+        # This is heavily dependent on the GITEA platform
+        if self.platform.name != "GITEA":
+            raise Exception("Unsupported platform: this bot is only supported on Gitea")
+
+    def get_git_staging_configuration(self, owner, project, commit_sha):
+        # FIXME: support JWCC
+        return self.platform.get_path(
+            f"repos/{owner}/{project}/raw/staging.config?ref={commit_sha}"
+        ).json()
+
+    def get_qa_projects(self, request_id, staging_configuration):
+        base_project = staging_configuration["StagingProject"]
+        for project in staging_configuration.get("QA", []):
+            yield f"{base_project}:{request_id}:{project['Name']}"
+
+    @staticmethod
+    def is_request_approved_by(request, approver):
+        for review in request.reviews:
+            if review.by == approver and review.state == "accepted":
+                # We skip dismissed reviews, so we can afford returning
+                # as soon as we find a matching review
+                return True
+
+        return False
+
+    @staticmethod
+    def get_request_from_src_rev(requests, src_rev):
+        for request in requests:
+            if request.actions[0].src_rev == src_rev:
+                return request
+
+        return None
+
+    def set_project_flag(self, project, flag, repository, status):
+        return http_POST(
+            makeurl(
+                self.apiurl,
+                ["source", project],
+                {
+                    "cmd": "set_flag",
+                    "flag": flag,
+                    "repository": repository,
+                    "status": status,
+                },
+            )
+        )
+
+    def check_source_submission(
+        self, src_owner, src_project, src_rev, target_owner, target_package
+    ):
+        self.logger.info(f"Checking {src_project}: {src_owner} -> {target_owner}")
+
+        try:
+            result = self.run_pkglistgen(
+                src_owner, src_project, src_rev, target_owner, target_package
+            )
+        except Exception:
+            self.review_messages["declined"] = (
+                f"Unhandled exception:\n\n```{traceback.format_exc()}```"
+            )
+            return False
+
+        if result:
+            self.review_messages["accepted"] = "pkglistgen ran successfully"
+
+        return result  # True or None
+
+    def run_pkglistgen(
+        self, src_owner, src_project, src_rev, target_owner, target_package
+    ):
+        """
+        Runs pkglistgen.
+
+        :return: either True (pkglistgen ran), or None (should skip/retry later)
+        """
+
+        request = self.get_request_from_src_rev(self.requests, src_rev)
+        if not request:
+            self.logger.warning(f"Request for src_rev {src_rev} not found")
+            return None
+
+        base_commit = request.actions[0].tgt_rev
+        staging_configuration = self.get_git_staging_configuration(
+            target_owner, target_package, base_commit
+        )
+
+        if "QA" not in staging_configuration:
+            self.logger.warning(
+                f"PR {request._owner}/{request._repo}#{request._pr_id} has no QA staging configured"
+            )
+            return None
+
+        main_project = staging_configuration["ObsProject"]
+
+        Config(self.apiurl, main_project)
+        target_config = conf.config[main_project]
+
+        main_repo = target_config["main-repo"]
+        engine = Engine[target_config.get("pkglistgen-engine", DEFAULT_ENGINE)]
+        enable_repositories = target_config.get(
+            "pkglistgen-enable-repositories", DEFAULT_ENABLE_REPOSITORIES
+        ).split(" ")
+
+        approver = target_config.get("pkglistgen-approver", DEFAULT_AUTOGITS_REVIEWER)
+        if not self.is_request_approved_by(request, approver):
+            return None
+
+        for project_name in self.get_qa_projects(request._pr_id, staging_configuration):
+            api = StagingAPI(self.apiurl, project_name)
+
+            meta = api.get_prj_meta(project_name)
+            git_url = meta.xpath("/project/scmsync")[0].text
+
+            self.tool.reset()
+            self.tool.dry_run = self.dryrun
+            try:
+                self.tool.update_and_solve_target(
+                    api,
+                    main_project,
+                    target_config,
+                    main_repo,
+                    git_url=git_url,
+                    project=project_name,
+                    scope="target",
+                    engine=engine,
+                    force=True,
+                    no_checkout=False,
+                    only_release_packages=False,
+                    only_update_weakremovers=False,
+                    stop_after_solve=False,
+                    custom_cache_tag="git-pkglistgen",
+                )
+            except MismatchedRepoException:
+                # Repo still building, just exit now as presumably eventual
+                # other projects are also affected
+                self.logger.warning("Repository is still building, trying next time...")
+                return None
+            else:
+                # Enable builds
+                if not self.dryrun:
+                    for repository in enable_repositories:
+                        self.set_project_flag(
+                            project_name, "build", repository, "enable"
+                        )
+
+        return True
+
+
+class CommandLineInterface(ReviewBot.CommandLineInterface):
+    def __init__(self, *args, **kwargs):
+        ReviewBot.CommandLineInterface.__init__(self, args, kwargs)
+        self.clazz = GitPkgListGenBot
+
+
+if __name__ == "__main__":
+    app = CommandLineInterface()
+    logging.basicConfig(level=logging.DEBUG)
+
+    sys.exit(app.main())

--- a/git-pkglistgen.py
+++ b/git-pkglistgen.py
@@ -108,6 +108,7 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
         self.tool = PkgListGen()
         self.apiurl = conf.config["apiurl"]
 
+        self.allowed_repositories = []
         self.cloned_repositories = GitRepositories()
 
         # This is heavily dependent on the GITEA platform
@@ -195,6 +196,12 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
         request = self.get_request_from_src_rev(self.requests, src_rev)
         if not request:
             self.logger.warning(f"Request for src_rev {src_rev} not found")
+            return None
+
+        if f"{request._owner}/{request._repo}" not in self.allowed_repositories:
+            self.logger.info(
+                f"{request._owner}/{request._repo} is not in the allowed repositories list"
+            )
             return None
 
         base_commit = request.actions[0].tgt_rev
@@ -297,8 +304,29 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
 
 class CommandLineInterface(ReviewBot.CommandLineInterface):
     def __init__(self, *args, **kwargs):
-        ReviewBot.CommandLineInterface.__init__(self, args, kwargs)
+        super().__init__(*args, *kwargs)
         self.clazz = GitPkgListGenBot
+
+    def get_optparser(self):
+        parser = super().get_optparser()
+
+        # Add bot-specific options
+        # If ReviewBot/Cmdln moves to ArgumentParser, we can turn this into a
+        # string directly and use nargs=*.
+        parser.add_option(
+            "--git-allow-repos",
+            default="",
+            help="allowed git repositories (e.g. products/SLFO,products/SLES)",
+        )
+
+        return parser
+
+    def setup_checker(self):
+        instance = super().setup_checker()
+
+        instance.allowed_repositories = self.options.git_allow_repos.split(",")
+
+        return instance
 
 
 if __name__ == "__main__":

--- a/git-pkglistgen.py
+++ b/git-pkglistgen.py
@@ -14,6 +14,7 @@ import subprocess
 import tempfile
 
 from urllib.parse import urljoin, urldefrag
+import urllib.error
 
 from lxml import etree
 
@@ -24,13 +25,18 @@ from osclib.stagingapi import StagingAPI
 from pkglistgen.engine import Engine
 from pkglistgen.tool import PkgListGen, MismatchedRepoException
 
+from collections import namedtuple
+
 DEFAULT_AUTOGITS_REVIEWER = "autogits_obs_staging_bot"
 DEFAULT_ENGINE = "product_composer"
 DEFAULT_ENABLE_REPOSITORIES = "product images"
 
 STAGING_PROGRESS_MARKER = "staging/In Progress"
+STAGING_TYPE_MARKERS = "QA-SLES-Basic QA-SLES-Reduced QA-SLES-Full"
 
 slugify_regex = re.compile("[^a-z0-9_]+")
+
+StagingProject = namedtuple("StagingProject", ["target", "name", "origin", "label"])
 
 
 def slugify(x):
@@ -109,6 +115,9 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
         self.apiurl = conf.config["apiurl"]
 
         self.allowed_repositories = []
+
+        self.staging_origin_cache = {}
+
         self.cloned_repositories = GitRepositories()
 
         # This is heavily dependent on the GITEA platform
@@ -124,7 +133,12 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
     def get_qa_projects(self, request_id, staging_configuration):
         base_project = staging_configuration["StagingProject"]
         for project in staging_configuration.get("QA", []):
-            yield f"{base_project}:{request_id}:{project['Name']}"
+            yield StagingProject(
+                target=f"{base_project}:{request_id}:{project['Name']}",
+                origin=project["Origin"],
+                name=project["Name"],
+                label=project.get("Label"),
+            )
 
     @staticmethod
     def is_request_approved_by(request, approver):
@@ -238,17 +252,52 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
         enable_repositories = target_config.get(
             "pkglistgen-enable-repositories", DEFAULT_ENABLE_REPOSITORIES
         ).split(" ")
+        staging_type_markers = target_config.get(
+            "staging-type-markers", STAGING_TYPE_MARKERS
+        ).split(" ")
 
         approver = target_config.get("pkglistgen-approver", DEFAULT_AUTOGITS_REVIEWER)
         if not self.is_request_approved_by(request, approver):
-            return None
+            return None, None
 
-        for project_name in self.get_qa_projects(request._pr_id, staging_configuration):
-            target_repository_name = project_name.split(":")[-1]
-            api = StagingAPI(self.apiurl, project_name)
+        if True not in [x in staging_type_markers for x in request._labels]:
+            self.logger.info(
+                f"PR {request._owner}/{request._repo}#{request._pr_id} has no valid staging markers set"
+            )
+            return True, "Not asked to create stagings. Accepting."
 
-            meta = api.get_prj_meta(project_name)
-            staging_repo_url = urljoin(staging_org_url, target_repository_name)
+        staging_project_available = False
+        for qa_project in self.get_qa_projects(request._pr_id, staging_configuration):
+            api = StagingAPI(self.apiurl, qa_project.target)
+
+            try:
+                meta = api.get_prj_meta(qa_project.target)
+            except urllib.error.HTTPError as e:
+                if e.code == 404:
+                    # Let's go ahead, as the QA project might have been masked by the used Label,
+                    # and we will check that further on
+                    continue
+                else:
+                    raise
+            else:
+                staging_project_available = True
+
+            # Obtain the target repository name by looking at the repository name
+            # in the Origin's scmsync. We cannot use qa_project["Name"] in this case
+            # as after labels have been introduced, the same origin might have multiple
+            # QA projects
+            if qa_project.origin not in self.staging_origin_cache:
+                origin_meta = api.get_prj_meta(qa_project.origin)
+                origin_git_url_element = origin_meta.xpath("/project/scmsync")[0]
+
+                url, fragment = urldefrag(origin_git_url_element.text)
+                self.staging_origin_cache[qa_project.origin] = url.split("/")[
+                    -1
+                ].replace(".git", "")
+
+            staging_repo_url = urljoin(
+                staging_org_url, self.staging_origin_cache[qa_project.origin]
+            )
             target_git_url = urljoin(staging_repo_url, f"#{staging_branch}")
             git_url_element = meta.xpath("/project/scmsync")[0]
 
@@ -269,7 +318,7 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
 
                 git_url_element.text = target_git_url
 
-                self.replace_meta(project_name, meta)
+                self.replace_meta(qa_project.target, meta)
 
                 # We will get back to it later
                 return None, None
@@ -283,7 +332,7 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
                     target_config,
                     main_repo,
                     git_url=git_url_element.text,
-                    project=project_name,
+                    project=qa_project.target,
                     scope="target",
                     engine=engine,
                     force=True,
@@ -303,10 +352,19 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
                 if not self.dryrun:
                     for repository in enable_repositories:
                         self.set_project_flag(
-                            project_name, "build", repository, "enable"
+                            qa_project.target, "build", repository, "enable"
                         )
 
-        return True, "pkglistgen ran successfully"
+        if staging_project_available:
+            return True, "pkglistgen ran successfully"
+        else:
+            self.logger.info(
+                "Staging bot didn't create the QA project, but accepted the review. Nothing to do."
+            )
+            return (
+                True,
+                "Staging bot didn't create the QA project, but accepted the review. Nothing to do.",
+            )
 
 
 class CommandLineInterface(ReviewBot.CommandLineInterface):

--- a/git-pkglistgen.py
+++ b/git-pkglistgen.py
@@ -204,6 +204,12 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
             )
             return None
 
+        if STAGING_PROGRESS_MARKER not in request._labels:
+            self.logger.info(
+                f"PR {request._owner}/{request._repo}#{request._pr_id} is not in progress"
+            )
+            return None
+
         base_commit = request.actions[0].tgt_rev
         staging_configuration = self.get_git_staging_configuration(
             target_owner, target_package, base_commit

--- a/git-pkglistgen.py
+++ b/git-pkglistgen.py
@@ -170,7 +170,7 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
         self.logger.info(f"Checking {src_project}: {src_owner} -> {target_owner}")
 
         try:
-            result = self.run_pkglistgen(
+            result, message = self.run_pkglistgen(
                 src_owner, src_project, src_rev, target_owner, target_package
             )
         except Exception:
@@ -180,7 +180,7 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
             return False
 
         if result:
-            self.review_messages["accepted"] = "pkglistgen ran successfully"
+            self.review_messages["accepted"] = message or "OK"
 
         return result  # True or None
 
@@ -190,25 +190,26 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
         """
         Runs pkglistgen.
 
-        :return: either True (pkglistgen ran), or None (should skip/retry later)
+        :return: result: True (pkglistgen ran), or None (should skip/retry later).
+                 message: a message that should be shown into the comment, or None.
         """
 
         request = self.get_request_from_src_rev(self.requests, src_rev)
         if not request:
             self.logger.warning(f"Request for src_rev {src_rev} not found")
-            return None
+            return None, None
 
         if f"{request._owner}/{request._repo}" not in self.allowed_repositories:
             self.logger.info(
                 f"{request._owner}/{request._repo} is not in the allowed repositories list"
             )
-            return None
+            return None, None
 
         if STAGING_PROGRESS_MARKER not in request._labels:
             self.logger.info(
                 f"PR {request._owner}/{request._repo}#{request._pr_id} is not in progress"
             )
-            return None
+            return None, None
 
         base_commit = request.actions[0].tgt_rev
         staging_configuration = self.get_git_staging_configuration(
@@ -219,7 +220,7 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
             self.logger.warning(
                 f"PR {request._owner}/{request._repo}#{request._pr_id} has no QA staging configured"
             )
-            return None
+            return None, None
 
         main_project = staging_configuration["ObsProject"]
 
@@ -271,7 +272,7 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
                 self.replace_meta(project_name, meta)
 
                 # We will get back to it later
-                return None
+                return None, None
 
             self.tool.reset()
             self.tool.dry_run = self.dryrun
@@ -296,7 +297,7 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
                 # Repo still building, just exit now as presumably eventual
                 # other projects are also affected
                 self.logger.warning("Repository is still building, trying next time...")
-                return None
+                return None, None
             else:
                 # Enable builds
                 if not self.dryrun:
@@ -305,7 +306,7 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
                             project_name, "build", repository, "enable"
                         )
 
-        return True
+        return True, "pkglistgen ran successfully"
 
 
 class CommandLineInterface(ReviewBot.CommandLineInterface):

--- a/git-pkglistgen.py
+++ b/git-pkglistgen.py
@@ -601,6 +601,6 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
 
 if __name__ == "__main__":
     app = CommandLineInterface()
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.INFO)
 
     sys.exit(app.main())

--- a/git-pkglistgen.py
+++ b/git-pkglistgen.py
@@ -36,28 +36,114 @@ STAGING_TYPE_MARKERS = "QA-SLES-Basic QA-SLES-Reduced QA-SLES-Full"
 
 slugify_regex = re.compile("[^a-z0-9_]+")
 
-StagingProject = namedtuple("StagingProject", ["target", "name", "origin", "label"])
+StagingProject = namedtuple(
+    "StagingProject", ["target", "name", "origin", "label"]
+)
 
 
 def slugify(x):
     return slugify_regex.sub("-", x.lower())
 
 
-class GitRepository(object):
 
-    def __init__(self, origin_remote):
 
-        self.origin_remote = origin_remote
+class GitObject(object):
 
+    def __init__(self):
         # This gets cleaned up on exit
         self.temporary_directory = tempfile.TemporaryDirectory(suffix="pkglistgen")
 
         self.git_checkout = os.path.join(self.temporary_directory.name, "git")
 
+    def __get_ref(self, pointer):
+        if (
+            subprocess.run(
+                ["git", "rev-parse", "--verify", f"refs/heads/{pointer}"],
+                cwd=self.git_checkout,
+            ).returncode
+            > 0
+        ):
+            # commit/tag
+            return pointer
+        else:
+            # branch
+            return f"refs/heads/{pointer}"
+
+    def add(self, content: list):
+        subprocess.check_call(
+            ["git", "add"] + content,
+            cwd=self.git_checkout,
+        )
+
+    def commit(self, message):
+        subprocess.check_call(
+            [
+                "git",
+                "commit",
+                "-m",
+                message,
+            ],
+            cwd=self.git_checkout,
+        )
+
+    def push_to_branch(self, source_pointer, target_remote, target_branch, force=False):
+        subprocess.check_call(
+            [
+                "git",
+                "push",
+                "--force" if force else "--no-force",
+                target_remote,
+                f"{self.__get_ref(source_pointer)}:refs/heads/{target_branch}",
+            ],
+            cwd=self.git_checkout,
+        )
+
+    def push(self):
+        subprocess.check_call(
+            ["git", "push"],
+            cwd=self.git_checkout,
+        )
+
+    def reset_to_ref(self, ref):
+        subprocess.check_call(
+            ["git", "reset", "--hard", ref],
+            cwd=self.git_checkout,
+        )
+
+
+class GitWorktree(GitObject):
+
+    @classmethod
+    def from_repository(cls, repository, branch_name):
+        obj = cls()
+        subprocess.check_call(
+            ["git", "worktree", "add", obj.git_checkout, branch_name],
+            cwd=repository.git_checkout,
+        )
+
+        return obj
+
+
+class GitRepository(GitObject):
+
+    def __init__(self, origin_remote, mirror=False):
+
+        super().__init__()
+
+        self.origin_remote = origin_remote
+
+        self.mirror = mirror
+
     def fetch(self):
         if not os.path.exists(self.git_checkout):
             subprocess.check_call(
-                ["git", "clone", "--mirror", self.origin_remote, self.git_checkout]
+                [
+                    "git",
+                    "clone",
+                    "--mirror" if self.mirror else "--no-mirror",
+                    self.origin_remote,
+                    self.git_checkout,
+                ]
             )
 
         # Fetch
@@ -65,30 +151,13 @@ class GitRepository(object):
             ["git", "fetch", self.origin_remote], cwd=self.git_checkout
         )
 
-    def push_to_branch(self, source_pointer, target_remote, target_branch):
-
-        if (
-            subprocess.run(
-                ["git", "rev-parse", "--verify", f"refs/heads/{source_pointer}"],
-                cwd=self.git_checkout,
-            ).returncode
-            > 0
-        ):
-            # commit/tag
-            source_ref = source_pointer
-        else:
-            # branch
-            source_ref = f"refs/heads/{source_pointer}"
-
-        subprocess.check_call(
-            [
-                "git",
-                "push",
-                target_remote,
-                f"{source_ref}:refs/heads/{target_branch}",
-            ],
-            cwd=self.git_checkout,
-        )
+    @contextmanager
+    def transient_worktree(self, branch_name):
+        worktree = GitWorktree.from_repository(self, branch_name)
+        try:
+            yield worktree
+        finally:
+            pass
 
 
 class GitRepositories(object):
@@ -96,11 +165,20 @@ class GitRepositories(object):
     def __init__(self):
         self.mapping = {}
 
+    def register_repository(self, remote):
+        return GitRepository(remote)
+
     def __getitem__(self, origin_remote):
         if origin_remote not in self.mapping:
-            self.mapping[origin_remote] = GitRepository(origin_remote)
+            self.mapping[origin_remote] = self.register_repository(origin_remote)
 
         return self.mapping[origin_remote]
+
+
+class GitMirrors(GitRepositories):
+
+    def register_repository(self, remote):
+        return GitRepository(remote, mirror=True)
 
 
 class GitPkgListGenBot(ReviewBot.ReviewBot):

--- a/git-pkglistgen.py
+++ b/git-pkglistgen.py
@@ -13,6 +13,8 @@ import subprocess
 
 import tempfile
 
+from argparse import Namespace
+
 from urllib.parse import urljoin, urldefrag
 import urllib.error
 
@@ -27,8 +29,18 @@ from pkglistgen.tool import PkgListGen, MismatchedRepoException
 
 from collections import namedtuple
 
+from contextlib import contextmanager
+
+try:
+    from package_monkey.subcommands import PackageMonkey, subcommandRegistry
+
+    is_package_monkey_available = True
+except:
+    print("Package Monkey not found")
+    is_package_monkey_available = False
+
 DEFAULT_AUTOGITS_REVIEWER = "autogits_obs_staging_bot"
-DEFAULT_ENGINE = "product_composer"
+DEFAULT_ENGINE = "package_monkey"  # "product_composer"
 DEFAULT_ENABLE_REPOSITORIES = "product images"
 
 STAGING_PROGRESS_MARKER = "staging/In Progress"
@@ -45,6 +57,76 @@ def slugify(x):
     return slugify_regex.sub("-", x.lower())
 
 
+class MonkeyContext(PackageMonkey if is_package_monkey_available else object):
+    """
+    A Context Manager to execute Package Monkey commands.
+
+    The following assumptions are made:
+    - Only a single thread can access the context
+    - The cache directory is shared with every context, and also
+      between bot runs
+    - The state directory is per-context and gets cleaned-up on
+      context exit
+    """
+
+    DEFAULTS = {
+        "codebase": "slfo",
+        "verbose": True,
+        "quiet": False,
+    }
+
+    def __init__(self, user_name, **context_opts):
+
+        if not is_package_monkey_available:
+            raise Exception(
+                "Created a MonkeyContext without package-monkey being available"
+            )
+
+        super().__init__(user_name)
+
+        # Use a different cache directory to differentiate with the standalone
+        # tool.
+        # This cache directory is *shared* between all the contextes
+        # TODO: add user_name in the mix
+        self.cache_directory = os.path.expanduser(
+            "~/.cache/git-pkglistgen-package_monkey"
+        )
+
+        # Generate a per-context state directory.
+        # Gets cleaned up on exit
+        self.temporary_directory = tempfile.TemporaryDirectory(suffix="package_monkey")
+
+        self.context_opts = {**self.DEFAULTS, **context_opts}
+        self.context_opts["statedir"] = self.temporary_directory.name
+        self.context_opts["cache"] = self.cache_directory
+
+    def __run_command(self, cmd, *extra_args, **extra_kwargs):
+
+        # self.initializeLogging(cmd)
+
+        args = self.args.parse_args(args=[cmd.NAME, *extra_args])
+        vars(args).update({**self.context_opts, **extra_kwargs})
+        application = cmd.createApplication(args)
+
+        try:
+            return application.run()
+        except SystemExit as e:
+            if e.code > 0:
+                raise Exception(f"package-monkey {cmd} call failed with exit code {e.code}")
+
+    def __getattr__(self, attr):
+        cmd = self.findSubcommand(attr, subcommandRegistry.commands)
+        if cmd:
+            return lambda *args, **kwargs: self.__run_command(cmd, *args, **kwargs)
+
+        return super().__getattr__(attr)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        # Clean the tempdir
+        del self.temporary_directory
 
 
 class GitObject(object):
@@ -197,6 +279,7 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
         self.staging_origin_cache = {}
 
         self.cloned_repositories = GitRepositories()
+        self.mirrored_repositories = GitMirrors()
 
         # This is heavily dependent on the GITEA platform
         if self.platform.name != "GITEA":
@@ -327,7 +410,11 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
         staging_branch = slugify(
             f"qa_{request._owner}_{request._repo}_pr{request._pr_id}"
         )
-        engine = Engine[target_config.get("pkglistgen-engine", DEFAULT_ENGINE)]
+
+        configured_engine = target_config.get("pkglistgen-engine", DEFAULT_ENGINE)
+        if configured_engine != "package_monkey":
+            pkglistgen_engine = Engine[configured_engine]
+
         enable_repositories = target_config.get(
             "pkglistgen-enable-repositories", DEFAULT_ENABLE_REPOSITORIES
         ).split(" ")
@@ -390,9 +477,9 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
                 # Should do the initial push
                 url, fragment = urldefrag(git_url_element.text)
                 self.logger.info(f"Creating branch {staging_branch}")
-                self.cloned_repositories[url].fetch()
-                self.cloned_repositories[url].push_to_branch(
-                    fragment, staging_repo_url, staging_branch
+                self.mirrored_repositories[url].fetch()
+                self.mirrored_repositories[url].push_to_branch(
+                    fragment, staging_repo_url, staging_branch, force=True
                 )
 
                 git_url_element.text = target_git_url
@@ -402,25 +489,64 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
                 # We will get back to it later
                 return None, None
 
-            self.tool.reset()
-            self.tool.dry_run = self.dryrun
             try:
-                self.tool.update_and_solve_target(
-                    api,
-                    main_project,
-                    target_config,
-                    main_repo,
-                    git_url=git_url_element.text,
-                    project=qa_project.target,
-                    scope="target",
-                    engine=engine,
-                    force=True,
-                    no_checkout=False,
-                    only_release_packages=False,
-                    only_update_weakremovers=False,
-                    stop_after_solve=False,
-                    custom_cache_tag="git-pkglistgen",
-                )
+                if configured_engine == "package_monkey":
+                    # Download model
+                    model_url = "https://src.suse.de/sle-prjmgr/SLFO.git"
+                    self.cloned_repositories[model_url].fetch()
+                    self.cloned_repositories[model_url].reset_to_ref(
+                        "remotes/origin/main"
+                    )
+
+                    with MonkeyContext(
+                        "user_name",
+                        codebase="slfo",
+                        extra_build_project=[
+                            qa_project.codebase_project,
+                            qa_project.target,
+                        ],
+                        model_path=self.cloned_repositories[model_url].git_checkout,
+                    ) as monkey:
+                        monkey.download()
+                        monkey.prepare(ignore_errors=True)
+                        monkey.classify()
+
+                        staging_repo = self.mirrored_repositories[staging_repo_url]
+                        staging_repo.fetch()
+                        with staging_repo.transient_worktree(
+                            staging_branch
+                        ) as worktree:
+                            monkey.compose(build_path=worktree.git_checkout)
+                            monkey.publish(
+                                os.path.join(
+                                    worktree.git_checkout, "000productcompose"
+                                ),
+                                scope="compose",
+                            )
+
+                            # package-monkey only outputs productcompose files
+                            worktree.add(["000productcompose/default.productcompose"])
+                            worktree.commit("Package list update by package-monkey")
+                            worktree.push()
+                else:
+                    self.tool.reset()
+                    self.tool.dry_run = self.dryrun
+                    self.tool.update_and_solve_target(
+                        api,
+                        main_project,
+                        target_config,
+                        main_repo,
+                        git_url=git_url_element.text,
+                        project=qa_project.target,
+                        scope="target",
+                        engine=pkglistgen_engine,
+                        force=True,
+                        no_checkout=False,
+                        only_release_packages=False,
+                        only_update_weakremovers=False,
+                        stop_after_solve=False,
+                        custom_cache_tag="git-pkglistgen",
+                    )
             except MismatchedRepoException:
                 # Repo still building, just exit now as presumably eventual
                 # other projects are also affected

--- a/git-pkglistgen.py
+++ b/git-pkglistgen.py
@@ -37,7 +37,7 @@ STAGING_TYPE_MARKERS = "QA-SLES-Basic QA-SLES-Reduced QA-SLES-Full"
 slugify_regex = re.compile("[^a-z0-9_]+")
 
 StagingProject = namedtuple(
-    "StagingProject", ["target", "name", "origin", "label"]
+    "StagingProject", ["target", "codebase_project", "name", "origin", "label"]
 )
 
 
@@ -213,6 +213,7 @@ class GitPkgListGenBot(ReviewBot.ReviewBot):
         for project in staging_configuration.get("QA", []):
             yield StagingProject(
                 target=f"{base_project}:{request_id}:{project['Name']}",
+                codebase_project=f"{base_project}:{request_id}",
                 origin=project["Origin"],
                 name=project["Name"],
                 label=project.get("Label"),

--- a/pkglistgen/tool.py
+++ b/pkglistgen/tool.py
@@ -927,11 +927,18 @@ class PkgListGen(ToolBase.ToolBase):
                 ['git', 'add', self.output_dir],
                 cwd=cache_dir, encoding='utf-8'))
 
-            logging.debug(subprocess.check_output(
-                ['git', 'commit', '-m', 'Update by pkglistgen of openSUSE-release-tool'], cwd=cache_dir, encoding='utf-8'))
-            if not self.dry_run:
+            # Check if any changes are staged (i.e. they have been caught
+            # up by the git call above)
+            # Returncode 1 means that there is something staged, so that
+            # we can actually commit
+            if subprocess.run(['git', 'diff', '--cached', '--stat', '--quiet'], cwd=cache_dir).returncode == 1:
                 logging.debug(subprocess.check_output(
-                    ['git', 'push'], cwd=cache_dir))
+                    ['git', 'commit', '-m', 'Update by pkglistgen of openSUSE-release-tool'], cwd=cache_dir, encoding='utf-8'))
+                if not self.dry_run:
+                    logging.debug(subprocess.check_output(
+                        ['git', 'push'], cwd=cache_dir))
+            else:
+                logging.debug("No changes to commit.")
         elif not self.dry_run:
             self.commit_package(self.output_dir)
 

--- a/plat/gitea.py
+++ b/plat/gitea.py
@@ -168,6 +168,25 @@ class RequestAction:
         self._set_attr_from_json('tgt_rev', json, 'base.sha')
 
 
+class Review:
+    attributes = ["by", "state", "type", "when"]
+
+    states_mapping = {
+        "APPROVED": "accepted",
+        "REQUEST_CHANGES": "declined",
+        "REQUEST_REVIEW": "new",
+    }
+
+    def __init__(self, **kwargs):
+        self._review_data = kwargs
+
+    def __getattr__(self, attribute):
+        if attribute == "state":
+            return self.states_mapping[self._review_data.get("state", "REQUEST_REVIEW")]
+
+        return self._review_data.get(attribute, None)
+
+
 class Request:
     """Request structure implemented for Gitea"""
     def __init__(self):
@@ -181,6 +200,25 @@ class Request:
     @staticmethod
     def construct_request_id(owner, repo, pr_id):
         return f'{owner}:{repo}:{pr_id}'
+
+    @staticmethod
+    def format_review(review):
+        if review.get("user") is not None:
+            return Review(
+                by=review["user"]["login"],
+                state=review["state"],
+                type="User",
+                when=review["updated_at"]
+            )
+        elif review.get("team") is not None:
+            return Review(
+                by=review["team"]["name"],
+                state=review["state"],
+                type="Group",
+                when=review["updated_at"]
+            )
+        else:
+            raise Exception("Unknown review type")
 
     def _init_attributes(self):
         self.reqid = None
@@ -201,27 +239,30 @@ class Request:
         self._repo = None
         self._pr_id = None
 
-    def read(self, json, owner, repo):
+    def read(self, request_json, reviews_json, owner, repo):
         """Read in a request from JSON response"""
         self._init_attributes()
 
         self._owner = owner
         self._repo = repo
-        self._pr_id = json["number"]
+        self._pr_id = request_json["number"]
 
-        self.reqid = Request.construct_request_id(owner, repo, json["number"])
-        self.creator = json["user"]["login"]
-        self.created_at = json["created_at"]
-        self.updated_at = json["updated_at"]
-        self.title = json["title"]
-        self.description = json["body"]
-        self.state = json["state"]
+        self.reqid = Request.construct_request_id(owner, repo, request_json["number"])
+        self.creator = request_json["user"]["login"]
+        self.created_at = request_json["created_at"]
+        self.updated_at = request_json["updated_at"]
+        self.title = request_json["title"]
+        self.description = request_json["body"]
+        self.state = request_json["state"]
 
-        self.actions = [RequestAction(type="submit", json=json)]
+        self.actions = [RequestAction(type="submit", json=request_json)]
 
-        if json.get("merged"):
-            self.accept_at = json["merged_at"]
+        if request_json.get("merged"):
+            self.accept_at = request_json["merged_at"]
 
+        for review in reviews_json:
+            if not review.get("dismissed", False):
+                self.reviews.append(Request.format_review(review))
 
 class ProjectConfig:
     """Project Config implemented for Gitea"""
@@ -250,8 +291,10 @@ class Gitea(plat.base.PlatformBase):
     def _get_request(self, pr_id, owner, repo):
         res = self.api.get(f'repos/{owner}/{repo}/pulls/{pr_id}').json()
 
+        reviews = self.api.get(f'repos/{owner}/{repo}/pulls/{pr_id}/reviews').json()
+
         ret = Request()
-        ret.read(res, owner=owner, repo=repo)
+        ret.read(res, reviews, owner=owner, repo=repo)
         return ret
 
     def get_request(self, request_id, with_full_history=False):

--- a/plat/gitea.py
+++ b/plat/gitea.py
@@ -235,6 +235,7 @@ class Request:
         self._issues = None
 
         # Gitea specific attributes
+        self._labels = set()
         self._owner = None
         self._repo = None
         self._pr_id = None
@@ -263,6 +264,9 @@ class Request:
         for review in reviews_json:
             if not review.get("dismissed", False):
                 self.reviews.append(Request.format_review(review))
+
+        self._labels = {x["name"] for x in request_json["labels"]}
+
 
 class ProjectConfig:
     """Project Config implemented for Gitea"""


### PR DESCRIPTION
A more meaningful diff is available here: https://github.com/YoukouTenhouin/openSUSE-release-tools/compare/379976afddf4311b5156253e3c815970b7508111...g7:openSUSE-release-tools:pkglistgen-bot

This review bot runs pkglistgen on codestream QA projects.

pkglistgen only runs on successful builds, otherwise the request
is skipped and retried later.

Contributes to https://github.com/openSUSE/openSUSE-git/issues/207