### PR TITLE
Add metadata for Leap 16.0 maintenance

### DIFF
--- a/data/metadata/Leap1600.yml
+++ b/data/metadata/Leap1600.yml
@@ -1,0 +1,15 @@
+product: Leap
+product_repo:
+  - SLES
+settings:
+  DISTRI: leap
+  VERSION: '16.0'
+incidents:
+  FLAVOR:
+    staged-Updates:
+      aggregate_job: false
+      archs:
+        - x86_64
+        - aarch64
+      issues:
+        OS_TEST_ISSUES: openSUSE/Leap


### PR DESCRIPTION
This is a place to add the Leap16.0 metadata so [qem-bot](https://github.com/openSUSE/qem-bot/) can be used for the handling of maintenance updates

What is not clear yet is what should be done with the different repos [from here](https://github.com/openSUSE/openSUSE-release-tools/blob/08a2a8313d34d8c639396b29ed5731d3a1572f23/git-openqa-maintenance.py#L25) `openSUSE/Leap`, `openSUSE/LeapNonFree` and `products/PackageHub`
