### PR TITLE
container_cleaner.py: keep the last 30 snapshots

### DIFF
--- a/container_cleaner.py
+++ b/container_cleaner.py
@@ -86,7 +86,7 @@ class ContainerCleaner(ToolBase.ToolBase):
             for srccontainer in buckets[package]:
                 contributes = False
                 for arch in srccontainerarchs[srccontainer]:
-                    if archs_found[arch] < 5:
+                    if archs_found[arch] < 30:
                         archs_found[arch] += 1
                         contributes = True
 


### PR DESCRIPTION
Due to the rapid release of Tumbleweed, keeping the last 5 snapshots per architecture means we only have a week old image for x86_64 at most...

Keeping 30 snapshots should not be a big hit on storage, according to @dirkmueller 

Discussion see [this thread](https://lists.opensuse.org/archives/list/buildservice@lists.opensuse.org/thread/WDDABPDTXTUZRDWNIDIUO4GLLXHJZS7D/)