### PR TITLE
fix: skip changes updated check on gitea empty PRs

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -473,7 +473,22 @@ class CheckSource(ReviewBot.ReviewBot):
                 if subprocess.run(["cmp", "-s", os.path.join(old, changes), os.path.join(directory, changes)]).returncode:
                     changes_updated = True
 
-        if not changes_updated:
+        new_package = False
+        if self.platform_type == "GITEA":
+            # XXX temporary measure for detecting a new package PR on Gitea
+            # This might change once the workflow PR bot takes over
+            # If not, we shall abstruct this inside Gitea platform implementation
+            json = self.platform.get_path("repos",
+                                          self.request._owner,
+                                          self.request._repo,
+                                          "pulls",
+                                          str(self.request._pr_id)).json()
+            labels = set((x["name"] for x in json["labels"]))
+            if "new_package" in labels:
+                new_package = True
+                self.logger.info("Empty PR; skippng changes_updated check")
+
+        if not changes_updated and not new_package:
             self.review_messages['declined'] = "No changelog. Please use 'osc vc' to update the changes file(s)."
             return False
 

--- a/check_source.py
+++ b/check_source.py
@@ -484,7 +484,14 @@ class CheckSource(ReviewBot.ReviewBot):
                 if subprocess.run(["cmp", "-s", os.path.join(old, changes), os.path.join(directory, changes)]).returncode:
                     changes_updated = True
 
-        if not changes_updated:
+        new_package = False
+        if self.platform_type == "GITEA":
+            # On Gitea new package submission is an empty PR with no commits
+            if self.request.actions[0].src_rev == self.request.actions[0].tgt_rev:
+                new_package = True
+                self.logger.info("Empty PR; skipping changes_updated check")
+
+        if not changes_updated and not new_package:
             self.review_messages['declined'] = "No changelog. Please use 'osc vc' to update the changes file(s)."
             return False
 


### PR DESCRIPTION
On Gitea the process of adding a new package is created by submitting an empty PR for that. This wasn't allowed by factory-auto before. Skip that check for Gitea to allow new package submission.