### PR TITLE
ReviewBot: consume the generator when using search_review(), and ensure the behaviour between platform is consistent

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -691,7 +691,7 @@ class ReviewBot(object):
         return self.platform.can_accept_review(req, review_user=self.review_user, review_group=self.review_group)
 
     def set_request_ids_search_review(self):
-        self.requests = self.platform.search_review(review_user=self.review_user, review_group=self.review_group)
+        self.requests = list(self.platform.search_review(review_user=self.review_user, review_group=self.review_group))
 
     # also used by openqabot
     def ids_project(self, project, typename):

--- a/docs/bot-framework/bot_framework.md
+++ b/docs/bot-framework/bot_framework.md
@@ -109,7 +109,7 @@ The Platform layer provides an abstraction for interacting with different collab
         Common kwargs:
             review_user: Filter by reviewer username
             review_group: Filter by reviewer group
-        Returns: List/generator of Request objects
+        Returns: Generator of Request objects
 
     can_accept_review(req, **kwargs) - Check whether it's possible to accept review for a request
         Parameters:

--- a/plat/obs.py
+++ b/plat/obs.py
@@ -71,14 +71,10 @@ class OBS(plat.base.PlatformBase):
                                'match': f"state/@name='review' and review[{review}]", 'withfullhistory': 1})
         root = ET.parse(osc.core.http_GET(url)).getroot()
 
-        ret = []
-
         for request in root.findall('request'):
             req = osc.core.Request()
             req.read(request)
-            ret.append(req)
-
-        return ret
+            yield req
 
     def _has_open_review_by(self, root, by_what, reviewer):
         states = set([review.get('state') for review in root.findall('review') if review.get(by_what) == reviewer])


### PR DESCRIPTION
~Users of search_review() expect a list, not a generator.~