### PR TITLE
fix: pass in branch name in checkout_package

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -628,9 +628,23 @@ class ReviewBot(object):
         return self.request_default_return
 
     def check_source_submission(self, src_project: str, src_package: str, src_rev: str, target_project: str, target_package: str) -> None:
+        target_rev = None
+        if hasattr(self, 'action') and hasattr(self.action, 'tgt_rev'):
+            target_rev = self.action.tgt_rev
+        return self.check_source_submission_v2(src_project, src_package, src_rev, target_project, target_package, target_rev)
+
+    def check_source_submission_v2(
+            self,
+            src_project: str,
+            src_package: str,
+            src_rev: str,
+            target_project: str,
+            target_package: str,
+            target_rev: Optional[str]
+    ) -> None:
         """ default implemention does nothing """
-        self.logger.info(f"{src_project}/{src_package}@{src_rev} -> {target_project}/{target_package}")
-        return None
+        target_rev_str = f"@{target_rev}" if target_rev else ""
+        self.logger.info(f"{src_project}/{src_package}@{src_rev} -> {target_project}/{target_package}{target_rev_str}")
 
     @staticmethod
     @memoize(session=True)

--- a/check_source.py
+++ b/check_source.py
@@ -135,16 +135,17 @@ class CheckSource(ReviewBot.ReviewBot):
 
         return ret
 
-    def check_source_submission(
+    def check_source_submission_v2(
             self,
             source_project: str,
             source_package: str,
             source_revision: str,
             target_project: str,
-            target_package: str
+            target_package: str,
+            target_rev: Optional[str]
     ) -> bool:
-        super(CheckSource, self).check_source_submission(source_project,
-                                                         source_package, source_revision, target_project, target_package)
+        super(CheckSource, self).check_source_submission_v2(source_project,
+                                                            source_package, source_revision, target_project, target_package, target_rev)
         self.target_project_config(target_project)
 
         if self.single_action_require and len(self.request.actions) != 1:
@@ -273,8 +274,8 @@ class CheckSource(ReviewBot.ReviewBot):
         os.chdir(copath)
 
         try:
-            CheckSource.checkout_package(self.scm, target_project, target_package, pathname=copath,
-                                         server_service_files=True, expand_link=True)
+            CheckSource.checkout_package(self.scm, target_project, target_package, revision=target_rev,
+                                         pathname=copath, server_service_files=True, expand_link=True)
             os.rename(target_package, '_old')
         except HTTPError as e:
             if e.code == 404:


### PR DESCRIPTION
on Gitea the submission target might contain different branches as well. Update checkout_package to also pass in target revision.