### PR TITLE
freeze: Do not resign binaries when aggregating from Ring1

### DIFF
--- a/osclib/freeze_command.py
+++ b/osclib/freeze_command.py
@@ -56,7 +56,7 @@ class FreezeCommand(object):
     def create_bootstrap_aggregate_file(self):
         url = self.api.makeurl(['source', self.prj, 'bootstrap-copy', '_aggregate'])
 
-        root = ET.Element('aggregatelist')
+        root = ET.Element('aggregatelist', {'resign': 'false'})
         a = ET.SubElement(root, 'aggregate',
                           {'project': f'{self.api.crings}:0-Bootstrap'})
 


### PR DESCRIPTION
Rings:0-Bootstrap binaries are copied by means of _aggregate into
the letter stagings. Rings:* and Stagings use the same signing key,
we can thus avoid resigning all RPMs on aggregate and substantially
speed up `osc staging freeze`
