### PR TITLE
osclib: repochecks: maintain compatibility with Python 3.6

### DIFF
--- a/osclib/repochecks.py
+++ b/osclib/repochecks.py
@@ -147,7 +147,8 @@ def parsed_installcheck(repos, arch, target_packages, whitelist):
         repos = [repos]
 
     p = subprocess.run(['/usr/bin/installcheck', maparch2installarch(arch)] + repos,
-                       stdout=subprocess.PIPE, errors='backslashreplace', text=True)
+                       stdout=subprocess.PIPE, errors='backslashreplace',
+                       universal_newlines=True)
     if p.returncode:
         in_problem = False
         package = None


### PR DESCRIPTION
The "text" kwarg has been added to subprocess.run in Python 3.7, as an alias of "universal_newlines".

Use the latter so that we can keep supporting Python 3.6, which is the system interpreter in SLE15 and we're still using.