### PR TITLE
scm/git.py: fix git fetch

### DIFF
--- a/scm/git.py
+++ b/scm/git.py
@@ -70,7 +70,7 @@ class Git(scm.base.SCMBase):
                 if revision_name is not None:
                     to_fetch = f"{revision}:{revision_name}"
                 else:
-                    to_fetch = f"{revision}:{revision}"
+                    to_fetch = f"{revision}"
                 repo.remote(remote).fetch([to_fetch])
 
         if revision_name is not None:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/share/openSUSE-release-tools/ReviewBot.py", line 268, in check_requests
    good = self.check_one_request(req)
  File "/usr/share/openSUSE-release-tools/ReviewBot.py", line 526, in check_one_request
    ret = func(req, a)
  File "/usr/share/openSUSE-release-tools/ReviewBot.py", line 618, in check_action_submit
    return self.check_source_submission(a.src_project, a.src_package, a.src_rev, a.tgt_project, a.tgt_package)
  File "/usr/share/openSUSE-release-tools/ReviewBot.py", line 634, in check_source_submission
    return self.check_source_submission_v2(src_project, src_package, src_rev, target_project, target_package, target_rev)
  File "/usr/bin/osrt-check_source", line 282, in check_source_submission_v2
    pathname=copath, server_service_files=True, expand_link=True)
  File "/usr/bin/osrt-check_source", line 567, in checkout_package
    **kwargs
  File "/usr/lib/python3.6/site-packages/scm/git.py", line 106, in checkout_package
    self.clone_repository(url, dstpath, **kwargs)
  File "/usr/lib/python3.6/site-packages/scm/git.py", line 92, in clone_repository
    Git.checkout_revision(repo, revision, revision_name=revision_name)
  File "/usr/lib/python3.6/site-packages/scm/git.py", line 74, in checkout_revision
    repo.remote(remote).fetch([to_fetch])
  File "/usr/lib/python3.6/site-packages/git/remote.py", line 856, in fetch
    res = self._get_fetch_info_from_stderr(proc, progress)
  File "/usr/lib/python3.6/site-packages/git/remote.py", line 765, in _get_fetch_info_from_stderr
    output.append(FetchInfo._from_line(self.repo, err_line, fetch_line))
  File "/usr/lib/python3.6/site-packages/git/remote.py", line 403, in _from_line
    raise TypeError("Cannot handle reference type: %r" % ref_type_name)
TypeError: Cannot handle reference type: "'3cb17eee0bd72ef2de42d8f5244f17854dff7b70c774c59578a14d9e10b6c9f6'"
```