### PR TITLE
check_bugowner: Allow overriding OSRT_BUGOWNER_CACHE_HOME for the systemd service.

### DIFF
--- a/config/osrt-check-bugowner-gitea.env.in
+++ b/config/osrt-check-bugowner-gitea.env.in
@@ -24,3 +24,7 @@ OSRT_BUGOWNER_LDAP_SERVER="pan.suse.de"
 # check_bugower script will wait for a response when querying
 # the LDAP instance
 OSRT_BUGOWNER_LDAP_TIMEOUT="30"
+
+# OSRT_BUGOWNER_CACHE_HOME: The directory where repositories will be
+# cached to compute Git submodules diffs.
+OSRT_BUGOWNER_CACHE_HOME="/var/lib/osrt-staging/check-bugowner"

--- a/systemd/osrt-check-bugowner-gitea@.service
+++ b/systemd/osrt-check-bugowner-gitea@.service
@@ -8,7 +8,6 @@ Type=oneshot
 User=osrt-staging
 SyslogIdentifier=osrt-slsa
 EnvironmentFile=/etc/default/osrt-check-bugowner-gitea-%i.env
-Environment="OSRT_BUGOWNER_CACHE_HOME=/var/lib/osrt-staging/check-bugowner"
 WorkingDirectory=/var/lib/osrt-staging/check-bugowner
 ExecStartPre=/bin/bash -xc '/usr/bin/systemctl is-active --quiet osrt-check-bugowner-gitea@%i.service && exit 1 || exit 0'
 ExecStart=/usr/bin/osrt-check_bugowner --scm=git --platform=gitea --gitea-url="${GITEA_URL}" --user="%i" --verbose --ldap review


### PR DESCRIPTION
This allows to set the cache directory to mountpoints outside `/var`