### PR TITLE
git-openqa-maintenance: Implement pagination for Gitea timeline API calls

### DIFF
--- a/git-openqa-maintenance.py
+++ b/git-openqa-maintenance.py
@@ -11,9 +11,9 @@ from lxml import etree as ET
 from collections import namedtuple
 import osc.core
 
-USER_AGENT = "git-openqa-maintenance (https://github.com/openSUSE/openSUSE-release-tools"
 dry_run = False
 openqa_dry_run = False
+USER_AGENT = "git-openqa-maintenance (https://github.com/openSUSE/openSUSE-release-tools)"
 
 log = logging.getLogger(sys.argv[0] if __name__ == "__main__" else __name__)
 log.setLevel(logging.DEBUG)
@@ -86,13 +86,28 @@ def process_project(args):
 
 
 def get_open_prs_for_project_branch(project, branch):
-    pull_requests_url = GITEA_HOST + f"/api/v1/repos/{project}/pulls?state=open&base_branch={branch}"
+    limit = 50
+    page = 1
+    pull_requests = []
 
-    try:
-        pull_requests = request_get(pull_requests_url)
-    except requests.exceptions.HTTPError as e:
-        log.error(f"Project '{project}' doesn't exist: {e}")
-        return []
+    while True:
+        pull_requests_url = GITEA_HOST + f"/api/v1/repos/{project}/pulls?state=open&base_branch={branch}&limit={limit}&page={page}"
+
+        try:
+            request = request_get(pull_requests_url)
+        except requests.exceptions.HTTPError as e:
+            log.error(f"Project '{project}' doesn't exist: {e}")
+            return []
+
+        if not request:
+            break
+
+        pull_requests.extend(request)
+
+        if len(request) < limit:
+            break
+
+        page += 1
 
     if not pull_requests:
         log.warning(f"No pull requests found for '{project}' on'{branch}'")
@@ -443,15 +458,24 @@ def gitea_get_review(project, pr_id, review_id):
 
 def get_events_by_timeline(project, pr_id):
     log.debug("============== get_events_by_timeline")
-    url = GITEA_HOST + f"/api/v1/repos/{project}/issues/{pr_id}/timeline"
-    request = request_get(url)
+    limit = 50
+    page = 1
+    timeline = []
 
-    # if request.status_code == 404:
-    #     self.logger.error(f"'{self}' does not have a timeline")
-    #     # this should throw an exception
-    #     return
+    while True:
+        url = GITEA_HOST + f"/api/v1/repos/{project}/issues/{pr_id}/timeline?limit={limit}&page={page}"
+        request = request_get(url)
 
-    timeline = request
+        if not request:
+            break
+
+        timeline.extend(request)
+
+        if len(request) < limit:
+            break
+
+        page += 1
+
     timeline.reverse()
 
     events = {}


### PR DESCRIPTION
The Gitea API has a hard limit of 50 results per query, which can hide potential useful information such as a pull request or a needed comment both of which are needed to take any sort of 

This updates the two functions that query endpoints that can return multiple pages to handle pagination with a maximum limit of 50 items per page. It will now iterate through all available pages and append the results until the server returns null or a list smaller than the limit.

This is needed for PRs where there are too many comments: https://src.opensuse.org/products/PackageHub/pulls/304

Now the flow is working as expected, most recent comment is properly detected to be an approval one, and the bot doesn't do anything else, a similar result happens for pull requests

```
git-openqa-maintenance.py DEBUG get_events_by_timeline:445: ============== get_events_by_timeline                         
git-openqa-maintenance.py DEBUG request_get:508: Sending request to gitea for https://src.opensuse.org/api/v1/repos/products/PackageHub/issues/304/timeline?limit=50&page=
1                                                                                                                                                                         
...                                                                                                                                                                   git-openqa-maintenance.py DEBUG request_get:508: Sending request to gitea for https://src.opensuse.org/api/v1/repos/products/PackageHub/issues/304/timeline?limit=50&page=
18                                                                                                                                                                        
git-openqa-maintenance.py DEBUG get_events_by_timeline:480: Storing most recent 'comment' for 'openqa-maintenance' (ID: 206657)
...
git-openqa-maintenance.py DEBUG get_events_by_timeline:480: Storing most recent 'comment' for 'openqa-maintenance' (ID: 206657)
git-openqa-maintenance.py DEBUG get_events_by_timeline:483: Skipping older 'comment' for 'openqa-maintenance' (ID: 206631)
...
git-openqa-maintenance.py INFO process_pull_request:149: Build for products/PackageHub#304 has a review already by us: openQA tests passed: https://openqa.opensuse.org/te
sts/overview?build=%3Aproducts_PackageHub%3A304%3Abird3&distri=opensuse&version=16.0
@qam-openqa-review: approve
```
