### PR TITLE
devel_update: Use POSIX locale for sorting

### DIFF
--- a/devel_update.sh
+++ b/devel_update.sh
@@ -28,7 +28,7 @@ function setdevel {
         exit 10
     fi
 
-    cat <(awk "{ if ( \$1 != \"$pkg\" ) print }" "$DEVEL_PACKAGES") <(echo "$pkg" "$prj") | sort -d > "$DEVEL_PACKAGES".$$
+    cat <(awk "{ if ( \$1 != \"$pkg\" ) print }" "$DEVEL_PACKAGES") <(echo "$pkg" "$prj") | LANG=POSIX sort -d > "$DEVEL_PACKAGES".$$
     mv "$DEVEL_PACKAGES".$$ "$DEVEL_PACKAGES"
 }
 


### PR DESCRIPTION
We need to be sure that everybody uses the same LANG to sort the file otherwise the file just keeps re-ordering depending on who runs the script on what machine.