### PR TITLE
pkglistgen: fix frequent error with mis-detected latest collection

### DIFF
--- a/pkglistgen/update_repo_handler.py
+++ b/pkglistgen/update_repo_handler.py
@@ -243,7 +243,32 @@ def target_files(repo_dir, key):
     files = list()
     for suffix in ['xz', 'zst']:
         files += glob.glob(os.path.join(repo_dir, f'{key}_*.packages.{suffix}'))
-    return files
+
+    def file_sort_key(filepath):
+        basename = os.path.basename(filepath)
+        filename = basename[len(key) + 1:]
+        for sfx in ['.packages.xz', '.packages.zst']:
+            if filename.endswith(sfx):
+                filename = filename[:-len(sfx)]
+                break
+
+        is_compacted = False
+        if filename.endswith('_and_before'):
+            filename = filename[:-len('_and_before')]
+            is_compacted = True
+
+        parts = []
+        for part in re.split(r'([^0-9]+)', filename):
+            if not part:
+                continue
+            if part.isdigit():
+                parts.append((0, int(part)))
+            else:
+                parts.append((1, part))
+
+        return (not is_compacted, parts)
+
+    return sorted(files, key=file_sort_key)
 
 
 def update_project(apiurl, project, fixate=None):


### PR DESCRIPTION
Addresses the kind of issues seen quite often like 
https://botmaster.suse.de/go/tab/build/detail/Update.Repos.Factory/2410/Update/1/openSUSE_Factory

```
Traceback (most recent call last):
  File "/godata/pipelines/Update.Repos.Factory/./pkglistgen.py", line 8, in <module>
    sys.exit(app.main())
             ~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/cmdln.py", line 261, in main
    return self.cmd(args)
           ~~~~~~~~^^^^^^
  File "/usr/lib/python3.13/site-packages/cmdln.py", line 284, in cmd
    retval = self.onecmd(argv)
  File "/usr/lib/python3.13/site-packages/cmdln.py", line 422, in onecmd
    return self._dispatch_cmd(handler, argv)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/cmdln.py", line 1123, in _dispatch_cmd
    return handler(argv[0], opts, *args)
  File "/godata/pipelines/Update.Repos.Factory/pkglistgen/cli.py", line 44, in do_handle_update_repos
    return update_project(conf.config['apiurl'], project, opts.fixate)
  File "/godata/pipelines/Update.Repos.Factory/pkglistgen/update_repo_handler.py", line 290, in update_project
    raise Exception('The oldest is already a compated file')
Exception: The oldest is already a compated file
```

Every once in a while it gets confused, created x_before_and_before archives, and ultimately crashes out later

Last run with the fixed code committed:
https://build.opensuse.org/package/rdiff/openSUSE:Factory/000update-repos?linkrev=base&rev=2918