### PR TITLE
gocd: run SLE.Legal.Import at 02:00 instead of midnight

### DIFF
--- a/gocd/checkers.suse.gocd.yaml
+++ b/gocd/checkers.suse.gocd.yaml
@@ -264,7 +264,7 @@ pipelines:
     group: SUSE.Legal
     lock_behavior: unlockWhenFinished
     timer:
-      spec: 0 0 0 ? * *
+      spec: 0 0 2 ? * *
     environment_variables:
       OSC_CONFIG: /home/go/config/oscrc-legal-auto
     materials:

--- a/gocd/checkers.suse.gocd.yaml.erb
+++ b/gocd/checkers.suse.gocd.yaml.erb
@@ -264,7 +264,7 @@ pipelines:
     group: SUSE.Legal
     lock_behavior: unlockWhenFinished
     timer:
-      spec: 0 0 0 ? * *
+      spec: 0 0 2 ? * *
     environment_variables:
       OSC_CONFIG: /home/go/config/oscrc-legal-auto
     materials:


### PR DESCRIPTION
Shift the daily legal import timer from 00:00 to 02:00 to avoid the midnight run window.