### PR TITLE
gocd: enable shallow_clone for the botmaster suse-repos and opensuse-repos materials

### DIFF
--- a/gocd/alp-stagings.gocd.yaml
+++ b/gocd/alp-stagings.gocd.yaml
@@ -12,6 +12,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -53,6 +54,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -94,6 +96,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -135,6 +138,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -176,6 +180,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -217,6 +222,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -258,6 +264,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -299,6 +306,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -340,6 +348,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -381,6 +390,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -422,6 +432,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:

--- a/gocd/alp-stagings.gocd.yaml.erb
+++ b/gocd/alp-stagings.gocd.yaml.erb
@@ -13,6 +13,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:

--- a/gocd/bci.gocd.yaml
+++ b/gocd/bci.gocd.yaml
@@ -70,6 +70,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:

--- a/gocd/bci.gocd.yaml.erb
+++ b/gocd/bci.gocd.yaml.erb
@@ -70,6 +70,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:

--- a/gocd/microos-stagings.gocd.yaml
+++ b/gocd/microos-stagings.gocd.yaml
@@ -41,6 +41,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -102,6 +103,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:

--- a/gocd/microos-stagings.gocd.yaml.erb
+++ b/gocd/microos-stagings.gocd.yaml.erb
@@ -37,6 +37,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:

--- a/gocd/microos.target.gocd.yaml
+++ b/gocd/microos.target.gocd.yaml
@@ -6,6 +6,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:ALP:Products:Marble:6.0_-_images.yaml
@@ -72,6 +73,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:SLFO:Products:SL-Micro:6.1_-_images.yaml
@@ -120,6 +122,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:SLFO:Products:SL-Micro:6.1_-_images.yaml
@@ -159,6 +162,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:SLFO:Products:SL-Micro:6.2_-_images.yaml
@@ -207,6 +211,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:SLFO:Products:SL-Micro:6.2_-_images.yaml
@@ -246,6 +251,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:SLFO:Products:SLCS:6.0_-_images.yaml

--- a/gocd/monitors.gocd.yaml
+++ b/gocd/monitors.gocd.yaml
@@ -134,6 +134,7 @@ pipelines:
         destination: scripts
       repos:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         branch: master
         destination: repos
       notifications:
@@ -166,6 +167,7 @@ pipelines:
         destination: scripts
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         branch: master
         destination: repos
       notifications:

--- a/gocd/pkglistgen_staging.gocd.yaml
+++ b/gocd/pkglistgen_staging.gocd.yaml
@@ -145,6 +145,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -210,6 +211,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -275,6 +277,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -340,6 +343,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -405,6 +409,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -470,6 +475,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -535,6 +541,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -600,6 +607,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -665,6 +673,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -730,6 +739,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -795,6 +805,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -860,6 +871,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -925,6 +937,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -990,6 +1003,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1055,6 +1069,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1120,6 +1135,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1185,6 +1201,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:

--- a/gocd/pkglistgen_staging.gocd.yaml.erb
+++ b/gocd/pkglistgen_staging.gocd.yaml.erb
@@ -36,6 +36,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:

--- a/gocd/sle15-stagings.gocd.yaml
+++ b/gocd/sle15-stagings.gocd.yaml
@@ -104,6 +104,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -172,6 +173,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -240,6 +242,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -308,6 +311,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -376,6 +380,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -444,6 +449,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -512,6 +518,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -580,6 +587,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -648,6 +656,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -716,6 +725,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -784,6 +794,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:

--- a/gocd/sle15-stagings.gocd.yaml.erb
+++ b/gocd/sle15-stagings.gocd.yaml.erb
@@ -37,6 +37,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:

--- a/gocd/sles.target.gocd.yaml
+++ b/gocd/sles.target.gocd.yaml
@@ -6,6 +6,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:SLFO:Products:SLES:16.1_-_images.yaml
@@ -59,6 +60,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:SLFO:Products:SLES:16.1_-_images.yaml
@@ -105,6 +107,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:SLFO:Products:SLES:16.0_-_images.yaml
@@ -158,6 +161,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:SLFO:Products:SLES:16.0_-_images.yaml

--- a/gocd/slfo-stagings.gocd.yaml
+++ b/gocd/slfo-stagings.gocd.yaml
@@ -70,6 +70,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -163,6 +164,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -256,6 +258,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -349,6 +352,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -442,6 +446,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -535,6 +540,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -628,6 +634,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -721,6 +728,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -814,6 +822,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -907,6 +916,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1000,6 +1010,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1093,6 +1104,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1186,6 +1198,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1279,6 +1292,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1372,6 +1386,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1465,6 +1480,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1559,6 +1575,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1612,6 +1629,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1665,6 +1683,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1718,6 +1737,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1771,6 +1791,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1824,6 +1845,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1877,6 +1899,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1930,6 +1953,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -1983,6 +2007,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2036,6 +2061,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2089,6 +2115,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2142,6 +2169,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2195,6 +2223,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2248,6 +2277,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2301,6 +2331,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2354,6 +2385,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2407,6 +2439,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2460,6 +2493,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2513,6 +2547,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2566,6 +2601,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2619,6 +2655,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2672,6 +2709,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2725,6 +2763,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2778,6 +2817,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2831,6 +2871,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -2884,6 +2925,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:

--- a/gocd/slfo-stagings.gocd.yaml.erb
+++ b/gocd/slfo-stagings.gocd.yaml.erb
@@ -71,6 +71,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:
@@ -167,6 +168,7 @@ pipelines:
     materials:
       stagings:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         destination: repos
         whitelist:

--- a/gocd/slfo.target.gocd.yaml
+++ b/gocd/slfo.target.gocd.yaml
@@ -6,6 +6,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:SLFO:Main:Build_-_standard.yaml
@@ -51,6 +52,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:SLFO:1.1:Build_-_standard.yaml

--- a/gocd/sp.target.gocd.yaml
+++ b/gocd/sp.target.gocd.yaml
@@ -6,6 +6,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:SLE-15-SP7:Update:QR_-_images.yaml
@@ -54,6 +55,7 @@ pipelines:
     materials:
       repos:
         git: git://botmaster.suse.de/suse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - SUSE:SLE-15-SP7:Update:QR_-_images.yaml

--- a/gocd/staging.bot.gocd.yaml
+++ b/gocd/staging.bot.gocd.yaml
@@ -11,6 +11,7 @@ pipelines:
         destination: scripts
       repos:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - openSUSE:Factory:Staging:adi*.yaml
@@ -68,6 +69,7 @@ pipelines:
         destination: scripts
       repos:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - openSUSE:Factory:NonFree:Staging:adi*.yaml

--- a/gocd/staging.bot.gocd.yaml.erb
+++ b/gocd/staging.bot.gocd.yaml.erb
@@ -13,6 +13,7 @@ pipelines:
         destination: scripts
       repos:
         git: git://botmaster.suse.de/opensuse-repos.git
+        shallow_clone: true
         auto_update: true
         whitelist:
           - openSUSE:<%= project %>:Staging:adi*.yaml


### PR DESCRIPTION
suse-repos.git is 1.37 GiB / 893k commits and opensuse-repos.git is 822 MiB / 939k commits, but together they only hold ~7 MB of actual content, so a cold checkout costs up to 17 minutes; shallow_clone brings the agent-side checkout down to ~12 MB and makes it near-instant.