### PR TITLE
pkglistgen: Force 2nd run for prodcomposer

### DIFF
--- a/gocd/pkglistgen.opensuse.gocd.yaml
+++ b/gocd/pkglistgen.opensuse.gocd.yaml
@@ -23,7 +23,7 @@ pipelines:
               - script: |
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s target --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s target
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s target --engine=product_composer
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s target --engine=product_composer --force
           openSUSE_Factory_ring1:
             resources:
             - repo-checker
@@ -31,7 +31,7 @@ pipelines:
               - script: |
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s ring1 --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s ring1
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s ring1 --engine=product_composer
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory -s ring1 --engine=product_composer --force
           openSUSE_Factory_ARM_target:
             resources:
             - repo-checker
@@ -39,7 +39,7 @@ pipelines:
               - script: |
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s target --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s target
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s target --engine=product_composer
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s target --engine=product_composer --force
           openSUSE_Factory_ARM_ring1:
             resources:
             - repo-checker
@@ -47,7 +47,7 @@ pipelines:
               - script: |
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s ring1 --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s ring1
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s ring1 --engine=product_composer
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:ARM -s ring1 --engine=product_composer --force
           openSUSE_Factory_LegacyX86_target:
             resources:
             - repo-checker
@@ -55,7 +55,7 @@ pipelines:
               - script: |
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:LegacyX86 -s target --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:LegacyX86 -s target
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:LegacyX86 -s target --engine=product_composer
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:LegacyX86 -s target --engine=product_composer --force
           openSUSE_Factory_PowerPC:
             resources:
             - repo-checker
@@ -63,7 +63,7 @@ pipelines:
               - script: |
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:PowerPC -s target --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:PowerPC -s target
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:PowerPC -s target --engine=product_composer
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:PowerPC -s target --engine=product_composer --force
           openSUSE_Factory_zSystems:
             resources:
             - repo-checker
@@ -71,7 +71,7 @@ pipelines:
               - script: |
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:zSystems -s target --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:zSystems -s target
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:zSystems -s target --engine=product_composer
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:zSystems -s target --engine=product_composer --force
           openSUSE_Factory_RISCV:
             resources:
             - repo-checker
@@ -79,7 +79,7 @@ pipelines:
               - script: |
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:RISCV -s target --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:RISCV -s target
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:RISCV -s target --engine=product_composer
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p openSUSE:Factory:RISCV -s target --engine=product_composer --force
   Update.Repos.Factory:
     group: Factory
     lock_behavior: unlockWhenFinished

--- a/gocd/pkglistgen.opensuse.gocd.yaml.erb
+++ b/gocd/pkglistgen.opensuse.gocd.yaml.erb
@@ -33,7 +33,7 @@ pipelines:
               - script: |
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p <%= project[0] %><%= options %> --only-release-packages --force
                   python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p <%= project[0] %><%= options %>
-                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p <%= project[0] %><%= options %> --engine=product_composer
+                  python3 -u ./pkglistgen.py -d -A https://api.opensuse.org update_and_solve -p <%= project[0] %><%= options %> --engine=product_composer --force
 <% end -%>
   Update.Repos.Factory:
     group: Factory


### PR DESCRIPTION
For Tumbleweed, we currently calculate two media, the legacy yast dvd and the modern agama offline image. Once the release/yast dvd is calculated and checked in, the repo is 'dirty', which stops the calculation of the prodcomposer based product. As we know at this time that the repo was effectively clean, and we polluted it, we can just force the calculation of the new DVD as well instead of waiting a whole cycle to catch a repo-clean state again.