### PR TITLE
Freeze: also setup product repository for Agama offline image

### DIFF
--- a/osclib/freeze_command.py
+++ b/osclib/freeze_command.py
@@ -200,6 +200,13 @@ class FreezeCommand(object):
                 a = ET.SubElement(r, 'arch')
                 a.text = 'local'
 
+            # The 'product' repo needs to build against 'images' and 'bootstrap-copy'
+            # images is used for agama-baseiso (baseiso-containment of agama installer)
+            # bootstrap-copy is used for Ring0 packages to be available for the product
+            if repository == "product":
+                ET.SubElement(r, 'path', {'project': self.prj, 'repository': 'images'})
+                ET.SubElement(r, 'path', {'project': self.prj, 'repository': 'bootstrap_copy'})
+
             a = ET.SubElement(r, 'arch')
             a.text = 'x86_64'
 


### PR DESCRIPTION
The code detects if the staging to be frozen has a product repo, which matches our usecase very well. But the repo needs to be built against images (for agama-baseiso) and bootstrap_copy) as product compose only takes packages from referenced paths.