### PR TITLE
check_source.py: Do not skip unchanged URLs

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -702,26 +702,7 @@ class CheckSource(ReviewBot.ReviewBot):
 
         return True
 
-    def _snipe_out_existing_urls(self, old, directory, specs):
-        if not os.path.isdir(old):
-            return
-        oldsources = self._mentioned_sources(old, specs)
-        for spec in specs:
-            specfn = os.path.join(directory, spec)
-            nspecfn = specfn + '.new'
-            wf = open(nspecfn, 'w')
-            with open(specfn) as rf:
-                for line in rf:
-                    m = re.match(r'(Source[0-9]*\s*):\s*(.*)$', line)
-                    if m and m.group(2) in oldsources:
-                        wf.write(m.group(1) + ":" + os.path.basename(m.group(2)) + "\n")
-                        continue
-                    wf.write(line)
-            wf.close()
-            os.rename(nspecfn, specfn)
-
     def check_urls(self, old, directory, specs):
-        self._snipe_out_existing_urls(old, directory, specs)
         oldcwd = os.getcwd()
         with tempfile.TemporaryDirectory() as tmpdir:
             os.chdir(directory)

--- a/tests/check_source_tests.py
+++ b/tests/check_source_tests.py
@@ -386,7 +386,7 @@ class TestCheckSource(OBSLocal.TestCase):
 
     @pytest.mark.usefixtures("default_config")
     def test_existing_source_urls(self):
-        """Accepts invalid source URLs if previously present"""
+        """Refuses invalid source URLs even if previously present"""
         self._setup_devel_project(devel_files='blowfish-with-urls', target_files='blowfish-with-existing-url')
 
         req_id = self.wf.create_submit_request(self.devel_package.project,
@@ -397,7 +397,10 @@ class TestCheckSource(OBSLocal.TestCase):
         self.review_bot.set_request_ids([req_id])
         self.review_bot.check_requests()
 
-        self.assertReview(req_id, by_user=(self.bot_user, 'accepted'))
+        # not declined but not accepted either
+        review = self.assertReview(req_id, by_user=(self.bot_user, 'new'))
+        self.assertIn("Source URLs are not valid. Try `osc service runall download_files`.", review.comment)
+        self.assertIn("ERROR: Failed to download \"https://example.com/blowfish-1.tar.gz\"", review.comment)
 
     @pytest.mark.usefixtures("default_config")
     def test_two_patches_in_one_line(self):


### PR DESCRIPTION
- The URLs may contain macros like %{version}
- The file may have changed but the URL stayed the same
- The URL may be dead meanwhile

https://build.opensuse.org/request/show/1374395 was incorrectly accepted.