### PR TITLE
container_cleaner.py: Handle multibuild flavors separately

### DIFF
--- a/container_cleaner.py
+++ b/container_cleaner.py
@@ -8,7 +8,7 @@ import logging
 import ToolBase
 import sys
 import re
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from lxml import etree as xml
 
 
@@ -27,85 +27,70 @@ class ContainerCleaner(ToolBase.ToolBase):
         return xml.parse(self.retried_GET(url))
 
     def findSourcepkgsToDelete(self, project):
-        # Get a list of all images
-        srccontainers = self.getDirEntries(["source", project])
+        # Get a set of all srccontainers in the project
+        srccontainers = set(self.getDirEntries(["source", project]))
 
-        # Sort the released packages into buckets for each origin package:
-        # {"opensuse-tumbleweed-image": ["opensuse-tumbleweed-image.20190402134201", ...]}
-        buckets = defaultdict(list)
-        regex_maintenance_release = re.compile(R"^(.+)\.[0-9]+$")
-        for srccontainer in srccontainers:
-            # Get the right bucket
-            match = regex_maintenance_release.match(srccontainer)
-            if match:
-                # Maintenance release
-                package = match.group(1)
-            else:
-                # Not renamed
-                package = srccontainer
-
-            if srccontainer not in buckets[package]:
-                buckets[package] += [srccontainer]
-
-        for package in buckets:
-            # Sort each bucket: Newest provider first
-            buckets[package].sort(reverse=True)
-            logging.debug("Found %d providers of %s", len(buckets[package]), package)
-
-        # Get a hash for sourcecontainer -> arch with binaries
-        # {"opensuse-tumbleweed-image.20190309164844": ["aarch64", "armv7l", "armv6l"],
-        # "kubic-pause-image.20190306124139": ["x86_64", "i586"], ... }
-        srccontainerarchs = defaultdict(list)
-
+        # List of all binaries in the project
         resultlist = self.getBinaryList(project)
 
-        regex_srccontainer = re.compile(R"^([^:]+)(:[^:]+)?$")
+        # The bot keeps five releases of each image alive. "Same image" is defined by
+        # having the same package name, flavor and architecture.
+        ImageKey = namedtuple("ProvidedImage", ["pkgname", "flavor", "arch"])
+
+        # A released image. maint_release kept as first tuple member to act for sorting.
+        ReleasedImage = namedtuple("ReleasedImage", ["maint_release", "buildcontainer", "srccontainer"])
+
+        # Sort the released packages into buckets for each image it provides:
+        # {ImageKey("opensuse-tumbleweed-image", "docker", "x86_64"):
+        #    [ReleasedImage(20190402134201, "container-image.20190402134201:docker", "container-image.20190402134201"), ...]}
+        buckets = defaultdict(list)
+
+        # Split a buildcontainer name like "sourcepkg.01234:flavor" into its parts
+        regex_buildcontainer = re.compile(R"^([^:]+)\.([0-9]+)(:[^:]+)?$")
+
         for arch_result in resultlist.xpath("result"):
             arch = arch_result.get("arch")
 
             for binarylist in arch_result.xpath("binarylist"):
                 buildcontainer = binarylist.get("package")
-                if len(binarylist.xpath("binary")) > 0:
-                    match = regex_srccontainer.match(buildcontainer)
-                    if not match:
-                        raise Exception(f"Could not map {buildcontainer} to source container")
+                if len(binarylist.xpath("binary")) == 0:
+                    continue
 
-                    srccontainer = match.group(1)
-                    if srccontainer not in srccontainers:
-                        raise Exception(f"Mapped {buildcontainer} to wrong source container ({srccontainer})")
+                match = regex_buildcontainer.match(buildcontainer)
+                if not match:
+                    raise Exception(f"Could not parse {buildcontainer} as build container")
 
-                    logging.debug("%s provides binaries for %s", srccontainer, arch)
-                    srccontainerarchs[srccontainer] += [arch]
+                pkgname, maint_release, flavor = match.group(1, 2, 3)
+                srccontainer = f"{pkgname}.{maint_release}"
+                if srccontainer not in srccontainers:
+                    raise Exception(f"Mapped {buildcontainer} to wrong source container ({srccontainer})")
+
+                imgbucket = ImageKey(pkgname, flavor, arch)
+                logging.debug("%s provides binaries for %s through %s", buildcontainer, imgbucket, srccontainer)
+                buckets[imgbucket] += [ReleasedImage(maint_release, buildcontainer, srccontainer)]
+
+        # The list of srccontainers referenced by released images
+        seen_srccontainers = set([img.srccontainer for pkg in buckets for img in buckets[pkg]])
+        srccontainers_not_seen = set(srccontainers) - seen_srccontainers
+        if srccontainers_not_seen:
+            logging.warning(f"The following srccontainers have no binaries and will not be touched: {srccontainers_not_seen}")
+        else:
+            logging.debug("All srccontainers have binaries!")
 
         # Now go through each bucket and find out what doesn't contribute to the newest five
-        can_delete = []
+        srccontainers_referenced = set()
         for package in buckets:
-            # {"x86_64": 1, "aarch64": 2, ...}
-            archs_found = defaultdict(lambda: 0)
+            # Sort each bucket: Newest provider first
+            buckets[package].sort(reverse=True)
+            logging.debug("Found %d providers of %s", len(buckets[package]), package)
 
-            for srccontainer in buckets[package]:
-                contributes = False
-                for arch in srccontainerarchs[srccontainer]:
-                    if archs_found[arch] < 5:
-                        archs_found[arch] += 1
-                        contributes = True
+            for released_image in buckets[package][:5]:
+                logging.debug(f"\t{released_image} needed")
+                srccontainers_referenced.add(released_image.srccontainer)
+            for released_image in buckets[package][5:]:
+                logging.debug(f"\t{released_image} no longer needed")
 
-                if len(srccontainerarchs[srccontainer]) == 0:
-                    logging.warning("%s has no binaries (any flavor/any arch) - skipping", srccontainer)
-                elif contributes:
-                    logging.debug("%s contributes to %s", srccontainer, package)
-                else:
-                    logging.info("%s does not contribute", srccontainer)
-                    if len([count for count in archs_found.values() if count > 0]) == 0:
-                        # If there are A, B, C and D, with only C and D providing binaries,
-                        # A and B aren't deleted because they have newer sources. This is
-                        # to avoid deleting something due to unforeseen circumstances, e.g.
-                        # OBS didn't copy the binaries yet.
-                        logging.warning("No newer provider found either, ignoring")
-                    else:
-                        can_delete += [srccontainer]
-
-        return can_delete
+        return seen_srccontainers - srccontainers_referenced
 
     def run(self, project):
         packages = self.findSourcepkgsToDelete(project)

--- a/tests/container_cleaner_tests.py
+++ b/tests/container_cleaner_tests.py
@@ -6,6 +6,7 @@ from lxml import etree as xml
 
 class MockedContainerCleaner(ContainerCleaner):
     def __init__(self, container_arch_map):
+        super().__init__()
         self.container_arch_map = container_arch_map
 
     def getDirEntries(self, path):
@@ -43,7 +44,7 @@ class MockedContainerCleaner(ContainerCleaner):
 class TestContainerCleaner(unittest.TestCase):
     def doTest(self, container_arch_map, to_be_deleted_exp):
         cleaner = MockedContainerCleaner(container_arch_map)
-        to_be_deleted = cleaner.findSourcepkgsToDelete("mock:prj")
+        to_be_deleted = list(cleaner.findSourcepkgsToDelete("mock:prj"))
         to_be_deleted.sort()
         self.assertEqual(to_be_deleted, to_be_deleted_exp)
 
@@ -57,7 +58,7 @@ class TestContainerCleaner(unittest.TestCase):
 
     def test_nothingToDo(self):
         """Non-empty project, still do nothing"""
-        container_arch_map = {"c": ["i586", "x86_64"],
+        container_arch_map = {"c.00": ["i586", "x86_64"],
                               "c.01": ["i586"],
                               "c.02": ["x86_64"],
                               "c.04": ["i586", "x86_64"],
@@ -73,7 +74,7 @@ class TestContainerCleaner(unittest.TestCase):
 
     def test_multiplePackages(self):
         """Multiple packages in one project"""
-        container_arch_map = {"c": ["i586", "x86_64"],
+        container_arch_map = {"c.00": ["i586", "x86_64"],
                               "c.01": ["i586"],
                               "c.02": ["x86_64"],
                               "c.03": [],
@@ -94,15 +95,14 @@ class TestContainerCleaner(unittest.TestCase):
                               "e.56": ["i586"],
                               "e.57": ["i586"]}
 
-        to_be_deleted_exp = ["c", "c.01", "c.02", "c.04",
+        to_be_deleted_exp = ["c.00", "c.01", "c.02", "c.04",
                              "e.51"]
 
         return self.doTest(container_arch_map, to_be_deleted_exp)
 
     def test_multibuild(self):
-        """Packages using _multbuild.
-        There is no special handling for _multibuild - It's enough if any flavor has binaries."""
-        container_arch_map = {"c:docker": ["i586", "x86_64"],
+        """_multibuild flavors are treated like separate binaries"""
+        container_arch_map = {"c.00:docker": ["i586", "x86_64"],
                               "c.01:docker": ["i586"],
                               "c.02:lxc": ["x86_64"],
                               "c.03:docker": [],
@@ -114,7 +114,8 @@ class TestContainerCleaner(unittest.TestCase):
                               "c.09:docker": ["i586", "x86_64"],
                               "c.10:docker": ["i586", "x86_64"],
                               "c.11:docker": [],
-                              "d.42:lxc": [], "d.43": [],
+                              "d.42:lxc": [],
+                              "d.43": [],
                               "e.51": ["i586"],
                               "e.52": ["aarch64"],
                               "e.53": ["i586"],
@@ -123,7 +124,45 @@ class TestContainerCleaner(unittest.TestCase):
                               "e.56": ["i586"],
                               "e.57": ["i586"]}
 
-        to_be_deleted_exp = ["c", "c.01", "c.02", "c.04",
-                             "e.51"]
+        to_be_deleted_exp = ["c.00", "c.01"]
 
         return self.doTest(container_arch_map, to_be_deleted_exp)
+
+    def test_multibuild_independent(self):
+        """_multibuild flavors are treated like separate binaries"""
+        container_arch_map = {"f.0:a": ["x86_64"],
+                              "f.0:b": ["x86_64"],
+                              "f.1:b": ["x86_64"],
+                              "f.2:b": ["x86_64"],
+                              "f.3:b": ["x86_64"],
+                              "f.4:b": ["x86_64"],
+                              "f.5:b": ["x86_64"],
+                              "f.6:b": ["x86_64"]}
+
+        # f.0 is needed for f.0:a, keep it
+        to_be_deleted_exp = ["f.1"]
+
+        self.doTest(container_arch_map, to_be_deleted_exp)
+
+    def test_multibuild_manyflavors(self):
+        """Packages using _multbuild with many flavors
+        Ensure that every flavors is accounted for separately."""
+        container_arch_map = {}
+
+        # Generate five releases of a container with six flavors each.
+        # The flavors are released separately, so each flavor gets a new maintenance release
+        # number, i.e. c.00:fl0 and c.01:fl1 have binaries,
+        # while c.00:fl1-fl6, c.01:fl0 and c.01:fl2-6 do not.
+        relcounter = 0
+        for release in range(0, 4):
+            for flavor in range(0, 6):
+                relcounter = 6 * release + flavor
+                for allflavor in range(0, 6):
+                    container_arch_map[f"c.{relcounter}:fl{allflavor}"] = []
+
+                container_arch_map[f"c.{relcounter}:fl{flavor}"] = ["x86_64"]
+
+        # For each c:flX release, there are five binaries, thus nothing should get deleted.
+        to_be_deleted_exp = []
+
+        self.doTest(container_arch_map, to_be_deleted_exp)


### PR DESCRIPTION
Explicitly keep five releases of each pkg:flavor instead of pkg.

ttm releases each flavor separately, resulting in n releases for n flavors. With the previous logic, container_cleaner would only keep 5 releases, not 5 of each flavor. This resulted in less versions of individual container images than desired, or even immediate deletion of just released images if there are more then 5 flavors.